### PR TITLE
Initial fits_cut functionality

### DIFF
--- a/astrocut/__init__.py
+++ b/astrocut/__init__.py
@@ -24,3 +24,5 @@ if sys.version_info < tuple((int(val) for val in __minimum_python_version__.spli
 if not _ASTROPY_SETUP_:  # noqa
     from .make_cube import CubeFactory  # noqa
     from .cube_cut import CutoutFactory  # noqa
+    #from .fits_cut import *
+    from . import fits_cut

--- a/astrocut/__init__.py
+++ b/astrocut/__init__.py
@@ -24,4 +24,4 @@ if sys.version_info < tuple((int(val) for val in __minimum_python_version__.spli
 if not _ASTROPY_SETUP_:  # noqa
     from .make_cube import CubeFactory  # noqa
     from .cube_cut import CutoutFactory  # noqa
-    from .fits_cut import fits_cut  # noqa
+    from .cutouts import fits_cut  # noqa

--- a/astrocut/__init__.py
+++ b/astrocut/__init__.py
@@ -24,5 +24,4 @@ if sys.version_info < tuple((int(val) for val in __minimum_python_version__.spli
 if not _ASTROPY_SETUP_:  # noqa
     from .make_cube import CubeFactory  # noqa
     from .cube_cut import CutoutFactory  # noqa
-    #from .fits_cut import *
-    from . import fits_cut
+    from .fits_cut import fits_cut  # noqa

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -53,7 +53,7 @@ def _get_cutout_limits(img_wcs, center_coord, cutout_size):
     except wcs.NoConvergence:  # If wcs can't converge, center coordinate is far from the footprint
         raise InvalidQueryError("Cutout location is not in image footprint!")
 
-    print(f"Center pixel: {center_pixel}")
+    #print(f"Center pixel: {center_pixel}")
     
     lims = np.zeros((2, 2), dtype=int)
 
@@ -74,7 +74,7 @@ def _get_cutout_limits(img_wcs, center_coord, cutout_size):
         # The case where the requested area is so small it rounds to zero
         if lims[axis, 0] == lims[axis, 1]:
             lims[axis, 0] = int(np.floor(center_pixel[axis] - 1))
-            lims[axis, 1] = int(np.ceil(center_pixel[axis] - 1))
+            lims[axis, 1] = lims[axis, 0] + 1 #int(np.ceil(center_pixel[axis] - 1))
 
     return lims
 
@@ -198,13 +198,13 @@ def _hducut(img_hdu, center_coord, cutout_size, correct_wcs=False, drop_after=No
         padding[1, 0] = -xmin
         xmin = 0
     if ymin < 0:
-        padding[2, 0] = -ymin
+        padding[0, 0] = -ymin
         ymin = 0
     if xmax > xmax_img:
         padding[1, 1] = xmax - xmax_img
         xmax = xmax_img
     if ymax > ymax_img:
-        padding[2, 1] = ymax - ymax_img
+        padding[0, 1] = ymax - ymax_img
         ymax = ymax_img  
         
     img_cutout = img_hdu.data[ymin:ymax, xmin:xmax]
@@ -415,7 +415,7 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, drop_afte
         for fle in input_files:
             cutout = cutout_hdu_dict[fle]
             if cutout.header.get("EMPTY"):
-                warning.warn("Cutout of {} contains to data and will not be written.".format(fle))
+                warnings.warn("Cutout of {} contains to data and will not be written.".format(fle))
                 continue
 
             cutout_hdus.append(cutout)

--- a/astrocut/exceptions.py
+++ b/astrocut/exceptions.py
@@ -13,10 +13,16 @@ class InvalidQueryError(Exception):
     """
     pass
 
+class InvalidInputError(Exception):
+    """
+    Exception to be issued when user input is incorrect in a 
+    way that prevents the function from running.
+    """
+    pass
 
 class InputWarning(AstropyWarning):
     """
-    Warning to be issued when use input is incorrect in
+    Warning to be issued when user input is incorrect in
     some way but doesn't prevent the function from running.
     """
     pass

--- a/astrocut/fits_cut.py
+++ b/astrocut/fits_cut.py
@@ -1,0 +1,257 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""This module implements cutout functionality similar to fitscut."""
+
+
+import numpy as np
+import astropy.units as u
+
+from astropy.io import fits
+from astropy.coordinates import SkyCoord
+from astropy import wcs
+
+from time import time
+
+import os
+import warnings
+
+from . import __version__
+from .exceptions import InputWarning, TypeWarning, InvalidQueryError
+
+
+
+
+#### FUNCTIONS FOR UTILS ####
+def _get_cutout_limits(img_wcs, center_coord, cutout_size):
+    """
+    Takes the center coordinates, cutout size, and the wcs from
+    which the cutout is being taken and returns the x and y pixel limits
+    for the cutout.
+
+    Parameters
+    ----------
+    img_wcs : `~astropy.wcs.WCS`
+        The WCS for the image that the cutout is being cut from.
+    center_coord : `~astropy.coordinates.SkyCoord`
+        The central coordinate for the cutout
+    cutout_size : array
+        [ny,nx] in with ints (pixels) or astropy quantities
+
+    Returns
+    -------
+    response : `numpy.array`
+        The cutout pixel limits in an array of the form [[ymin,ymax],[xmin,xmax]]
+    """
+        
+    # Note: This is returning the center pixel in 1-up
+    try:
+        center_pixel = center_coord.to_pixel(img_wcs, 1)
+    except wcs.NoConvergence:  # If wcs can't converge, center coordinate is far from the footprint
+        raise InvalidQueryError("Cutout location is not in image footprint!")
+
+    lims = np.zeros((2, 2), dtype=int)
+
+    for axis, size in enumerate(cutout_size):
+        
+        if not isinstance(size, u.Quantity):  # assume pixels
+            dim = size / 2
+        elif size.unit == u.pixel:  # also pixels
+            dim = size.value / 2
+        elif size.unit.physical_type == 'angle':
+            pixel_scale = u.Quantity(wcs.utils.proj_plane_pixel_scales(img_wcs)[axis],
+                                     img_wcs.wcs.cunit[axis])
+            dim = (size / pixel_scale).decompose() / 2
+
+        lims[axis, 0] = int(np.round(center_pixel[axis] - 1 - dim))
+        lims[axis, 1] = int(np.round(center_pixel[axis] - 1 + dim))
+
+        # The case where the requested area is so small it rounds to zero
+        if lims[axis, 0] == lims[axis, 1]:
+            lims[axis, 0] = int(np.floor(center_pixel[axis] - 1))
+            lims[axis, 1] = int(np.ceil(center_pixel[axis] - 1))
+
+    # Checking at least some of the cutout is on the image
+    # TODO: I am not convinced by this check
+    if ((lims[0, 0] <= 0) and (lims[0, 1] <= 0)) or ((lims[1, 0] <= 0) and (lims[1, 1] <= 0)):
+        raise InvalidQueryError("Cutout location is not in cube footprint!")
+
+    return lims
+
+        
+def _get_cutout_wcs(img_wcs, cutout_lims):
+    """
+    Starting with the full FFI WCS and adjusting it for the cutout WCS.
+    Adjusts CRPIX values and adds physical WCS keywords.
+
+    Parameters
+    ----------
+    img_wcs : `~astropy.wcs.WCS`
+        WCS for the image the cutout is being cut from.
+    cutout_lims : `numpy.array`
+        The cutout pixel limits in an array of the form [[ymin,ymax],[xmin,xmax]]
+
+    Resturns
+    --------
+    response :  `~astropy.wcs.WCS`
+        The cutout WCS object including SIP distortions if present.
+    """
+
+    # relax = True is important when the WCS has sip distortions, otherwise it has no effect
+    wcs_header = img_wcs.to_header(relax=True) 
+
+    # Adjusting the CRPIX values
+    wcs_header["CRPIX1"] -= cutout_lims[0, 0]
+    wcs_header["CRPIX2"] -= cutout_lims[1, 0]
+
+    # Adding the physical wcs keywords
+    wcs_header.set("WCSNAMEP", "PHYSICAL", "name of world coordinate system alternate P")
+    wcs_header.set("WCSAXESP", 2, "number of WCS physical axes")
+    
+    wcs_header.set("CTYPE1P", "RAWX", "physical WCS axis 1 type CCD col")
+    wcs_header.set("CUNIT1P", "PIXEL", "physical WCS axis 1 unit")
+    wcs_header.set("CRPIX1P", 1, "reference CCD column")
+    wcs_header.set("CRVAL1P", cutout_lims[0, 0] + 1, "value at reference CCD column")
+    wcs_header.set("CDELT1P", 1.0, "physical WCS axis 1 step")
+                
+    wcs_header.set("CTYPE2P", "RAWY", "physical WCS axis 2 type CCD col")
+    wcs_header.set("CUNIT2P", "PIXEL", "physical WCS axis 2 unit")
+    wcs_header.set("CRPIX2P", 1, "reference CCD row")
+    wcs_header.set("CRVAL2P", cutout_lims[1, 0] + 1, "value at reference CCD row")
+    wcs_header.set("CDELT2P", 1.0, "physical WCS axis 2 step")
+
+    return wcs.WCS(wcs_header)
+        
+
+#### FUNCTIONS FOR UTILS ####
+
+
+def _hducut(img_hdu, center_coord, cutout_size, correct_wcs=False, verbose=False):
+    """
+    Does the actual cutting out.
+    """
+    
+    img_wcs = wcs.WCS(img_hdu.header)
+    img_wcs.sip = None # Necessary for CANDELS bc extra sip coeffs hanging around
+    
+    img_data = img_hdu.data
+
+    # Get cutout limits
+    cutout_lims = _get_cutout_limits(img_wcs, center_coord, cutout_size)
+
+    if verbose:
+        print("xmin,xmax: {}".format(cutout_lims[1]))
+        print("ymin,ymax: {}".format(cutout_lims[0]))
+
+    # These limits are not guarenteed to be within the image footprint
+    xmin, xmax = cutout_lims[1]
+    ymin, ymax = cutout_lims[0]
+
+    ymax_img, xmax_img = img_data.shape
+
+    # Adjust limits and figuring out the padding
+    padding = np.zeros((2, 2), dtype=int)
+    if xmin < 0:
+        padding[1, 0] = -xmin
+        xmin = 0
+    if ymin < 0:
+        padding[2, 0] = -ymin
+        ymin = 0
+    if xmax > xmax_img:
+        padding[1, 1] = xmax - xmax_img
+        xmax = xmax_img
+    if ymax > ymax_img:
+        padding[2, 1] = ymax - ymax_img
+        ymax = ymax_img  
+        
+    img_cutout = img_hdu.data[ymin:ymax, xmin:xmax]
+
+    # Adding padding to the cutout so that it's the expected size
+    if padding.any():  # only do if we need to pad
+        img_cutout = np.pad(img_cutout, padding, 'constant', constant_values=np.nan)
+
+    if verbose:
+        print("Image cutout shape: {}".format(img_cutout.shape))
+
+    # Getting the cutout wcs
+    cutout_wcs = _get_cutout_wcs(img_wcs, cutout_lims)
+
+    # Building the HDU
+    hdu_header = fits.Header(img_hdu.header, copy=True)
+    hdu_header.update(cutout_wcs.to_header(relax=True)) # relax arg is for sip distortions if they exist
+    # TODO: change filename -> original_file or something
+    # Add/change any other keywords as needed
+
+    
+    hdu = fits.ImageHDU(header=hdu_header, data=img_cutout)
+
+    return hdu
+    
+
+
+def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, single_outfile=True,
+             cutout_files=None, output_path='.', verbose=False):
+    """
+    Takes one or more fits files with the same WCS/pointing (in future will support resampling),
+    makes the same cutout in each file and returns the result in a single fitsfile with one cutout
+    per extension (in future will support outputting multiple files).
+    """
+
+    if verbose:
+            start_time = time()
+            
+    # Making sure we have an array of images
+    if type(input_files) == str:
+        input_files == [input_files]
+
+    if not isinstance(coordinates, SkyCoord):
+        coordinates = SkyCoord(coordinates, unit='deg')
+
+    # Making size into an array [ny, nx]
+    if np.isscalar(cutout_size):
+        cutout_size = np.repeat(cutout_size, 2)
+
+    if isinstance(cutout_size, u.Quantity):
+        cutout_size = np.atleast_1d(cutout_size)
+        if len(cutout_size) == 1:
+            cutout_size = np.repeat(cutout_size, 2)
+
+    if len(cutout_size) > 2:
+        warnings.warn("Too many dimensions in cutout size, only the first two will be used.",
+                      InputWarning)
+
+    cutout_hdus = []
+    for in_fle in input_files:
+        hdulist = fits.open(in_fle)
+        cutout_hdus.append( _hducut(hdulist[0], coordinates, cutout_size,
+                                    correct_wcs=correct_wcs, verbose=verbose))
+        hdulist.close()
+
+    # Setting up the Promary HDU
+    primary_hdu = fits.PrimaryHDU()
+    # TODO: add some info about origin etc
+
+    # TODO: implement multiple files
+    #if single_outfile:
+    cutout_hdulist = fits.HDUList([primary_hdu] + cutout_hdus)
+
+    # Getting the output filename
+    if not cutout_files:
+        cutout_files = "cutout.fits" # TODO: make this a better filename
+        # TODO: also need to deal with getting a list
+    cutout_path = os.path.join(output_path, cutout_files)
+
+    if verbose:
+        print("Cutout fits file(s): {}".format(cutout_path))
+
+    # Make sure the output directory exists
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+            
+    cutout_hdulist.writeto(cutout_path, overwrite=True, checksum=True)
+
+    if verbose:
+        print("Total time: {:.2} sec".format(time()-start_time))
+
+    return cutout_path
+        
+

--- a/astrocut/fits_cut.py
+++ b/astrocut/fits_cut.py
@@ -298,23 +298,57 @@ def _save_multiple(cutout_hdus, output_dir, filenames, center_coord):
 def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, drop_after=None,
              single_outfile=True, cutout_prefix="cutout", output_dir='.', verbose=False):
     """
-    Takes one or more fits files with the same WCS/pointing (in future will support resampling),
-    makes the same cutout in each file and returns the result in a single fitsfile with one cutout
-    per extension (in future will support outputting multiple files).
+    Takes one or more fits files with the same WCS/pointing, makes the same cutout in each file,
+    and returns the result either in a single fitsfile with one cutout per extension or in 
+    individual fits files.
+
+    Note: No checking is done on either the WCS pointing or pixel scale. If images don't line up
+          the cutouts will also not line up.
 
     Parameters
     ----------
-    input_files, coordinates, cutout_size, correct_wcs=False, drop_after=None,
-             single_outfile=True, cutout_prefix="cutout", output_dir='.', verbose=False
+    input_files : list
+        List of fits image files to cutout from. The image is assumed to be in the first extension.
+    coordinates : str or `~astropy.coordinates.SkyCoord` object
+        The position around which to cutout. It may be specified as a string ("ra dec" in degrees) 
+        or as the appropriate `~astropy.coordinates.SkyCoord` object.
+    cutout_size : int, array-like, `~astropy.units.Quantity`
+        The size of the cutout array. If ``cutout_size`` is a scalar number or a scalar 
+        `~astropy.units.Quantity`, then a square cutout of ``cutout_size`` will be created.  
+        If ``cutout_size`` has two elements, they should be in ``(ny, nx)`` order.  Scalar numbers 
+        in ``cutout_size`` are assumed to be in units of pixels. `~astropy.units.Quantity` objects 
+        must be in pixel or angular units.
+    correct_wcs : bool
+        Default False. If true a new WCS will be created for the cutout that is tangent projected
+        and does not include distortions.
+    drop_after : str or None
+        Default None. When creating the header for the cutout (and crucially, before 
+        building the WCS object) drop all header keywords starting with the one given.  This is
+        useful particularly for drizzle files that contain a multitude of extranious keywords
+        and sometimes leftover WCS keywords that astropy will try to parse even thought they should be
+        ignored.
+    single_outfile : bool 
+        Default True. If true return all cutouts in a single fits file with one cutout per extension,
+        if False return cutouts in individual fits files. If returing a single file the filename will 
+        have the form: <cutout_prefix>_<ra>_<dec>_<size x>_<size y>.fits. If returning multiple files
+        each will be named: <original filemame base>_<ra>_<dec>_<size x>_<size y>.fits.
+    cutout_prefix : str 
+        Default value "cutout". Only used if single_outfile is True. A prefix to prepend to the cutout 
+        filename. 
+    output_dir : str
+        Defaul value '.'. The directory to save the cutout file(s) to.
+    verbose : bool
+        Default False. If true intermediate information is printed.
 
     Returns
     -------
     response : str or list
-
+        If single_outfile is True returns the single output filename. Otherwise returns a list of all 
+        the output files.
     """
 
     if verbose:
-            start_time = time()
+        start_time = time()
             
     # Making sure we have an array of images
     if type(input_files) == str:

--- a/astrocut/tests/test_fits_cut.py
+++ b/astrocut/tests/test_fits_cut.py
@@ -1,0 +1,193 @@
+import numpy as np
+
+from astropy.io import fits
+from astropy import wcs
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+
+from .utils_for_test import create_test_imgs
+from .. import cutouts
+
+
+def test_get_cutout_limits():
+
+    test_img_wcs_kwds = fits.Header(cards=[('NAXIS', 2, 'number of array dimensions'),
+                                       ('NAXIS1', 20, ''),
+                                       ('NAXIS2', 30, ''),
+                                       ('CTYPE1', 'RA---TAN', 'Right ascension, gnomonic projection'),
+                                       ('CTYPE2', 'DEC--TAN', 'Declination, gnomonic projection'),
+                                       ('CRVAL1', 100, '[deg] Coordinate value at reference point'),
+                                       ('CRVAL2', 20, '[deg] Coordinate value at reference point'),
+                                       ('CRPIX1', 10, 'Pixel coordinate of reference point'),
+                                       ('CRPIX2', 15, 'Pixel coordinate of reference point'),
+                                       ('CDELT1', 1.0, '[deg] Coordinate increment at reference point'),
+                                       ('CDELT2', 1.0, '[deg] Coordinate increment at reference point'),
+                                       ('WCSAXES', 2, 'Number of coordinate axes'),
+                                       ('PC1_1', 1, 'Coordinate transformation matrix element'),
+                                       ('PC2_2', 1, 'Coordinate transformation matrix element'),
+                                       ('CUNIT1', 'deg', 'Units of coordinate increment and value'),
+                                       ('CUNIT2', 'deg', 'Units of coordinate increment and value')])
+    test_img_wcs = wcs.WCS(test_img_wcs_kwds)
+
+    center_coord = SkyCoord("100 20", unit='deg')
+    cutout_size = [10,10]
+
+    lims = cutouts._get_cutout_limits(test_img_wcs, center_coord, cutout_size)
+    assert (lims[0,1] - lims[0,0]) == (lims[1,1] - lims[1,0])
+    assert (lims == np.array([[ 4, 14], [ 9, 19]])).all()
+
+    cutout_size = [10,5]
+    lims = cutouts._get_cutout_limits(test_img_wcs, center_coord, cutout_size)
+    assert (lims[0,1] - lims[0,0]) == 10
+    assert (lims[1,1] - lims[1,0]) == 5
+
+    cutout_size = [.1,.1]*u.deg
+    lims = cutouts._get_cutout_limits(test_img_wcs, center_coord, cutout_size)
+    assert (lims[0,1] - lims[0,0]) == (lims[1,1] - lims[1,0])
+    assert (lims[0,1] - lims[0,0]) == 1
+
+    cutout_size = [4,5]*u.deg
+    lims = cutouts._get_cutout_limits(test_img_wcs, center_coord, cutout_size)
+    assert (lims[0,1] - lims[0,0]) == 4
+    assert (lims[1,1] - lims[1,0]) == 5
+
+    center_coord = SkyCoord("90 20", unit='deg')
+    cutout_size = [4,5]*u.deg
+    lims = cutouts._get_cutout_limits(test_img_wcs, center_coord, cutout_size)
+    assert lims[0,0] < 0
+
+    center_coord = SkyCoord("100 5", unit='deg')
+    cutout_size = [4,5]*u.pixel
+    lims = cutouts._get_cutout_limits(test_img_wcs, center_coord, cutout_size)
+    assert lims[1,0] < 0
+
+
+def test_get_cutout_wcs():
+    test_img_wcs_kwds = fits.Header(cards=[('NAXIS', 2, 'number of array dimensions'),
+                                       ('NAXIS1', 20, ''),
+                                       ('NAXIS2', 30, ''),
+                                       ('CTYPE1', 'RA---TAN', 'Right ascension, gnomonic projection'),
+                                       ('CTYPE2', 'DEC--TAN', 'Declination, gnomonic projection'),
+                                       ('CRVAL1', 100, '[deg] Coordinate value at reference point'),
+                                       ('CRVAL2', 20, '[deg] Coordinate value at reference point'),
+                                       ('CRPIX1', 10, 'Pixel coordinate of reference point'),
+                                       ('CRPIX2', 15, 'Pixel coordinate of reference point'),
+                                       ('CDELT1', 1.0, '[deg] Coordinate increment at reference point'),
+                                       ('CDELT2', 1.0, '[deg] Coordinate increment at reference point'),
+                                       ('WCSAXES', 2, 'Number of coordinate axes'),
+                                       ('PC1_1', 1, 'Coordinate transformation matrix element'),
+                                       ('PC2_2', 1, 'Coordinate transformation matrix element'),
+                                       ('CUNIT1', 'deg', 'Units of coordinate increment and value'),
+                                       ('CUNIT2', 'deg', 'Units of coordinate increment and value')])
+    test_img_wcs = wcs.WCS(test_img_wcs_kwds)
+
+    center_coord = SkyCoord("100 20", unit='deg')
+    cutout_size = [4,5]*u.deg
+    lims = cutouts._get_cutout_limits(test_img_wcs, center_coord, cutout_size)
+    cutout_wcs = cutouts._get_cutout_wcs(test_img_wcs, lims)
+    assert (cutout_wcs.wcs.crval == [100,20]).all()
+    assert (cutout_wcs.wcs.crpix == [3,4]).all()
+
+    center_coord = SkyCoord("100 5", unit='deg')
+    cutout_size = [4,5]*u.deg
+    lims = cutouts._get_cutout_limits(test_img_wcs, center_coord, cutout_size)
+    cutout_wcs = cutouts._get_cutout_wcs(test_img_wcs, lims)
+    assert (cutout_wcs.wcs.crval == [100,20]).all()
+    assert (cutout_wcs.wcs.crpix == [3,19]).all()
+
+    center_coord = SkyCoord("110 20", unit='deg')
+    cutout_size = [10,10]*u.deg
+    lims = cutouts._get_cutout_limits(test_img_wcs, center_coord, cutout_size)
+    cutout_wcs = cutouts._get_cutout_wcs(test_img_wcs, lims)
+    assert (cutout_wcs.wcs.crval == [100,20]).all()
+    assert (cutout_wcs.wcs.crpix == [-3,6]).all() 
+
+    
+def test_fits_cut(tmpdir):
+
+    test_images = create_test_imgs(50, 6)
+
+    # Single file
+    center_coord = SkyCoord("150.1163213 2.200973097", unit='deg')
+    cutout_size = 10
+    cutout_file = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=True)
+    assert isinstance(cutout_file, str)
+    
+    cutout_hdulist = fits.open(cutout_file)
+    assert len(cutout_hdulist) == len(test_images) + 1 # num imgs + primary header
+
+    cut1 = cutout_hdulist[1].data
+    assert cut1.shape == (cutout_size,cutout_size)
+    assert cutout_hdulist[1].data.shape == cutout_hdulist[2].data.shape
+    assert cutout_hdulist[2].data.shape == cutout_hdulist[3].data.shape
+    assert cutout_hdulist[3].data.shape == cutout_hdulist[4].data.shape
+    assert cutout_hdulist[4].data.shape == cutout_hdulist[5].data.shape
+    assert cutout_hdulist[5].data.shape == cutout_hdulist[6].data.shape
+    
+    cut_wcs = wcs.WCS(cutout_hdulist[1].header)
+    sra, sdec = cut_wcs.all_pix2world(cutout_size/2,cutout_size/2,0)
+    assert round(float(sra), 4) == round(center_coord.ra.deg, 4)
+    assert round(float(sdec), 4) == round(center_coord.dec.deg, 4)
+
+    cutout_hdulist.close()
+
+    # Multiple files
+    cutout_files = cutouts.fits_cut(test_images, center_coord, cutout_size,
+                                     drop_after="Dummy1", single_outfile=False)
+
+    assert isinstance(cutout_files, list)
+    assert len(cutout_files) == len(test_images)
+
+    cutout_hdulist = fits.open(cutout_files[0])
+    assert len(cutout_hdulist) == 1
+    
+    cut1 = cutout_hdulist[0].data
+    assert cut1.shape == (cutout_size,cutout_size)
+    
+    cut_wcs = wcs.WCS(cutout_hdulist[0].header)
+    sra,sdec = cut_wcs.all_pix2world(cutout_size/2,cutout_size/2,0)
+    assert round(float(sra), 4) == round(center_coord.ra.deg, 4)
+    assert round(float(sdec), 4) == round(center_coord.dec.deg, 4)
+
+    cutout_hdulist.close()
+
+    # Do an off the edge test
+    center_coord = SkyCoord("150.1163213 2.2005731", unit='deg')
+    cutout_file = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=True)
+    assert isinstance(cutout_file, str)
+    
+    cutout_hdulist = fits.open(cutout_file)
+    assert len(cutout_hdulist) == len(test_images) + 1 # num imgs + primary header
+
+    cut1 = cutout_hdulist[1].data
+    assert cut1.shape == (cutout_size,cutout_size)
+    assert np.isnan(cut1[:cutout_size//2,:]).all()
+
+    cutout_hdulist.close()
+
+    # Test when cutout is in some images not others
+
+    # Putting zeros into 2 images
+    for i in range(2):
+        hdu = fits.open(test_images[i], mode="update")
+        hdu[0].data[:20,:] = 0
+        hdu.flush()
+        hdu.close()
+        
+        
+    center_coord = SkyCoord("150.1163213 2.2007", unit='deg')
+    cutout_file = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=True)
+    
+    cutout_hdulist = fits.open(cutout_file)
+    assert len(cutout_hdulist) == len(test_images) + 1 # num imgs + primary header
+    assert (cutout_hdulist[1].data == 0).all()
+    assert (cutout_hdulist[2].data == 0).all()
+    assert ~(cutout_hdulist[3].data == 0).any()
+    assert ~(cutout_hdulist[4].data == 0).any()
+    assert ~(cutout_hdulist[5].data == 0).any()
+    assert ~(cutout_hdulist[6].data == 0).any()
+
+    
+    cutout_files = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=False)
+    assert isinstance(cutout_files, list)
+    assert len(cutout_files) == len(test_images) - 2

--- a/astrocut/tests/utils_for_test.py
+++ b/astrocut/tests/utils_for_test.py
@@ -1,11 +1,10 @@
 import numpy as np
 
-from astropy.io import fits
-
+from astropy.io import fits    
 
 def add_keywords(hdu, extname, time_increment, primary=False):
     """
-    Add a bunch of required keywords (mostly fake values)
+    Add a bunch of required keywords (mostly fake values).
     """
     
     hdu.header['extname'] = 'CAMERA.CCD 1.1 cal'
@@ -62,8 +61,7 @@ def create_test_ffis(img_size, num_images, basename='make_cube-test{:04d}.fits')
     Create test fits files
 
     Write negative values for data array and positive values for error array,
-    with unique values for all the pixels. The header keywords are just
-    populated to make things run but are not tested.
+    with unique values for all the pixels. 
     """
 
     img = np.arange(img_size*img_size, dtype=np.float32).reshape((img_size, img_size))
@@ -75,8 +73,7 @@ def create_test_ffis(img_size, num_images, basename='make_cube-test{:04d}.fits')
 
         primary_hdu = fits.PrimaryHDU()
         add_keywords(primary_hdu, "PRIMARY", i, primary=True)
-        
-        
+           
         hdu = fits.ImageHDU(-img)
         add_keywords(hdu, 'CAMERA.CCD 1.1 cal', i)
         
@@ -84,6 +81,65 @@ def create_test_ffis(img_size, num_images, basename='make_cube-test{:04d}.fits')
         add_keywords(ehdu, 'CAMERA.CCD 1.1 uncert', i)
         
         hdulist = fits.HDUList([primary_hdu, hdu, ehdu])
+        hdulist.writeto(file_list[-1], overwrite=True, checksum=True)
+        
+        img = img + img_size*img_size
+
+    return file_list
+
+
+def add_wcs_nosip_keywords(hdu, img_size):
+    """
+    Adds example wcs keywords without sip distortions to the given header.
+
+    Center coordinate is: 150.1163213, 2.200973097
+    """
+
+    hdu.header.extend([('WCSAXES', 2, 'Number of coordinate axes'),
+                       ('CRPIX1', img_size/2, 'Pixel coordinate of reference point'),
+                       ('CRPIX2', img_size/2, 'Pixel coordinate of reference point'),
+                       ('PC1_1', -1.666667e-05, 'Coordinate transformation matrix element'),
+                       ('PC2_2', 1.666667e-05, 'Coordinate transformation matrix element'),
+                       ('CDELT1', 1.0, '[deg] Coordinate increment at reference point'),
+                       ('CDELT2', 1.0, '[deg] Coordinate increment at reference point'),
+                       ('CUNIT1', 'deg', 'Units of coordinate increment and value'),
+                       ('CUNIT2', 'deg', 'Units of coordinate increment and value'),
+                       ('CTYPE1', 'RA---TAN', 'Right ascension, gnomonic projection'),
+                       ('CTYPE2', 'DEC--TAN', 'Declination, gnomonic projection'),
+                       ('CRVAL1', 150.1163213, '[deg] Coordinate value at reference point'),
+                       ('CRVAL2', 2.200973097, '[deg] Coordinate value at reference point')])
+
+def add_dummy_keywords(hdu):
+    """
+    Adding a number of dummy keywords, basically so the drop_after argument to fits_cut can be tested.
+    """
+    hdu.header.extend([('Dummy1', "Dummy1", 'Dummy1'),
+                       ('Dummy2', 2, 'Dummy2'),
+                       ('Dummy3', "", 'Dummy3')],strip=False)
+    
+
+def create_test_imgs(img_size, num_images, dummy_keywords=True, basename='img_{:04d}.fits'):
+    """
+    Create test fits image files, single extension.
+
+    Write unique values for all the pixels. 
+    The header keywords are populated with a simple WCS for testing.
+    """
+
+    img = np.arange(img_size*img_size, dtype=np.float32).reshape((img_size, img_size))
+    file_list = []
+    
+    for i in range(num_images):
+        
+        file_list.append(basename.format(i))
+
+        primary_hdu = fits.PrimaryHDU(data=img)
+        add_wcs_nosip_keywords(primary_hdu, img_size)
+
+        if dummy_keywords:
+            add_dummy_keywords(primary_hdu)
+        
+        hdulist = fits.HDUList([primary_hdu])
         hdulist.writeto(file_list[-1], overwrite=True, checksum=True)
         
         img = img + img_size*img_size

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -152,8 +152,7 @@ that all input image are aligned and have the same pixel scale, no checking is d
                 >>> center_coord = SkyCoord("150.0945 2.38681", unit='deg')
                 >>> cutout_size = [200,300]
                 >>> 
-                >>> cutout_file = astrocut.fits_cut(candels_fles, center_coord, cutout_size,
-                ...                                 drop_after="", single_outfile=True)
+                >>> cutout_file = fits_cut(input_files, center_coord, cutout_size, drop_after="", single_outfile=True)
                 >>> print(cutout_file)
                 cutout_150.094500_2.386810_200x300_astrocut.fits
 

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -8,18 +8,22 @@ Introduction
 Astrocut contains tools for creating image cutouts from sets images with
 shared footprints. This package is under active development, and will
 ultimately grow to encompass a range of cutout activities relevant to
-images from many missions, however at this time it is focused on the
-specific problem of creating image cutouts from sectors of TESS full
-frame images (FFIs).
+images from many missions. Currently there are two modes of interaction:
 
-There are two parts to this package, the `~astrocut.CubeFactory` class
-allows you to create a large image cube from a list of FFI files.
+    - Solving the specific problem of creating image cutouts from sectors of TESS full
+      frame images (FFIs) ( `~astrocut.CubeFactory` and `~astrocut.CutoutFactory`)
+    - More generalized cutouts from sets of images with the same WCS/pixel scale
+      (`~astrocut.fits_cut`)
+
+
+TESS Full-Frame Image Cutouts
+-----------------------------
+
+There are two parts of the package involved in this task, the `~astrocut.CubeFactory`
+class allows you to create a large image cube from a list of FFI files.
 This is what allows the cutout operation to be performed efficiently.
 The `~astrocut.CutoutFactory` class performs the actual cutout and builds
 a target pixel file (TPF) that is compatible with TESS pipeline TPFs.
-
-Getting Started
----------------
 
 The basic workflow is to first create an image cube from individual FFI files
 (this is one-time work), and then make individual cutout TPFs from this
@@ -128,7 +132,43 @@ TESS FFIs are large and therefore are described by WCS objects that have many no
 * **WCS_MSEP:** The maximum separation in degrees between the cutout's linear WCS and the FFI's full WCS.
 * **WCS_SIG:** The error in the cutout's linear WCS, calculated as sqrt((dist(Po_ij, Pl_ij)^2) where dist(Po_ij, Pl_ij) is the angular distance in degrees between the sky position of of pixel i,j in the original full WCS and the new linear WCS.
 
+General fits image cutouts (beta!)
+----------------------------------
 
+This function is a general purpose fits cutout tool.  It takes one or more fits files
+and performs the same cutout in each, returning the result either in a single fits file
+or as one fits file per cutout. It is important to remember that while the expectation is
+that all input image are aligned and have the same pixel scale, no checking is done.
+
+.. code-block:: python
+
+                >>> from astrocut import fits_cut
+                >>> from astropy.io import fits
+                >>> from astropy.coordinates import SkyCoord
+                >>> 
+                >>> input_files = ["https://archive.stsci.edu/pub/hlsp/candels/cosmos/cos-tot/v1.0/hlsp_candels_hst_acs_cos-tot-sect23_f606w_v1.0_drz.fits",
+                ...                "https://archive.stsci.edu/pub/hlsp/candels/cosmos/cos-tot/v1.0/hlsp_candels_hst_acs_cos-tot-sect23_f814w_v1.0_drz.fits"]
+
+                >>> center_coord = SkyCoord("150.0945 2.38681", unit='deg')
+                >>> cutout_size = [200,300]
+                >>> 
+                >>> cutout_file = astrocut.fits_cut(candels_fles, center_coord, cutout_size,
+                ...                                 drop_after="", single_outfile=True)
+                >>> print(cutout_file)
+                cutout_150.094500_2.386810_200x300_astrocut.fits
+
+                >>> cutout_hdulist = fits.open(cutout_file)
+                >>> cutout_hdulist.info()
+                Filename: cutout_150.094500_2.386810_200x300_astrocut.fits
+                No.    Name      Ver    Type      Cards   Dimensions   Format
+                  0  PRIMARY       1 PrimaryHDU      11   ()      
+                  1  CUTOUT        1 ImageHDU        44   (200, 300)   float32   
+                  2  CUTOUT        1 ImageHDU        44   (200, 300)   float32    
+
+
+\* This is the newest functionality and as such should be considered to be in beta. It has been tested primarily on Hubble deep field drizzled images. We welcome issues and pull-requests to make it more widely functional.
+
+  
 .. automodapi:: astrocut
     :skip: test
     :skip: UnsupportedPythonError

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,9 +2,16 @@
 Astrocut
 ========
 
-Tools for making image cutouts from sets of TESS full frame images.
+Tools for making image cutouts from sets of images with shared footprints.
 
-This package is under active development, and will ultimately grow to encompass a range of cutout activities relevant to images from many missions, however at this time it is focussed on the specific problem of creating Target Pixel File cutouts from sectors of TESS full frame images.
+This package is under active development, and will
+ultimately grow to encompass a range of cutout activities relevant to
+images from many missions. Currently there are two modes of interaction:
+
+    - Solving the specific problem of creating image cutouts from sectors of TESS full
+      frame images (FFIs) ( `~astrocut.CubeFactory` and `~astrocut.CutoutFactory`)
+    - More generalized cutouts from sets of images with the same WCS/pixel scale
+      (`~astrocut.fits_cut`)
 
 Astrocut lives on GitHub at: `github.com/spacetelescope/astrocut <https://github.com/spacetelescope/astrocut>`_.
 


### PR DESCRIPTION
This PR adds a new function `fits_cut` that allows for cutouts of one or more fits images with the same WCS/footprint. This is specifically in support of cutouts on CANDELS fields, and has only been tests on those fields.

This PR includes:
- The functionality
- Documentation
- Unit tests