### PR TITLE
Changing memmap mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 - Update wcs fitting to match Astropy (and use Astropy when available) [#29]
 - Limit the number of pixels used for WCS fitting to 100 [#30]
 - Deprecate drop_after and handle inconsistant wcs keywords automatically [#31]
+- Change the memmap access mode from ACCESS_COPY to ACCESS_READ to lower memory usage. [#33]
 
 
 0.5 (2020-01-13)

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -735,7 +735,7 @@ class CutoutFactory():
             start_time = time()
 
         warnings.filterwarnings("ignore", category=wcs.FITSFixedWarning)
-        with fits.open(cube_file) as cube:
+        with fits.open(cube_file, mode='denywrite', memmap=True) as cube:
 
             # Get the info we need from the data table
             self._parse_table_info(cube[2].header, cube[2].data, verbose)

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -448,7 +448,7 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, drop_afte
             print("\n{}".format(in_fle))
 
         warnings.filterwarnings("ignore", category=wcs.FITSFixedWarning)
-        with fits.open(in_fle) as hdulist:
+        with fits.open(in_fle, mode='denywrite', memmap=True) as hdulist:
             try:
                 cutout = _hducut(hdulist[0], coordinates, cutout_size,
                                  correct_wcs=correct_wcs, verbose=verbose)
@@ -677,7 +677,7 @@ def img_cut(input_files, coordinates, cutout_size, stretch='asinh', minmax_perce
     for in_fle in input_files:
         if verbose:
             print("\n{}".format(in_fle))
-        hdulist = fits.open(in_fle)
+        hdulist = fits.open(in_fle, mode='denywrite', memmap=True)
         cutout = _hducut(hdulist[0], coordinates, cutout_size,
                          correct_wcs=False, verbose=verbose)
         hdulist.close()

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -99,7 +99,7 @@ class CubeFactory():
         good_header_ind = None
     
         for i, ffi in enumerate(file_list):
-            ffi_data = fits.open(ffi)
+            ffi_data = fits.open(ffi, mode='denywrite', memmap=True)
             
             start_times[i] = ffi_data[1].header.get("TSTART")  # TODO: optionally pass this in?
             
@@ -124,7 +124,7 @@ class CubeFactory():
         if verbose:
             print("Using {} to initialize the image header table.".format(os.path.basename(fle)))
             
-        ffi_data = fits.open(fle)
+        ffi_data = fits.open(fle, mode='denywrite', memmap=True)
 
         # The image specific header information will be saved in a table in the second extension
         secondary_header = ffi_data[1].header
@@ -151,7 +151,7 @@ class CubeFactory():
         # Loop through files
         for i, fle in enumerate(file_list[sorted_indices]):
         
-            ffi_data = fits.open(fle)
+            ffi_data = fits.open(fle, mode='denywrite', memmap=True)
 
             # if the arrays/header aren't initialized do it now
             if img_cube is None:


### PR DESCRIPTION
This PR changes the memmap mode when reading a fits file from `readonly` to `denywrite,` the difference is that `readonly` map to memmap access mode "ACCESS_COPY" while `denywrite` maps to "ACCESS_READ." For our purposes the issue with "ACCESS_COPY" is that it requires more memory, which can cause problems for larger files. 