### PR TITLE
Streamline WCS fitting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,11 +101,11 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.13 ASTROPY_VERSION=3.0
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.16 ASTROPY_VERSION=3.0
         - os: linux
-          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.16
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.17
         - os: linux
-          env: NUMPY_VERSION=1.17
+          env: NUMPY_VERSION=1.18
 
         # Try numpy pre-release
         - os: linux

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.6 (unreleased)
 ----------------
 - Update wcs fitting to match Astropy (and use Astropy when available) [#29]
+- Limit the number of pixels used for WCS fitting to 100 [#30]
 
 
 0.5 (2020-01-13)

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -13,7 +13,7 @@ from itertools import product
 
 # Note: Use the astropy function if available
 import astropy
-if astropy.utils.minversion(astropy,"4.0.1"):
+if astropy.utils.minversion(astropy,"4.0.2"):
     from astropy.wcs.utils import fit_wcs_from_points
 else:
     from .utils.wcs_fitting import fit_wcs_from_points
@@ -273,24 +273,32 @@ class CutoutFactory():
 
         # Getting matched pixel, world coordinate pairs
         # We will choose no more than 100 pixels spread evenly throughout the image
+        # Centered on the center pixel.
         # To do this we the appropriate "step size" between pixel coordinates
-        # (i.e. we take every ith pixel in each row/column)
+        # (i.e. we take every ith pixel in each row/column) [TODOOOOOO]
         # For example in a 5x7 cutout with i = 2 we get:
         #
-        # xoxoxox
+        # xxoxoxx
         # ooooooo
-        # xoxoxox
+        # xxoxoxx
         # ooooooo
-        # xoxoxox
+        # xxoxoxx
         #
         # Where x denotes the indexes that will be used in the fit.
-
         y, x = cutout_shape
         i = 1
         while (x/i)*(y/i) > 100:
             i += 1
             
-        pix_inds = np.array(list(product(list(range(0,x,i)), list(range(0,y,i)))))
+        xvals = list(reversed(range(x//2, -1, -i)))[:-1] + list(range(x//2, x, i))
+        if xvals[-1] != x-1: xvals += [x-1]
+        if xvals[0] != 0: xvals = [0] + xvals
+        
+        yvals = list(reversed(range(y//2, -1, -i)))[:-1] + list(range(y//2, y, i))
+        if yvals[-1] != y-1: yvals += [y-1]
+        if yvals[0] != 0: yvals = [0] + yvals
+        
+        pix_inds = np.array(list(product(xvals,yvals)))
         world_pix = SkyCoord(cutout_wcs.all_pix2world(pix_inds, 0), unit='deg')
 
         # Getting the fit WCS

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -15,15 +15,15 @@ from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from astropy import wcs
 
+from . import __version__ 
+from .exceptions import InputWarning, TypeWarning, InvalidQueryError
+
 # Note: Use the astropy function if available
 import astropy
 if astropy.utils.minversion(astropy, "4.0.2"):
     from astropy.wcs.utils import fit_wcs_from_points
 else:
     from .utils.wcs_fitting import fit_wcs_from_points
-
-from . import __version__
-from .exceptions import InputWarning, TypeWarning, InvalidQueryError
 
 
 class CutoutFactory():
@@ -301,7 +301,7 @@ class CutoutFactory():
         if yvals[0] != 0:
             yvals = [0] + yvals
         
-        pix_inds = np.array(list(product(xvals,yvals)))
+        pix_inds = np.array(list(product(xvals, yvals)))
         world_pix = SkyCoord(cutout_wcs.all_pix2world(pix_inds, 0), unit='deg')
 
         # Getting the fit WCS

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -272,7 +272,18 @@ class CutoutFactory():
         """
 
         # Getting matched pixel, world coordinate pairs
-        # We don't want more than ~100 pairs, and we want them spread evenly through the iamge
+        # We will choose no more than 100 pixels spread evenly throughout the image
+        # To do this we the appropriate "step size" between pixel coordinates
+        # (i.e. we take every ith pixel in each row/column)
+        # For example in a 5x7 cutout with i = 2 we get:
+        #
+        # xoxoxox
+        # ooooooo
+        # xoxoxox
+        # ooooooo
+        # xoxoxox
+        #
+        # Where x denotes the indexes that will be used in the fit.
 
         y, x = cutout_shape
         i = 1
@@ -283,7 +294,7 @@ class CutoutFactory():
         world_pix = SkyCoord(cutout_wcs.all_pix2world(pix_inds, 0), unit='deg')
 
         # Getting the fit WCS
-        linear_wcs = fit_wcs_from_points([pix_inds[:, 0], pix_inds[:, 1]], world_pix, proj_point=self.center_coord)
+        linear_wcs = fit_wcs_from_points([pix_inds[:, 0], pix_inds[:, 1]], world_pix, proj_point='center')
 
         self.cutout_wcs = linear_wcs
 

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -274,7 +274,7 @@ class CutoutFactory():
         # Getting matched pixel, world coordinate pairs
         # We don't want more than ~100 pairs, and we want them spread evenly through the iamge
 
-        x, y = cutout_shape
+        y, x = cutout_shape
         i = 1
         while (x/i)*(y/i) > 100:
             i += 1

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -2,6 +2,12 @@
 
 """This module implements the cutout functionality."""
 
+import os
+import warnings
+
+from time import time
+from itertools import product
+
 import numpy as np
 import astropy.units as u
 
@@ -9,19 +15,12 @@ from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from astropy import wcs
 
-from itertools import product
-
 # Note: Use the astropy function if available
 import astropy
-if astropy.utils.minversion(astropy,"4.0.2"):
+if astropy.utils.minversion(astropy, "4.0.2"):
     from astropy.wcs.utils import fit_wcs_from_points
 else:
     from .utils.wcs_fitting import fit_wcs_from_points
-
-from time import time
-
-import os
-import warnings
 
 from . import __version__
 from .exceptions import InputWarning, TypeWarning, InvalidQueryError
@@ -291,12 +290,16 @@ class CutoutFactory():
             i += 1
             
         xvals = list(reversed(range(x//2, -1, -i)))[:-1] + list(range(x//2, x, i))
-        if xvals[-1] != x-1: xvals += [x-1]
-        if xvals[0] != 0: xvals = [0] + xvals
+        if xvals[-1] != x-1:
+            xvals += [x-1]
+        if xvals[0] != 0:
+            xvals = [0] + xvals
         
         yvals = list(reversed(range(y//2, -1, -i)))[:-1] + list(range(y//2, y, i))
-        if yvals[-1] != y-1: yvals += [y-1]
-        if yvals[0] != 0: yvals = [0] + yvals
+        if yvals[-1] != y-1:
+            yvals += [y-1]
+        if yvals[0] != 0:
+            yvals = [0] + yvals
         
         pix_inds = np.array(list(product(xvals,yvals)))
         world_pix = SkyCoord(cutout_wcs.all_pix2world(pix_inds, 0), unit='deg')

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -272,7 +272,14 @@ class CutoutFactory():
         """
 
         # Getting matched pixel, world coordinate pairs
-        pix_inds = np.array(list(product(list(range(cutout_shape[1])), list(range(cutout_shape[0])))))
+        # We don't want more than ~100 pairs, and we want them spread evenly through the iamge
+
+        x, y = cutout_shape
+        i = 1
+        while (x/i)*(y/i) > 100:
+            i += 1
+            
+        pix_inds = np.array(list(product(list(range(0,x,i)), list(range(0,y,i)))))
         world_pix = SkyCoord(cutout_wcs.all_pix2world(pix_inds, 0), unit='deg')
 
         # Getting the fit WCS
@@ -280,9 +287,11 @@ class CutoutFactory():
 
         self.cutout_wcs = linear_wcs
 
-        # Checking the fit
+        # Checking the fit (we want to use all of the pixels for this)
+        pix_inds = np.array(list(product(list(range(cutout_shape[1])), list(range(cutout_shape[0])))))
+        world_pix = SkyCoord(cutout_wcs.all_pix2world(pix_inds, 0), unit='deg')
         world_pix_new = SkyCoord(linear_wcs.all_pix2world(pix_inds, 0), unit='deg')
-    
+
         dists = world_pix.separation(world_pix_new).to('deg')
         sigma = np.sqrt(sum(dists.value**2))
 

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -218,11 +218,11 @@ def test_cutout_extras(tmpdir):
     # Test _fit_cutout_wcs #
     ########################
     max_dist, sigma = myfactory._fit_cutout_wcs(cutout_wcs_full, (3, 5))
-    assert round(max_dist.deg, 7) == 7e-07
-    assert round(sigma, 7) == 1.4e-06
+    assert round(max_dist.deg, 6) == 1e-06
+    assert round(sigma, 6) == 5e-06
 
     cry, crx = myfactory.cutout_wcs.wcs.crpix
-    assert round(cry) == 4
+    assert round(cry) == 3
     assert round(crx) == 2
     
 

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -218,8 +218,8 @@ def test_cutout_extras(tmpdir):
     # Test _fit_cutout_wcs #
     ########################
     max_dist, sigma = myfactory._fit_cutout_wcs(cutout_wcs_full, (3, 5))
-    assert round(max_dist.deg, 6) == 1e-06
-    assert round(sigma, 6) == 5e-06
+    assert max_dist.deg < 1e-05
+    assert sigma < 1e-05
 
     cry, crx = myfactory.cutout_wcs.wcs.crpix
     assert round(cry) == 3

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -157,11 +157,11 @@ aligned and have the same pixel scale, no checking is done.
                 >>> center_coord = SkyCoord("150.0945 2.38681", unit='deg')
                 >>> cutout_size = [200,300]
                 
-                >>> cutout_file = fits_cut(input_files, center_coord, cutout_size, drop_after="", single_outfile=True)  
-                >>> print(cutout_file)  
+                >>> cutout_file = fits_cut(input_files, center_coord, cutout_size, drop_after="", single_outfile=True)  #doctest: +SKIP
+                >>> print(cutout_file)    #doctest: +SKIP
                 ./cutout_150.094500_2.386810_200-x-300_astrocut.fits
 
-                >>> cutout_hdulist = fits.open(cutout_file)  
+                >>> cutout_hdulist = fits.open(cutout_file)  #doctest: +SKIP
                 >>> cutout_hdulist.info() #doctest: +SKIP
                 Filename: ./cutout_150.094500_2.386810_200-x-300_astrocut.fits
                 No.    Name      Ver    Type      Cards   Dimensions   Format
@@ -188,8 +188,8 @@ aligned and have the same pixel scale, no checking is done.
                 >>> center_coord = SkyCoord("150.0945 2.38681", unit='deg')
                 >>> cutout_size = [200,300]
                 
-                >>> png_files = img_cut(input_files, center_coord, cutout_size, img_format='png', drop_after="")  
-                >>> print(png_files[0])  
+                >>> png_files = img_cut(input_files, center_coord, cutout_size, img_format='png', drop_after="")    #doctest: +SKIP
+                >>> print(png_files[0])    #doctest: +SKIP
                 ./hlsp_candels_hst_acs_cos-tot-sect23_f606w_v1.0_drz_150.094500_2.386810_200-x-300_astrocut.png
 
                 >>> Image.open(png_files[1]) #doctest: +SKIP
@@ -212,8 +212,8 @@ treated as the R, G, and B channels respectively.
                 >>> center_coord = SkyCoord("189.51522 62.2865221", unit='deg')
                 >>> cutout_size = [200,300]
                 
-                >>> color_image = img_cut(input_files, center_coord, cutout_size, colorize=True)
-                >>> print(color_image)  
+                >>> color_image = img_cut(input_files, center_coord, cutout_size, colorize=True)   #doctest: +SKIP
+                >>> print(color_image)    #doctest: +SKIP
                 ./cutout_189.515220_62.286522_200-x-300_astrocut.jpg
                 
                 >>> Image.open(color_image) #doctest: +SKIP


### PR DESCRIPTION
This pertains to TESS cutouts.
Currently when fitting a linear WCS to a cutout we use every single pixel in the fit. This gets inefficient for large cutouts and does not make the fit appreciable better.
This PR limits the number of pixels used to a maximum of 100, spread evenly throughout the cutout.