### PR TITLE
Error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
         - PYTHON_VERSION=3.7
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
+        - COVERAGE_VERSION=4
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,9 +103,9 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.13 ASTROPY_VERSION=3.0
         - os: linux
-          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.15
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.16
         - os: linux
-          env: NUMPY_VERSION=1.16
+          env: NUMPY_VERSION=1.17
 
         # Try numpy pre-release
         - os: linux

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - Doc update (explain time column) [#19]
 - Adding img_cut and normalize_img [#21]
 - Improve cutout filenames, change minmax_cut to minmax_value [#24]
+- Add error handling when reading data raises an exception [#28]
 
 0.4 (2019-06-21)
 ----------------

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -703,83 +703,80 @@ class CutoutFactory():
         if verbose:
             start_time = time()
 
-        cube = fits.open(cube_file) 
+        with fits.open(cube_file) as cube:
 
-        # Get the info we need from the data table
-        self._parse_table_info(cube[2].header, cube[2].data, verbose)
+            # Get the info we need from the data table
+            self._parse_table_info(cube[2].header, cube[2].data, verbose)
 
-        if isinstance(coordinates, SkyCoord):
-            self.center_coord = coordinates
-        else:
-            self.center_coord = SkyCoord(coordinates, unit='deg')
+            if isinstance(coordinates, SkyCoord):
+                self.center_coord = coordinates
+            else:
+                self.center_coord = SkyCoord(coordinates, unit='deg')
 
-        if verbose:
-            print("Cutout center coordinate: {},{}".format(self.center_coord.ra.deg, self.center_coord.dec.deg))
+            if verbose:
+                print("Cutout center coordinate: {},{}".format(self.center_coord.ra.deg,
+                                                               self.center_coord.dec.deg))
 
-
-        # Making size into an array [ny, nx]
-        if np.isscalar(cutout_size):
-            cutout_size = np.repeat(cutout_size, 2)
-
-        if isinstance(cutout_size, u.Quantity):
-            cutout_size = np.atleast_1d(cutout_size)
-            if len(cutout_size) == 1:
+            # Making size into an array [ny, nx]
+            if np.isscalar(cutout_size):
                 cutout_size = np.repeat(cutout_size, 2)
 
-        if len(cutout_size) > 2:
-            warnings.warn("Too many dimensions in cutout size, only the first two will be used.",
-                          InputWarning)
-       
-        # Get cutout limits
-        self._get_cutout_limits(cutout_size)
+            if isinstance(cutout_size, u.Quantity):
+                cutout_size = np.atleast_1d(cutout_size)
+                if len(cutout_size) == 1:
+                    cutout_size = np.repeat(cutout_size, 2)
 
-        if verbose:
-            print("xmin,xmax: {}".format(self.cutout_lims[1]))
-            print("ymin,ymax: {}".format(self.cutout_lims[0]))
+            if len(cutout_size) > 2:
+                warnings.warn("Too many dimensions in cutout size, only the first two will be used.",
+                              InputWarning)
+                
+            # Get cutout limits
+            self._get_cutout_limits(cutout_size)
 
-        # Make the cutout
-        img_cutout, uncert_cutout, aperture = self._get_cutout(cube[1].data, verbose=verbose)
+            if verbose:
+                print("xmin,xmax: {}".format(self.cutout_lims[1]))
+                print("ymin,ymax: {}".format(self.cutout_lims[0]))
 
-        # Get cutout wcs info
-        cutout_wcs_full = self._get_full_cutout_wcs(cube[2].header)
-        max_dist, sigma = self._fit_cutout_wcs(cutout_wcs_full, img_cutout.shape[1:])
-        if verbose:
-            print("Maximum distance between approximate and true location: {}".format(max_dist))
-            print("Error in approximate WCS (sigma): {}".format(sigma))
-        
-        cutout_wcs_dict = self._get_cutout_wcs_dict()
+            # Make the cutout
+            img_cutout, uncert_cutout, aperture = self._get_cutout(cube[1].data, verbose=verbose)
+
+            # Get cutout wcs info
+            cutout_wcs_full = self._get_full_cutout_wcs(cube[2].header)
+            max_dist, sigma = self._fit_cutout_wcs(cutout_wcs_full, img_cutout.shape[1:])
+            if verbose:
+                print("Maximum distance between approximate and true location: {}".format(max_dist))
+                print("Error in approximate WCS (sigma): {}".format(sigma))
+                
+            cutout_wcs_dict = self._get_cutout_wcs_dict()
     
-        # Build the TPF
-        tpf_object = self._build_tpf(cube, img_cutout, uncert_cutout, cutout_wcs_dict, aperture)
+            # Build the TPF
+            tpf_object = self._build_tpf(cube, img_cutout, uncert_cutout, cutout_wcs_dict, aperture)
 
-        if verbose:
-            write_time = time()
+            if verbose:
+                write_time = time()
 
-        if not target_pixel_file:
-            _, flename = os.path.split(cube_file)
+            if not target_pixel_file:
+                _, flename = os.path.split(cube_file)
 
-            width = self.cutout_lims[0, 1]-self.cutout_lims[0, 0]
-            height = self.cutout_lims[1, 1]-self.cutout_lims[1, 0]
-            target_pixel_file = "{}_{:7f}_{:7f}_{}x{}_astrocut.fits".format(flename.rstrip('.fits').rstrip("-cube"),
-                                                                            self.center_coord.ra.value,
-                                                                            self.center_coord.dec.value,
-                                                                            width,
-                                                                            height)
-        target_pixel_file = os.path.join(output_path, target_pixel_file)
+                width = self.cutout_lims[0, 1]-self.cutout_lims[0, 0]
+                height = self.cutout_lims[1, 1]-self.cutout_lims[1, 0]
+                target_pixel_file = "{}_{:7f}_{:7f}_{}x{}_astrocut.fits".format(flename.rstrip('.fits').rstrip("-cube"),
+                                                                                self.center_coord.ra.value,
+                                                                                self.center_coord.dec.value,
+                                                                                width,
+                                                                                height)
+            target_pixel_file = os.path.join(output_path, target_pixel_file)
             
         
-        if verbose:
-            print("Target pixel file: {}".format(target_pixel_file))
+            if verbose:
+                print("Target pixel file: {}".format(target_pixel_file))
 
-        # Make sure the output directory exists
-        if not os.path.exists(output_path):
-            os.makedirs(output_path)
+            # Make sure the output directory exists
+            if not os.path.exists(output_path):
+                os.makedirs(output_path)
         
-        # Write the TPF
-        tpf_object.writeto(target_pixel_file, overwrite=True, checksum=True)
-
-        # Close the cube file
-        cube.close()
+            # Write the TPF
+            tpf_object.writeto(target_pixel_file, overwrite=True, checksum=True)
 
         if verbose:
             print("Write time: {:.2} sec".format(time()-write_time))

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -158,8 +158,6 @@ class CutoutFactory():
 
         Parameters
         ----------
-        center_coord : `~astropy.coordinates.SkyCoord`
-            The central coordinate for the cutout
         cutout_size : array
             [ny,nx] in with ints (pixels) or astropy quantities
 
@@ -759,12 +757,12 @@ class CutoutFactory():
 
         if not target_pixel_file:
             _, flename = os.path.split(cube_file)
-            tpf_name = "{}_{:7f}_{:7f}_{}x{}_astrocut.fits".format(flename.rstrip('.fits').rstrip("-cube"),
+            target_pixel_file = "{}_{:7f}_{:7f}_{}x{}_astrocut.fits".format(flename.rstrip('.fits').rstrip("-cube"),
                                                                    self.center_coord.ra.value,
                                                                    self.center_coord.dec.value,
                                                                    self.cutout_lims[0, 1]-self.cutout_lims[0, 0],
                                                                    self.cutout_lims[1, 1]-self.cutout_lims[1, 0])
-            target_pixel_file = os.path.join(output_path, tpf_name)
+        target_pixel_file = os.path.join(output_path, target_pixel_file)
             
         
         if verbose:

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -757,11 +757,14 @@ class CutoutFactory():
 
         if not target_pixel_file:
             _, flename = os.path.split(cube_file)
+
+            width = self.cutout_lims[0, 1]-self.cutout_lims[0, 0]
+            height = self.cutout_lims[1, 1]-self.cutout_lims[1, 0]
             target_pixel_file = "{}_{:7f}_{:7f}_{}x{}_astrocut.fits".format(flename.rstrip('.fits').rstrip("-cube"),
-                                                                   self.center_coord.ra.value,
-                                                                   self.center_coord.dec.value,
-                                                                   self.cutout_lims[0, 1]-self.cutout_lims[0, 0],
-                                                                   self.cutout_lims[1, 1]-self.cutout_lims[1, 0])
+                                                                            self.center_coord.ra.value,
+                                                                            self.center_coord.dec.value,
+                                                                            width,
+                                                                            height)
         target_pixel_file = os.path.join(output_path, target_pixel_file)
             
         

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -422,7 +422,7 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, drop_afte
 
     # If no cutouts contain data, raise exception
     if num_empty == len(input_files):
-        raise InvalidQueryError("Cutout contains to data! (Check image footprint.)")
+        raise InvalidQueryError("Cutout contains no data! (Check image footprint.)")
 
     # Make sure the output directory exists
     if not os.path.exists(output_dir):

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -408,7 +408,7 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, drop_afte
             cutout = _hducut(hdulist[0], coordinates, cutout_size,
                              correct_wcs=correct_wcs, drop_after=drop_after, verbose=verbose)
         except OSError as err:
-            warnings.warn("Error {} encountered when performing cutout on {}.\nFile will be skipped".format(err, in_fle),
+            warnings.warn("Error {} encountered when performing cutout on {}, skipping...".format(err, in_fle),
                           DataWarning)
             
         hdulist.close()
@@ -432,10 +432,10 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, drop_afte
     if single_outfile:
 
         cutout_path = "{}_{:7f}_{:7f}_{}-x-{}_astrocut.fits".format(cutout_prefix,
-                                                                  coordinates.ra.value,
-                                                                  coordinates.dec.value,
-                                                                  str(cutout_size[0]).replace(' ',''), 
-                                                                  str(cutout_size[1]).replace(' ',''))
+                                                                    coordinates.ra.value,
+                                                                    coordinates.dec.value,
+                                                                    str(cutout_size[0]).replace(' ', ''), 
+                                                                    str(cutout_size[1]).replace(' ', ''))
         cutout_path = os.path.join(output_dir, cutout_path)
         
         cutout_hdus = [cutout_hdu_dict[fle] for fle in input_files]
@@ -457,8 +457,8 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, drop_afte
             filename = "{}_{:7f}_{:7f}_{}-x-{}_astrocut.fits".format(os.path.basename(fle).rstrip('.fits'),
                                                                      coordinates.ra.value,
                                                                      coordinates.dec.value,
-                                                                     str(cutout_size[0]).replace(' ',''), 
-                                                                     str(cutout_size[1]).replace(' ',''))
+                                                                     str(cutout_size[0]).replace(' ', ''), 
+                                                                     str(cutout_size[1]).replace(' ', ''))
             cutout_path.append(os.path.join(output_dir, filename))
                 
         _save_multiple_fits(cutout_hdus, cutout_path, coordinates)
@@ -659,11 +659,11 @@ def img_cut(input_files, coordinates, cutout_size, stretch='asinh', minmax_perce
     if colorize:
 
         cutout_path = "{}_{:7f}_{:7f}_{}-x-{}_astrocut.{}".format(cutout_prefix,
-                                                                coordinates.ra.value,
-                                                                coordinates.dec.value,
-                                                                str(cutout_size[0]).replace(' ',''), 
-                                                                str(cutout_size[1]).replace(' ',''),
-                                                                img_format.lower())  # look nicer
+                                                                  coordinates.ra.value,
+                                                                  coordinates.dec.value,
+                                                                  str(cutout_size[0]).replace(' ', ''), 
+                                                                  str(cutout_size[1]).replace(' ', ''),
+                                                                  img_format.lower()) 
         cutout_path = os.path.join(output_dir, cutout_path)
 
         # TODO: This is not elegant or efficient, make it better
@@ -697,11 +697,11 @@ def img_cut(input_files, coordinates, cutout_size, stretch='asinh', minmax_perce
                 continue
 
             file_path = "{}_{:7f}_{:7f}_{}-x-{}_astrocut.{}".format(os.path.basename(fle).rstrip('.fits'),
-                                                                  coordinates.ra.value,
-                                                                  coordinates.dec.value,
-                                                                  str(cutout_size[0]).replace(' ',''), 
-                                                                  str(cutout_size[1]).replace(' ',''),
-                                                                  img_format.lower())
+                                                                    coordinates.ra.value,
+                                                                    coordinates.dec.value,
+                                                                    str(cutout_size[0]).replace(' ', ''), 
+                                                                    str(cutout_size[1]).replace(' ', ''),
+                                                                    img_format.lower())
             file_path = os.path.join(output_dir, file_path)
             cutout_path.append(file_path)
             

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -406,7 +406,7 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, drop_afte
         with fits.open(in_fle) as hdulist:
             try:
                 cutout = _hducut(hdulist[0], coordinates, cutout_size,
-                             correct_wcs=correct_wcs, drop_after=drop_after, verbose=verbose)
+                                 correct_wcs=correct_wcs, drop_after=drop_after, verbose=verbose)
             except OSError as err:
                 warnings.warn("Error {} encountered when performing cutout on {}, skipping...".format(err, in_fle),
                               DataWarning)

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -408,7 +408,7 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, drop_afte
             cutout = _hducut(hdulist[0], coordinates, cutout_size,
                              correct_wcs=correct_wcs, drop_after=drop_after, verbose=verbose)
         except OSError as err:
-            warnings.warn("Error {} encountered when performing cutout on {}.\nFile will be skipped".format(err, im_fle),
+            warnings.warn("Error {} encountered when performing cutout on {}.\nFile will be skipped".format(err, in_fle),
                           DataWarning)
             
         hdulist.close()

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -402,16 +402,14 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, drop_afte
     for in_fle in input_files:
         if verbose:
             print("\n{}".format(in_fle))
-        hdulist = fits.open(in_fle)
-
-        try:
-            cutout = _hducut(hdulist[0], coordinates, cutout_size,
+        
+        with fits.open(in_fle) as hdulist:
+            try:
+                cutout = _hducut(hdulist[0], coordinates, cutout_size,
                              correct_wcs=correct_wcs, drop_after=drop_after, verbose=verbose)
-        except OSError as err:
-            warnings.warn("Error {} encountered when performing cutout on {}, skipping...".format(err, in_fle),
-                          DataWarning)
-            
-        hdulist.close()
+            except OSError as err:
+                warnings.warn("Error {} encountered when performing cutout on {}, skipping...".format(err, in_fle),
+                              DataWarning)
         
         # Check that there is data in the cutout image
         if (cutout.data == 0).all() or (np.isnan(cutout.data)).all():

--- a/astrocut/exceptions.py
+++ b/astrocut/exceptions.py
@@ -35,3 +35,10 @@ class TypeWarning(AstropyWarning):
     Warnings to do with data types.
     """
     pass
+
+
+class DataWarning(AstropyWarning):
+    """
+    Warnings to do with data content.
+    """
+    pass

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -162,7 +162,8 @@ aligned and have the same pixel scale, no checking is done.
                 ./cutout_150.094500_2.386810_200-x-300_astrocut.fits
 
                 >>> cutout_hdulist = fits.open(cutout_file)  
-                >>> cutout_hdulist.info()  
+                >>> cutout_hdulist.info()
+                Filename: ./cutout_150.094500_2.386810_200-x-300_astrocut.fits
                 No.    Name      Ver    Type      Cards   Dimensions   Format
                   0  PRIMARY       1 PrimaryHDU      11   ()      
                   1  CUTOUT        1 ImageHDU        44   (200, 300)   float32   

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -162,7 +162,7 @@ aligned and have the same pixel scale, no checking is done.
                 ./cutout_150.094500_2.386810_200-x-300_astrocut.fits
 
                 >>> cutout_hdulist = fits.open(cutout_file)  
-                >>> cutout_hdulist.info()
+                >>> cutout_hdulist.info() #doctest: +SKIP
                 Filename: ./cutout_150.094500_2.386810_200-x-300_astrocut.fits
                 No.    Name      Ver    Type      Cards   Dimensions   Format
                   0  PRIMARY       1 PrimaryHDU      11   ()      

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -163,11 +163,11 @@ aligned and have the same pixel scale, no checking is done.
 
                 >>> cutout_hdulist = fits.open(cutout_file)  
                 >>> cutout_hdulist.info()  
-                Filename: ./cutout_150.094500_2.386810_200-x-300_astrocut.fits
                 No.    Name      Ver    Type      Cards   Dimensions   Format
                   0  PRIMARY       1 PrimaryHDU      11   ()      
                   1  CUTOUT        1 ImageHDU        44   (200, 300)   float32   
-                  2  CUTOUT        1 ImageHDU        44   (200, 300)   float32    
+                  2  CUTOUT        1 ImageHDU        44   (200, 300)   float32   
+
 
 
 The function `~astrocut.img_cut` takes one or more fits files and performs the same cutout in each,


### PR DESCRIPTION
Adding error handling so that if one file in a list for fits_cut or image_cut raises an error, the user still gets a cutout with the rest of the files.  A warning is raised showing which files caused a problem and what the error was.