### PR TITLE
fixing error resulting from forward slash in target name

### DIFF
--- a/astrocut/cutout_processing.py
+++ b/astrocut/cutout_processing.py
@@ -385,7 +385,6 @@ def center_on_path(path, size, cutout_fles, target=None, img_wcs=None,
         primary_header_list.append(hdu[0].header)
         table_headers.append(hdu[1].header)
         hdu.close()
-    
     # Building the new primary header
     primary_header = _combine_headers(primary_header_list, constant_only=True)
     primary_header['DATE'] = Time.now().to_value('iso', subfmt='date')

--- a/astrocut/cutout_processing.py
+++ b/astrocut/cutout_processing.py
@@ -425,7 +425,7 @@ def center_on_path(path, size, cutout_fles, target=None, img_wcs=None,
         target_pixel_file = (f"{target}_{primary_header['TSTART']}-{primary_header['TSTop']}_"
                              f"{size[0]}-x-{size[1]}_astrocut.fits")
     
-    # Replace any slashes/spaces with % for filename conventions
+    # Replace any slashes/spaces for filename conventions
     target_pixel_file = target_pixel_file.replace('/', '-').replace(' ', '_')
 
     filename = os.path.join(output_path, target_pixel_file)

--- a/astrocut/cutout_processing.py
+++ b/astrocut/cutout_processing.py
@@ -371,12 +371,12 @@ def center_on_path(path, size, cutout_fles, target=None, img_wcs=None,
     response : str
         The file path for the output target pixel file.
     """
-
-    # TODO: add ability to take sizes like in rest of cutout functionality
     
+    # TODO: add ability to take sizes like in rest of cutout functionality
+
     # Performing the path transformation
     cutout_table = _moving_target_focus(path, size, cutout_fles, verbose)
-
+    
     # Collecting header info we need
     primary_header_list = list()
     table_headers = list()
@@ -385,7 +385,7 @@ def center_on_path(path, size, cutout_fles, target=None, img_wcs=None,
         primary_header_list.append(hdu[0].header)
         table_headers.append(hdu[1].header)
         hdu.close()
-
+    
     # Building the new primary header
     primary_header = _combine_headers(primary_header_list, constant_only=True)
     primary_header['DATE'] = Time.now().to_value('iso', subfmt='date')
@@ -425,8 +425,12 @@ def center_on_path(path, size, cutout_fles, target=None, img_wcs=None,
         target = "path" if not target else target
         target_pixel_file = (f"{target}_{primary_header['TSTART']}-{primary_header['TSTop']}_"
                              f"{size[0]}-x-{size[1]}_astrocut.fits")
+    
+    # Replace any slashes/spaces with % for filename conventions
+    target_pixel_file = target_pixel_file.replace('/', '-').replace(' ', '_')
 
     filename = os.path.join(output_path, target_pixel_file)
+    
     mt_hdu_list.writeto(filename, overwrite=True, checksum=True)
 
     return filename

--- a/astrocut/cutout_processing.py
+++ b/astrocut/cutout_processing.py
@@ -376,7 +376,6 @@ def center_on_path(path, size, cutout_fles, target=None, img_wcs=None,
 
     # Performing the path transformation
     cutout_table = _moving_target_focus(path, size, cutout_fles, verbose)
-    
     # Collecting header info we need
     primary_header_list = list()
     table_headers = list()

--- a/astrocut/tests/test_cutout_processing.py
+++ b/astrocut/tests/test_cutout_processing.py
@@ -1,4 +1,6 @@
 import os 
+import pytest
+
 import numpy as np
 
 from astropy.io import fits

--- a/astrocut/tests/test_cutout_processing.py
+++ b/astrocut/tests/test_cutout_processing.py
@@ -252,7 +252,7 @@ def test_center_on_path(tmpdir):
                                                 target=target, output_path=tmpdir, 
                                                 verbose=False)
     assert "path" in out_file
-    # Making sure special characters are taken careof
+    # Making sure special characters are taken care of
     assert "C-_Targetname" in out_file
 
     hdu = fits.open(out_file)

--- a/astrocut/tests/test_cutout_processing.py
+++ b/astrocut/tests/test_cutout_processing.py
@@ -247,14 +247,18 @@ def test_center_on_path(tmpdir):
     assert primary_header["OBJECT"] == "Test Target"
 
     # Using the default output filename and not giving an image wcs
-    out_file = cutout_processing.center_on_path(path, size, [cutout_file],
-                                                output_path=tmpdir, verbose=False)
+    target = "C/ Targetname" 
+    out_file = cutout_processing.center_on_path(path, size, [cutout_file], 
+                                                target=target, output_path=tmpdir, 
+                                                verbose=False)
     assert "path" in out_file
+    # Making sure special characters are taken careof
+    assert "C-_Targetname" in out_file
 
     hdu = fits.open(out_file)
     assert len(hdu) == 2
     assert hdu[0].header["DATE"] == Time.now().to_value('iso', subfmt='date')
-    assert hdu[0].header["OBJECT"] == ""
+    assert hdu[0].header["OBJECT"] == target
     hdu.close()
 
 


### PR DESCRIPTION
Fixing an error originating from having forward slashes and spaces in the target name (e.g. `C/2014 UN271`). This edit catches any `/` or spaces in the name of the target and replaces them accordingly, which allows the script to continue writing the output Target Pixel File. 

This closes https://github.com/spacetelescope/astrocut/issues/50