### PR TITLE
Minor wcs update

### DIFF
--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from time import time
 from datetime import date
-from itertools import product
 
 from astropy import log
 from astropy import units as u

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -203,10 +203,10 @@ def _hducut(img_hdu, center_coord, cutout_size, correct_wcs=False, verbose=False
     if (len(log_list) > 0):
         if ("Inconsistent SIP distortion information" in log_list[0].msg):
             # Delete standard sip keywords
-            remove_sip_coefficients(hdu_header)
+            #remove_sip_coefficients(hdu_header)
         
             # load wcs ignoring any nonstandard keywords
-            img_wcs = wcs.WCS(hdu_header, relax=False)
+            #img_wcs = wcs.WCS(hdu_header, relax=False)
 
             # As an extra precaution make sure the img wcs has no sip coeefficients
             img_wcs.sip = None

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -126,33 +126,7 @@ def _get_cutout_wcs(img_wcs, cutout_lims):
     wcs_header.set("CDELT2P", 1.0, "physical WCS axis 2 step")
 
     return wcs.WCS(wcs_header)
-        
 
-def remove_sip_coefficients(hdu_header):
-    """
-    Remove standard sip coefficient keywords for a fits header.
-
-    Parameters
-    ----------
-    hdu_header : ~astropy.io.fits.Header
-        The header from which SIP keywords will be removed.  This is done in place.
-    """
-
-    for lets in product(["A", "B"], ["", "P"]):
-        lets = ''.join(lets)
-
-        key = "{}_ORDER".format(lets)
-        if key in hdu_header.keys():
-            del hdu_header["{}_ORDER".format(lets)]
-
-        key = "{}_DMAX".format(lets)
-        if key in hdu_header.keys():
-            del hdu_header["{}_DMAX".format(lets)]
-        
-        for i, j in product([0, 1, 2, 3], [0, 1, 2, 3]):
-            key = "{}_{}_{}".format(lets, i, j)
-            if key in hdu_header.keys():
-                del hdu_header["{}_{}_{}".format(lets, i, j)]
 #### FUNCTIONS FOR UTILS ####
 
 
@@ -202,13 +176,8 @@ def _hducut(img_hdu, center_coord, cutout_size, correct_wcs=False, verbose=False
     no_sip = False
     if (len(log_list) > 0):
         if ("Inconsistent SIP distortion information" in log_list[0].msg):
-            # Delete standard sip keywords
-            #remove_sip_coefficients(hdu_header)
-        
-            # load wcs ignoring any nonstandard keywords
-            #img_wcs = wcs.WCS(hdu_header, relax=False)
 
-            # As an extra precaution make sure the img wcs has no sip coeefficients
+            # Remove sip coefficients
             img_wcs.sip = None
             no_sip = True
             

--- a/astrocut/tests/test_cutouts.py
+++ b/astrocut/tests/test_cutouts.py
@@ -111,7 +111,8 @@ def test_get_cutout_wcs():
     cutout_wcs = cutouts._get_cutout_wcs(test_img_wcs, lims)
     assert (cutout_wcs.wcs.crval == [100, 20]).all()
     assert (cutout_wcs.wcs.crpix == [-3, 6]).all() 
-    
+
+
 def test_fits_cut(tmpdir, capsys):
 
     test_images = create_test_imgs(50, 6, dir_name=tmpdir)

--- a/astrocut/tests/test_cutouts.py
+++ b/astrocut/tests/test_cutouts.py
@@ -111,58 +111,6 @@ def test_get_cutout_wcs():
     cutout_wcs = cutouts._get_cutout_wcs(test_img_wcs, lims)
     assert (cutout_wcs.wcs.crval == [100, 20]).all()
     assert (cutout_wcs.wcs.crpix == [-3, 6]).all() 
-
-
-def test_remove_sip_coefficients():
-
-    test_img_wcs_kwds = fits.Header(cards=[('NAXIS', 2, 'number of array dimensions'),
-                                           ('NAXIS1', 20, ''),
-                                           ('NAXIS2', 30, ''),
-                                           ('CTYPE1', 'RA---TAN', 'Right ascension, gnomonic projection'),
-                                           ('CTYPE2', 'DEC--TAN', 'Declination, gnomonic projection'),
-                                           ('CRVAL1', 100, '[deg] Coordinate value at reference point'),
-                                           ('CRVAL2', 20, '[deg] Coordinate value at reference point'),
-                                           ('CRPIX1', 10, 'Pixel coordinate of reference point'),
-                                           ('CRPIX2', 15, 'Pixel coordinate of reference point'),
-                                           ('CDELT1', 1.0, '[deg] Coordinate increment at reference point'),
-                                           ('CDELT2', 1.0, '[deg] Coordinate increment at reference point'),
-                                           ('WCSAXES', 2, 'Number of coordinate axes'),
-                                           ('PC1_1', 1, 'Coordinate transformation matrix element'),
-                                           ('PC2_2', 1, 'Coordinate transformation matrix element'),
-                                           ('CUNIT1', 'deg', 'Units of coordinate increment and value'),
-                                           ('CUNIT2', 'deg', 'Units of coordinate increment and value')])
-
-    # no sip coefficients to remove
-    num_kwds = len(test_img_wcs_kwds)
-    cutouts.remove_sip_coefficients(test_img_wcs_kwds)
-    assert num_kwds == len(test_img_wcs_kwds)
-
-    # add sip coefficients
-    test_img_wcs_kwds['A_ORDER'] = 2
-    test_img_wcs_kwds['B_ORDER'] = 2
-    test_img_wcs_kwds['A_2_0'] = 2.024511892340E-05
-    test_img_wcs_kwds['A_0_2'] = 3.317603337918E-06
-    test_img_wcs_kwds['A_1_1'] = 1.73456334971071E-5
-    test_img_wcs_kwds['B_2_0'] = 3.331330003472E-06
-    test_img_wcs_kwds['B_0_2'] = 2.042474824825892E-5
-    test_img_wcs_kwds['B_1_1'] = 1.714767108041439E-5
-    test_img_wcs_kwds['AP_ORDER'] = 2
-    test_img_wcs_kwds['BP_ORDER'] = 2
-    test_img_wcs_kwds['AP_1_0'] = 9.047002963896363E-4
-    test_img_wcs_kwds['AP_0_1'] = 6.276607155847164E-4
-    test_img_wcs_kwds['AP_2_0'] = -2.023482905861E-05
-    test_img_wcs_kwds['AP_0_2'] = -3.332285841011E-06
-    test_img_wcs_kwds['AP_1_1'] = -1.731636633824E-05
-    test_img_wcs_kwds['BP_1_0'] = 6.279608820532116E-4
-    test_img_wcs_kwds['BP_0_1'] = 9.112228860848081E-4
-    test_img_wcs_kwds['BP_2_0'] = -3.343918167224E-06
-    test_img_wcs_kwds['BP_0_2'] = -2.041598249021E-05
-    test_img_wcs_kwds['BP_1_1'] = -1.711876336719E-05
-    test_img_wcs_kwds['A_DMAX'] = 44.72893589844534
-    test_img_wcs_kwds['B_DMAX'] = 44.62692873032506
-    cutouts.remove_sip_coefficients(test_img_wcs_kwds)
-    assert num_kwds == len(test_img_wcs_kwds)
-
     
 def test_fits_cut(tmpdir, capsys):
 


### PR DESCRIPTION
It turns out removing sip keywords manually is not necessary, you can just set `wcs.sip = 0`