### PR TITLE
Updating wcs fitting to match astropy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,6 @@
 0.6 (unreleased)
 ----------------
-- No changes yet
+- Update wcs fitting to match Astropy (and use Astropy when available) [#29]
 
 
 0.5 (2020-01-13)

--- a/astrocut/utils/wcs_fitting.py
+++ b/astrocut/utils/wcs_fitting.py
@@ -20,15 +20,28 @@ import numpy as np
 from astropy import units as u
 from astropy.wcs.utils import celestial_frame_to_wcs
 
-def _linear_transformation_fit(params, lon, lat, x, y, w_obj):  # pragma: no cover
-    """ Objective function for fitting linear terms."""
-    pc = params[0:4]
+def _linear_wcs_fit(params, lon, lat, x, y, w_obj):
+    """
+    Objective function for fitting linear terms.
+
+    Parameters
+    ----------
+    params : array
+        6 element array. First 4 elements are PC matrix, last 2 are CRPIX.
+    lon, lat: array
+        Sky coordinates.
+    x, y: array
+        Pixel coordinates
+    w_obj: `~astropy.wcs.WCS`
+        WCS object
+        """
+    cd = params[0:4]
     crpix = params[4:6]
 
-    w_obj.wcs.pc = ((pc[0],pc[1]),(pc[2],pc[3]))
+    w_obj.wcs.cd = ((cd[0], cd[1]), (cd[2], cd[3]))
     w_obj.wcs.crpix = crpix
-    lon2, lat2 = w_obj.wcs_pix2world(x,y,1)
-    
+    lon2, lat2 = w_obj.wcs_pix2world(x, y, 0)
+
     resids = np.concatenate((lon-lon2, lat-lat2))
     resids[resids > 180] = 360 - resids[resids > 180]
     resids[resids < -180] = 360	+ resids[resids < -180]
@@ -36,181 +49,220 @@ def _linear_transformation_fit(params, lon, lat, x, y, w_obj):  # pragma: no cov
     return resids
 
 
-def _sip_fit(params, lon, lat, u, v, w_obj, a_order, b_order, a_coeff_names,
-             b_coeff_names):  # pragma: no cover
-        """ Objective function for fitting SIP."""
-        from astropy.modeling.models import SIP # here instead of top to avoid circular import
+def _sip_fit(params, lon, lat, u, v, w_obj, order, coeff_names):
 
-        crpix = params[0:2]
-        cdx = params[2:6].reshape((2,2))
-        a_params, b_params = params[6:6+len(a_coeff_names)],params[6+len(a_coeff_names):]
-        w_obj.wcs.pc = cdx
-        w_obj.wcs.crpix = crpix
-        x,y = w_obj.wcs_world2pix(lon,lat,1) #'intermediate world coordinates', x & y
-        x,y = np.dot(w_obj.wcs.pc,(x - w_obj.wcs.crpix[0],y - w_obj.wcs.crpix[1]))
+    """ Objective function for fitting SIP.
+     Parameters
+    -----------
+    params : array
+        Fittable parameters. First 4 elements are PC matrix, last 2 are CRPIX.
+    lon, lat: array
+        Sky coordinates.
+    u, v: array
+        Pixel coordinates
+    w_obj: `~astropy.wcs.WCS`
+        WCS object
+    """
 
-        a_params, b_params = params[6:6+len(a_coeff_names)], params[6+len(a_coeff_names):]
-        a_coeff, b_coeff = {}, {}
-        for i in range(len(a_coeff_names)):
-            a_coeff['A_' + a_coeff_names[i]] = a_params[i]
-        for i in range(len(b_coeff_names)):
-            b_coeff['B_' + b_coeff_names[i]] = b_params[i]
+    from astropy.modeling.models import SIP, InverseSIP   # here to avoid circular import
 
-        sip = SIP(crpix=crpix, a_order=a_order, b_order=b_order, a_coeff=a_coeff, \
-                  b_coeff=b_coeff)
-        fuv, guv = sip(u,v)
-        xo, yo = np.dot(cdx, np.array([u+fuv-crpix[0], v+guv-crpix[1]]))
-        resids = np.concatenate((x-xo, y-yo))
-        return resids
+    # unpack params
+    crpix = params[0:2]
+    cdx = params[2:6].reshape((2, 2))
+    a_params = params[6:6+len(coeff_names)]
+    b_params = params[6+len(coeff_names):]
+
+    # assign to wcs, used for transfomations in this function
+    w_obj.wcs.cd = cdx
+    w_obj.wcs.crpix = crpix
+
+    a_coeff, b_coeff = {}, {}
+    for i in range(len(coeff_names)):
+        a_coeff['A_' + coeff_names[i]] = a_params[i]
+        b_coeff['B_' + coeff_names[i]] = b_params[i]
+
+    sip = SIP(crpix=crpix, a_order=order, b_order=order,
+              a_coeff=a_coeff, b_coeff=b_coeff)
+    fuv, guv = sip(u, v)
+
+    xo, yo = np.dot(cdx, np.array([u+fuv-crpix[0], v+guv-crpix[1]]))
+
+    # use all pix2world in case `projection` contains distortion table
+    x, y = w_obj.all_world2pix(lon, lat, 0)
+    x, y = np.dot(w_obj.wcs.cd, (x-w_obj.wcs.crpix[0], y-w_obj.wcs.crpix[1]))
+
+    resids = np.concatenate((x-xo, y-yo))
+    # to avoid bad restuls if near 360 -> 0 degree crossover
+    resids[resids > 180] = 360 - resids[resids > 180]
+    resids[resids < -180] = 360 + resids[resids < -180]
+
+    return resids
 
 
-def fit_wcs_from_points(xp, yp, coords, mode, projection='TAN', proj_point=None, order=None, inwcs=None):  # pragma: no cover
-    """Given a set of matched x,y pixel positions and celestial coordinates, solves for
-    WCS parameters and returns a WCS with these best fit values and other keywords based
-    on projection type, frame, and units.
-    Along with the matched coordinate pairs, users must provide the projection type
-    (e.g. 'TAN'), celestial coordinate pair for the projection point (or 'center' to use
-    the center of input sky coordinates), mode ('wcs' to fit only linear terms, or 'all'
-    to fit a SIP to the data). If a coordinate pair is passed to 'proj_point', it is
-    assumed to be in the same units respectivley as the input (lon, lat) coordinates.
-    Additionaly, if mode is set to 'all', the polynomial order must be provided.
-    Optionally, an existing ~astropy.wcs.WCS object with some may be passed in. For
-    example, this is useful if the user wishes to refit an existing WCS with better
-    astrometry, or are using a projection type with non-standard keywords. If any overlap
-    between keyword arguments passed to the function and values in the input WCS exist,
-    the keyword argument will override, including the CD/PC convention.
-    NAXIS1 and NAXIS2 will set as the span of the input points, unless an input WCS is
-    provided.
-    All output will be in degrees.
+
+def fit_wcs_from_points(xy, world_coords, proj_point='center',
+                        projection='TAN', sip_degree=None):
+    """
+    Given two matching sets of coordinates on detector and sky,
+    compute the WCS.
+
+    Fits a WCS object to matched set of input detector and sky coordinates.
+    Optionally, a SIP can be fit to account for geometric
+    distortion. Returns an `~astropy.wcs.WCS` object with the best fit
+    parameters for mapping between input pixel and sky coordinates.
+
+    The projection type (default 'TAN') can passed in as a string, one of
+    the valid three-letter projection codes - or as a WCS object with
+    projection keywords already set. Note that if an input WCS has any
+    non-polynomial distortion, this will be applied and reflected in the
+    fit terms and coefficients. Passing in a WCS object in this way essentially
+    allows it to be refit based on the matched input coordinates and projection
+    point, but take care when using this option as non-projection related
+    keywords in the input might cause unexpected behavior.
+
+    Notes
+    ------
+    - The fiducial point for the spherical projection can be set to 'center'
+      to use the mean position of input sky coordinates, or as an
+      `~astropy.coordinates.SkyCoord` object.
+    - Units in all output WCS objects will always be in degrees.
+    - If the coordinate frame differs between `~astropy.coordinates.SkyCoord`
+      objects passed in for ``world_coords`` and ``proj_point``, the frame for
+      ``world_coords``  will override as the frame for the output WCS.
+    - If a WCS object is passed in to ``projection`` the CD/PC matrix will
+      be used as an initial guess for the fit. If this is known to be
+      significantly off and may throw off the fit, set to the identity matrix
+      (for example, by doing wcs.wcs.pc = [(1., 0.,), (0., 1.)])
+
     Parameters
     ----------
-    xp, yp : float or `numpy.ndarray`
+    xy : tuple of two `numpy.ndarray`
         x & y pixel coordinates.
-    coords : `~astropy.coordinates.SkyCoord`
-        Skycoord object.
-    mode : str
-        Whether SIP distortion should be fit (``'all'``), or only the linear
-        terms of the core WCS transformation (``'wcs'``).
-    inwcs : None or `~astropy.wcs.WCS`
-        Optional input WCS object. Populated keyword values will be used. Keyword
-        arguments passed to the function will override any in 'inwcs' if both are present.
-    projection : None or str
-        Three-letter projection code. Defaults to TAN.
-    proj_point: `~astropy.coordinates.SkyCoord` or str
-        Celestial coordinates of projection point (lat, lon). If 'center', the geometric
-        center of input coordinates will be used for the projection. If None, and input
-        wcs with CRVAL set must be passed in.
-    order : None, int, or tuple of ints
-        A order, B order, respectivley, for SIP polynomial to be fit, or single integer
-        for both. Must be provided if mode is 'sip'.
+    world_coords : `~astropy.coordinates.SkyCoord`
+        Skycoord object with world coordinates.
+    proj_point : 'center' or ~astropy.coordinates.SkyCoord`
+        Defaults to 'center', in which the geometric center of input world
+        coordinates will be used as the projection point. To specify an exact
+        point for the projection, a Skycoord object with a coordinate pair can
+        be passed in. For consistency, the units and frame of these coordinates
+        will be transformed to match ``world_coords`` if they don't.
+    projection : str or `~astropy.wcs.WCS`
+        Three letter projection code, of any of standard projections defined
+        in the FITS WCS standard. Optionally, a WCS object with projection
+        keywords set may be passed in.
+    sip_degree : None or int
+        If set to a non-zero integer value, will fit SIP of degree
+        ``sip_degree`` to model geometric distortion. Defaults to None, meaning
+        no distortion corrections will be fit.
+
     Returns
     -------
     wcs : `~astropy.wcs.WCS`
-        WCS object with best fit coefficients given the matched set of X, Y pixel and
-        sky positions of sources.
-    Notes
-    -----
-    Please pay careful attention to the logic that applies when both an input WCS with
-    keywords populated is passed in. For example, if no 'CUNIT' is set in this input
-    WCS, the units of the CRVAL etc. are assumed to be the same as the input Skycoord.
-    Additionally, if 'RADESYS' is not set in the input WCS, this will be taken from the
-    Skycoord as well. """
+        The best-fit WCS to the points given.
+    """
 
-    from scipy.optimize import least_squares
+    from astropy.coordinates import SkyCoord # here to avoid circular import
+    import astropy.units as u
     from astropy.wcs import Sip
-    import copy
+    from scipy.optimize import least_squares
 
-    lon, lat = coords.data.lon.deg, coords.data.lat.deg
-    mode = mode.lower()
-    if mode not in ("wcs", "all"):
-        raise ValueError("mode must be 'wcs' or 'all'")
-    if inwcs is not None:
-        inwcs = copy.deepcopy(inwcs)
-    if projection is None:
-        if (inwcs is None) or ('' in inwcs.wcs.ctype):
-            raise ValueError("Must provide projection type or input WCS with CTYPE.")
-        projection = inwcs.wcs.ctype[0].replace('-SIP','').split('-')[-1]
+    try:
+        xp, yp = xy
+        lon, lat = world_coords.data.lon.deg, world_coords.data.lat.deg
+    except AttributeError:
+        unit_sph =  world_coords.unit_spherical
+        lon, lat = unit_sph.lon.deg, unit_sph.lat.deg
 
-    # template wcs
-    wcs = celestial_frame_to_wcs(frame=coords.frame, projection=projection)
+    # verify input
+    if (proj_point != 'center') and (type(proj_point) != type(world_coords)):
+        raise ValueError("proj_point must be set to 'center', or an" +
+                         "`~astropy.coordinates.SkyCoord` object with " +
+                         "a pair of points.")
+    if proj_point != 'center':
+        assert proj_point.size == 1
 
-    # Determine CRVAL from input, and
-    close = lambda l, p: p[np.where(np.abs(l) == min(np.abs(l)))[0][0]]
-    if str(proj_point) == 'center': #use center of input points
-        wcs.wcs.crval = ((max(lon)+min(lon))/2.,(max(lat)+min(lat))/2.)
-        wcs.wcs.crpix = ((max(xp)+min(xp))/2.,(max(yp)+min(yp))/2.) #initial guess
-    elif (proj_point is None) and (inwcs is None):
-        raise ValueError("Must give proj_point as argument or as CRVAL in input wcs.")
-    elif proj_point is not None: # convert units + rough initial guess for crpix for fit
-        lon_u, lat_u = u.Unit(coords.data.lon.unit), u.Unit(coords.data.lat.unit)
-        wcs.wcs.crval = (proj_point[0]*lon_u.to(u.deg), proj_point[1]*lat_u.to(u.deg))
-        wcs.wcs.crpix = (close(lon-wcs.wcs.crval[0],xp),close(lon-wcs.wcs.crval[1],yp))
+    proj_codes = [
+        'AZP', 'SZP', 'TAN', 'STG', 'SIN', 'ARC', 'ZEA', 'AIR', 'CYP',
+        'CEA', 'CAR', 'MER', 'SFL', 'PAR', 'MOL', 'AIT', 'COP', 'COE',
+        'COD', 'COO', 'BON', 'PCO', 'TSC', 'CSC', 'QSC', 'HPX', 'XPH'
+    ]
+    if type(projection) == str:
+        if projection not in proj_codes:
+            raise ValueError("Must specify valid projection code from list of "
+                             + "supported types: ", ', '.join(proj_codes))
+        # empty wcs to fill in with fit values
+        wcs = celestial_frame_to_wcs(frame=world_coords.frame,
+                                     projection=projection)
+    else: #if projection is not string, should be wcs object. use as template.
+        wcs = copy.deepcopy(projection)
+        wcs.cdelt = (1., 1.) # make sure cdelt is 1
+        wcs.sip = None
 
-    if inwcs is not None:
-        if inwcs.wcs.radesys == '': # no frame specified, use Skycoord's frame (warn???)
-            inwcs.wcs.radesys = coords.frame.name
-        wcs.wcs.radesys = inwcs.wcs.radesys
-        coords.transform_to(inwcs.wcs.radesys.lower()) #work in inwcs units
-        if proj_point is None: # crval, crpix from wcs. crpix used for initial guess.
-            wcs.wcs.crval, wcs.wcs.crpix = inwcs.wcs.crval, inwcs.wcs.crpix
-            if wcs.wcs.crpix[0] == wcs.wcs.crpix[1] == 0: # assume 0 wasn't intentional
-                wcs.wcs.crpix = (close(lon-wcs.wcs.crval[0],xp), \
-                                 close(lon-wcs.wcs.crval[1],yp))
-        if inwcs.wcs.has_pc():
-            wcs.wcs.pc = inwcs.wcs.pc # work internally with pc
-        if inwcs.wcs.has_cd():
-            wcs.wcs.pc = inwcs.wcs.cd
-        # create dictionaries of both wcs (input and kwarg), merge them favoring kwargs
-        wcs_dict = dict(wcs.to_header(relax=False))
-        in_wcs_dict = dict(inwcs.to_header(relax=False))
-        wcs = WCS({**in_wcs_dict,**wcs_dict})
-        wcs.pixel_shape = inwcs.pixel_shape
-    else:
-        wcs.pixel_shape = (max(xp) - min(xp), max(yp) - min(yp))
+    # Change PC to CD, since cdelt will be set to 1
+    if wcs.wcs.has_pc():
+        wcs.wcs.cd = wcs.wcs.pc
+        wcs.wcs.__delattr__('pc')
 
-    # fit
-    p0 = np.concatenate((wcs.wcs.pc.flatten(),wcs.wcs.crpix.flatten()))
-    fit = least_squares(_linear_transformation_fit, p0, args=(lon, lat, xp, yp, wcs))
+    if (type(sip_degree) != type(None)) and (type(sip_degree) != int):
+        raise ValueError("sip_degree must be None, or integer.")
 
-    # put fit values in wcs
+    # set pixel_shape to span of input points
+    wcs.pixel_shape = (xp.max()-xp.min(), yp.max()-yp.min())
+
+    # determine CRVAL from input
+    close = lambda l, p: p[np.argmin(np.abs(l))]
+    if str(proj_point) == 'center':  # use center of input points
+        sc1 = SkyCoord(lon.min()*u.deg, lat.max()*u.deg)
+        sc2 = SkyCoord(lon.max()*u.deg, lat.min()*u.deg)
+        pa = sc1.position_angle(sc2)
+        sep = sc1.separation(sc2)
+        midpoint_sc = sc1.directional_offset_by(pa, sep/2)
+        wcs.wcs.crval = ((midpoint_sc.data.lon.deg, midpoint_sc.data.lat.deg))
+        wcs.wcs.crpix = ((xp.max()+xp.min())/2., (yp.max()+yp.min())/2.)
+    elif proj_point is not None:  # convert units, initial guess for crpix
+        proj_point.transform_to(world_coords)
+        wcs.wcs.crval = (proj_point.data.lon.deg, proj_point.data.lat.deg)
+        wcs.wcs.crpix = (close(lon-wcs.wcs.crval[0], xp),
+                         close(lon-wcs.wcs.crval[1], yp))
+
+    # fit linear terms, assign to wcs
+    # use (1, 0, 0, 1) as initial guess, in case input wcs was passed in
+    # and cd terms are way off.
+    p0 = np.concatenate([wcs.wcs.cd.flatten(), wcs.wcs.crpix.flatten()])
+    fit = least_squares(_linear_wcs_fit, p0,
+                        args=(lon, lat, xp, yp, wcs))
     wcs.wcs.crpix = np.array(fit.x[4:6])
-    wcs.wcs.pc = np.array(fit.x[0:4].reshape((2,2)))
+    wcs.wcs.cd = np.array(fit.x[0:4].reshape((2, 2)))
 
-    if mode == "all":
-        wcs.wcs.ctype = [x + '-SIP' for x in wcs.wcs.ctype]
-        if (order is None) or (type(order) == float):
-            raise ValueError("Must provide integer or tuple (a_order, b_order) for SIP.")
-        if type(order) == int:
-            a_order = b_order = order
-        elif (len(order) == 2):
-            if (type(order[0]) != int) or (type(order[1]) != int):
-                raise ValueError("Must provide integer or tuple (a_order, b_order) for SIP.")
-            a_order, b_order = order
-        else:
-            raise ValueError("Must provide integer or tuple (a_order, b_order) for SIP.")
-        a_coef_names = ['{0}_{1}'.format(i,j) for i in range(a_order+1) \
-                        for j in range(a_order+1) if (i+j) < (a_order+1) and (i+j) > 1]
-        b_coef_names = ['{0}_{1}'.format(i,j) for i in range(b_order+1) \
-                        for j in range(b_order+1) if (i+j) < (b_order + 1) and (i+j) > 1]
-        # fit
-        p0 = np.concatenate((np.array(wcs.wcs.crpix), wcs.wcs.pc.flatten(), \
-                             np.zeros(len(a_coef_names)+len(b_coef_names))))
-        fit = least_squares(_sip_fit, p0, args=(lon, lat, xp, yp, wcs, a_order, b_order,
-                                                a_coef_names, b_coef_names))
+    # fit SIP, if specified. Only fit forward coefficients
+    if sip_degree:
+        degree = sip_degree
+        if '-SIP' not in wcs.wcs.ctype[0]:
+            wcs.wcs.ctype = [x + '-SIP' for x in wcs.wcs.ctype]
+
+        coef_names = ['{0}_{1}'.format(i, j) for i in range(degree+1)
+                      for j in range(degree+1) if (i+j) < (degree+1) and
+                      (i+j) > 1]
+        p0 = np.concatenate((np.array(wcs.wcs.crpix), wcs.wcs.cd.flatten(),
+                             np.zeros(2*len(coef_names))))
+
+        fit = least_squares(_sip_fit, p0,
+                            args=(lon, lat, xp, yp, wcs, degree, coef_names))
+        coef_fit = (list(fit.x[6:6+len(coef_names)]),
+                    list(fit.x[6+len(coef_names):]))
+
         # put fit values in wcs
-        wcs.wcs.pc = fit.x[2:6].reshape((2,2))
+        wcs.wcs.cd = fit.x[2:6].reshape((2, 2))
         wcs.wcs.crpix = fit.x[0:2]
-        coef_fit = (list(fit.x[6:6+len(a_coef_names)]),list(fit.x[6+len(b_coef_names):]))
-        a_vals, b_vals = np.zeros((a_order+1,a_order+1)), np.zeros((b_order+1,b_order+1))
-        for coef_name in a_coef_names:
-            a_vals[int(coef_name[0])][int(coef_name[2])] = coef_fit[0].pop(0)
-        for coef_name in b_coef_names:
-            b_vals[int(coef_name[0])][int(coef_name[2])] = coef_fit[1].pop(0)
-        wcs.sip = Sip(a_vals, b_vals, a_vals * -1., b_vals * -1., wcs.wcs.crpix)
 
-    if (inwcs is not None): # maintain cd matrix if it was in input wcs
-        if inwcs.wcs.has_cd():
-            wcs.wcs.cd = wcs.wcs.pc
-            wcs.wcs.__delattr__('pc')
+        a_vals = np.zeros((degree+1, degree+1))
+        b_vals = np.zeros((degree+1, degree+1))
+
+        for coef_name in coef_names:
+            a_vals[int(coef_name[0])][int(coef_name[2])] = coef_fit[0].pop(0)
+            b_vals[int(coef_name[0])][int(coef_name[2])] = coef_fit[1].pop(0)
+
+        wcs.sip = Sip(a_vals, b_vals, np.zeros((degree+1, degree+1)),
+                      np.zeros((degree+1, degree+1)), wcs.wcs.crpix)
 
     return wcs

--- a/astrocut/utils/wcs_fitting.py
+++ b/astrocut/utils/wcs_fitting.py
@@ -20,7 +20,7 @@ import numpy as np
 from astropy import units as u
 from astropy.wcs.utils import celestial_frame_to_wcs
 
-def _linear_wcs_fit(params, lon, lat, x, y, w_obj):
+def _linear_wcs_fit(params, lon, lat, x, y, w_obj):  # pragma: no cover
     """
     Objective function for fitting linear terms.
 
@@ -49,7 +49,7 @@ def _linear_wcs_fit(params, lon, lat, x, y, w_obj):
     return resids
 
 
-def _sip_fit(params, lon, lat, u, v, w_obj, order, coeff_names):
+def _sip_fit(params, lon, lat, u, v, w_obj, order, coeff_names):  # pragma: no cover
 
     """ Objective function for fitting SIP.
      Parameters
@@ -101,7 +101,7 @@ def _sip_fit(params, lon, lat, u, v, w_obj, order, coeff_names):
 
 
 def fit_wcs_from_points(xy, world_coords, proj_point='center',
-                        projection='TAN', sip_degree=None):
+                        projection='TAN', sip_degree=None):  # pragma: no cover
     """
     Given two matching sets of coordinates on detector and sky,
     compute the WCS.


### PR DESCRIPTION
The PR resolves issue https://github.com/spacetelescope/astrocut/issues/22.

- Updated the local `fit_wcs_from_points` to match what is in Astropy.
- Added additional residual checking.
- Opened bugfix PR to add the same residual checking in Astropy (https://github.com/astropy/astropy/pull/10155).
- Added check so that for Astropy version >=4.0.1 the Astropy function will be used preferentially (this will be the version my bugfix goes into)