### PR TITLE
Set the `CREATOR` keyword to `astrocut`

### DIFF
--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -14,6 +14,7 @@ from time import time
 import os
 import warnings
 
+from . import __version__
 from .exceptions import InputWarning, TypeWarning, InvalidQueryError
 
 
@@ -318,6 +319,9 @@ class CutoutFactory():
         """
 
         # Adding cutout specific headers
+        primary_header['CREATOR'] = ('astrocut', 'software used to produce this file')
+        primary_header['PROCVER'] = (__version__, 'software version')
+
         primary_header['RA_OBJ'] = (self.center_coord.ra.deg, '[deg] right ascension')
         primary_header['DEC_OBJ'] = (self.center_coord.dec.deg, '[deg] declination')
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -132,7 +132,7 @@ class CubeFactory():
                 cols = []
                 for kwd, val, cmt in secondary_header.cards: 
                     if type(val) == str:
-                        tpe = "S" + str(len(val)) # TODO: Maybe switch to U?
+                        tpe = "S" + str(len(val))  # TODO: Maybe switch to U?
                     elif type(val) == int:
                         tpe = np.int32
                     else:
@@ -154,7 +154,7 @@ class CubeFactory():
                     nulval = None
                     if img_info_table[kwd].dtype.name == "int32":
                         nulval = 0
-                    elif img_info_table[kwd].dtype.char == "S": # hacky way to check if it's a string
+                    elif img_info_table[kwd].dtype.char == "S":  # hacky way to check if it's a string
                         nulval = ""
                     img_info_table[kwd][i] = ffi_data[1].header.get(kwd, nulval)
 


### PR DESCRIPTION
Currently the TESScut service returns Target Pixel Files with a header which suggests that they were created using the FFI exporter of the official pipeline, cf.:
```
CREATOR = '113 FfiExporter'    / pipeline job and program used to produce this f
PROCVER = 'spoc-3.3.31-20180902' / SW version 
```

This PR proposes to set the `CREATOR` keyword to contain `astrocut`, which enables TPFs generated using astrocut/tesscut to be identified more easily.

Again, thank you for providing the fantastic TESScut service!