### PR TITLE
Uniform formatting on target pixel file names

### DIFF
--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -662,11 +662,11 @@ class CutoutFactory():
         if not target_pixel_file:
             _, flename = os.path.split(cube_file)
             target_pixel_file = output_path + "/"
-            target_pixel_file += "{}_{}_{}_{}x{}_astrocut.fits".format(flename.rstrip('.fits').rstrip("-cube"),
-                                                                       self.center_coord.ra.value,
-                                                                       self.center_coord.dec.value,
-                                                                       self.cutout_lims[0, 1]-self.cutout_lims[0, 0],
-                                                                       self.cutout_lims[1, 1]-self.cutout_lims[1, 0])
+            target_pixel_file += "{}_{:7f}_{:7f}_{}x{}_astrocut.fits".format(flename.rstrip('.fits').rstrip("-cube"),
+                                                                             self.center_coord.ra.value,
+                                                                             self.center_coord.dec.value,
+                                                                             self.cutout_lims[0, 1]-self.cutout_lims[0, 0],
+                                                                             self.cutout_lims[1, 1]-self.cutout_lims[1, 0])
         
         if verbose:
             print("Target pixel file: {}".format(target_pixel_file))


### PR DESCRIPTION
In `cube_cut`, the string formatting for target coordinates in the downloaded filename was not specified. The minor change in this PR ensure that TESScut filenames are saved with the coordinates in the form of floats with consistent length. This makes it easier to check locally if a given target has already been downloaded.