### PR TITLE
Bugfix: the aperture extension must use integers

### DIFF
--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -288,7 +288,7 @@ class CutoutFactory():
         uncert_cutout = cutout[:,:,:,1].transpose((2,0,1))
     
         # Making the aperture array
-        aperture = np.ones((xmax-xmin, ymax-ymin))
+        aperture = np.ones((xmax-xmin, ymax-ymin), dtype=np.int32)
 
         # Adding padding to the cutouts so that it's the expected size
         if padding.any(): # only do if we need to pad

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -51,6 +51,9 @@ def checkcutout(cutfile,pixcrd,world,csize,ecube,eps=1.e-7):
     check1(tab['FLUX'],x1,x2,y1,y2,ecube[:,:,:,0],'FLUX',cutfile)
     check1(tab['FLUX_ERR'],x1,x2,y1,y2,ecube[:,:,:,1],'FLUX_ERR',cutfile)
     
+    # Regression test for PR #6
+    assert hdulist[2].data.dtype.type == np.int32
+
     return 
 
 def check1(flux,x1,x2,y1,y2,ecube,label,cutfile):


### PR DESCRIPTION
Thank you for providing the fabulous TESScut service.  It is impressively fast and user-friendly!

I noticed that the files returned by TESScut contain an aperture mask image extension (HDU 2) which contains floating point values.  In contrast, the standard TESS/Kepler target pixel files contain integers in this extension.

This is a minor issue because this extension represents a bitmask image, and therefore *lightkurve* (and likely other data analysis tools) expect to encounter integers here. I believe this PR fixes the issue!