### PR TITLE
WCS bugfix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ----------------
 
 - Adding more unit tests and coveralls setup [#11]
+- Adding workaround for FFIs with bad WCS info [#12]
 
 
 0.3 (2019-05-03)

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -88,13 +88,13 @@ class CutoutFactory():
             One row from the cube image header data table.
         """
 
-        data_ind = int(len(table_data)/2)
+        data_ind = int(len(table_data)/2)  # using the middle file for table info
         table_row = None
 
         # Making sure we have a row with wcs info
         while table_row is None:
             table_row = table_data[data_ind]
-            ra_col = int([x for x in table_header.cards if x[1] == "CTYPE1"][0][0].replace("TTYPE","")) - 1
+            ra_col = int([x for x in table_header.cards if x[1] == "CTYPE1"][0][0].replace("TTYPE", "")) - 1
             if "RA" not in table_row[ra_col]:
                 table_row is None
                 data_ind += 1
@@ -633,8 +633,7 @@ class CutoutFactory():
         cube = fits.open(cube_file) 
 
         # Get the info we need from the data table
-        #data_ind = int(len(cube[2].data)/2)  # using the middle file for table info
-        self._parse_table_info(cube[2].header, cube[2].data, verbose)#[data_ind])
+        self._parse_table_info(cube[2].header, cube[2].data, verbose)
 
         if isinstance(coordinates, SkyCoord):
             self.center_coord = coordinates

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -114,7 +114,7 @@ class CutoutFactory():
             
             wcs_val = table_row[col_num]
             if (not isinstance(wcs_val, str)) and (np.isnan(wcs_val)):
-                continue # Just skip nans
+                continue  # Just skip nans
             
             if "A" in tform:
                 wcs_header[header_val] = str(table_row[col_num])
@@ -156,7 +156,7 @@ class CutoutFactory():
         # Note: This is returning the center pixel in 1-up
         try:
             center_pixel = self.center_coord.to_pixel(self.cube_wcs, 1)
-        except wcs.NoConvergence: # If wcs can't converge, center coordinate is far from the footprint
+        except wcs.NoConvergence:  # If wcs can't converge, center coordinate is far from the footprint
             raise InvalidQueryError("Cutout location is not in cube footprint!")
 
         lims = np.zeros((2, 2), dtype=int)

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -111,6 +111,11 @@ class CutoutFactory():
         
             col_num = int(header_key[5:]) - 1
             tform = table_header[header_key.replace("TTYPE", "TFORM")]
+            
+            wcs_val = table_row[col_num]
+            if (not wcs_val.isinstance(str)) and (np.isnan(wcs_val)):
+                continue # Just skip nans
+            
             if "A" in tform:
                 wcs_header[header_val] = str(table_row[col_num])
             elif "D" in tform:
@@ -149,7 +154,10 @@ class CutoutFactory():
         """
         
         # Note: This is returning the center pixel in 1-up
-        center_pixel = self.center_coord.to_pixel(self.cube_wcs, 1)
+        try:
+            center_pixel = self.center_coord.to_pixel(self.cube_wcs, 1)
+        except wcs.NoConvergence: # If wcs can't converge, center coordinate is far from the footprint
+            raise InvalidQueryError("Cutout location is not in cube footprint!")
 
         lims = np.zeros((2, 2), dtype=int)
 

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -113,7 +113,7 @@ class CutoutFactory():
             tform = table_header[header_key.replace("TTYPE", "TFORM")]
             
             wcs_val = table_row[col_num]
-            if (not wcs_val.isinstance(str)) and (np.isnan(wcs_val)):
+            if (not isinstance(wcs_val, str)) and (np.isnan(wcs_val)):
                 continue # Just skip nans
             
             if "A" in tform:

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -98,6 +98,8 @@ class CutoutFactory():
             if "RA" not in table_row[ra_col]:
                 table_row is None
                 data_ind += 1
+                if data_ind == len(table_data):
+                    raise wcs.NoWcsKeywordsFoundError("No FFI rows contain valid WCS keywords.")
 
         if verbose:
             print("Using WCS from row {} out of {}".format(data_ind, len(table_data)))

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -72,7 +72,7 @@ class CutoutFactory():
                          "VIGNAPP": [None, "vignetting or collimator correction applied"]}
 
         
-    def _parse_table_info(self, table_header, table_row):
+    def _parse_table_info(self, table_header, table_data, verbose=False):
         """
         Takes the header and one entry from the cube table of image header data,
         builds a WCS object that encalpsulates the given WCS information,
@@ -88,7 +88,21 @@ class CutoutFactory():
             One row from the cube image header data table.
         """
 
-        # Turning the table row inot a new header object
+        data_ind = int(len(table_data)/2)
+        table_row = None
+
+        # Making sure we have a row with wcs info
+        while table_row is None:
+            table_row = table_data[data_ind]
+            ra_col = int([x for x in table_header.cards if x[1] == "CTYPE1"][0][0].replace("TTYPE","")) - 1
+            if "RA" not in table_row[ra_col]:
+                table_row is None
+                data_ind += 1
+
+        if verbose:
+            print("Using WCS from row {} out of {}".format(data_ind, len(table_data)))
+
+        # Turning the table row into a new header object
         wcs_header = fits.header.Header()
 
         for header_key, header_val in table_header.items():
@@ -619,8 +633,8 @@ class CutoutFactory():
         cube = fits.open(cube_file) 
 
         # Get the info we need from the data table
-        data_ind = int(len(cube[2].data)/2)  # using the middle file for table info
-        self._parse_table_info(cube[2].header, cube[2].data[data_ind])
+        #data_ind = int(len(cube[2].data)/2)  # using the middle file for table info
+        self._parse_table_info(cube[2].header, cube[2].data, verbose)#[data_ind])
 
         if isinstance(coordinates, SkyCoord):
             self.center_coord = coordinates

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -101,10 +101,10 @@ class CubeFactory():
         for i, ffi in enumerate(file_list):
             ffi_data = fits.open(ffi)
             
-            start_times[i] = ffi_data[1].header.get("TSTART") # TODO: optionally pass this in?
+            start_times[i] = ffi_data[1].header.get("TSTART")  # TODO: optionally pass this in?
             
-            if good_header_ind is None: # Only check this if we don't already have it
-                if ffi_data[1].header.get("CTYPE1"): # Checking for WCS info
+            if good_header_ind is None:  # Only check this if we don't already have it
+                if ffi_data[1].header.get("CTYPE1"):  # Checking for WCS info
                     good_header_ind = i
             
             ffi_data.close()


### PR DESCRIPTION
Sometimes the TESS pipeline fails to produce a WCS object, in this case the FFI lacks the WCS header keywords.  This is a problem for Astrocut in two situations:

1. The FFI used to set up the header keywords table in the cube file is missing the WCS header keywords, in which case the cube as a whole is missing those keywords.
2. The FFI used to make the WCS information for the cutout lacks the WCS keywords.  In this case a WCS object cannot be created so the cutout cannot proceed.

This PR solve both of these problems with the following changes:

- In the make_cube file the WCS keyword "CTYPE1" is checked and must be present for an FFI to be used as the template for making the header table.
- In the cube_cut file the WCS keyword "CTYPE1" is checked and must be present  for the row of header information to be used to make the cutout WCS.

Additionally I added a catch for the NoResolve exception when finding the cutout location and instead raise a clearer error message informing the user that their cutout is not on the FFI in question.