### PR TITLE
fixing broken tests from GitHub Actions CI run

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - main
     tags:
+    - '*'
   pull_request:
 
 jobs:
@@ -56,9 +57,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
+    - name: Updating apt-get before install
+      if: startsWith(matrix.os, 'ubuntu')
+      run: sudo apt-get update 
     - name: Install language-pack-de and tzdata
       if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get install language-pack-de tzdata
+      run: sudo apt-get --fix-missing install language-pack-de tzdata
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox codecov
     - name: Run tests
@@ -96,9 +100,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
+    - name: Updating apt-get before install
+      if: startsWith(matrix.os, 'ubuntu')
+      run: sudo apt-get update 
     - name: Install language-pack-de and tzdata
       if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get install language-pack-de tzdata
+      run: sudo apt-get --fix-missing install language-pack-de tzdata
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox codecov
     - name: Run tests

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -57,12 +57,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    - name: Updating apt-get before install
-      if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get update 
     - name: Install language-pack-de and tzdata
       if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get --fix-missing install language-pack-de tzdata
+      run: | 
+        sudo apt-get update
+        sudo apt-get install language-pack-de tzdata
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox codecov
     - name: Run tests
@@ -100,12 +99,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    - name: Updating apt-get before install
-      if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get update 
     - name: Install language-pack-de and tzdata
       if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt-get --fix-missing install language-pack-de tzdata
+      run: | 
+        sudo apt-get update
+        sudo apt-get install language-pack-de tzdata
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox codecov
     - name: Run tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ testpaths = "astrocut" "docs"
 astropy_header = true
 doctest_plus = enabled
 text_file_format = rst
-addopts = --doctest-rst
+addopts = --doctest-modules
 
 [flake8]
 exclude = extern,sphinx,*parsetab.py,astrocut

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ install_requires =
     astropy >=3.0
     scipy
     Pillow
-    sphinx-astropy
 
 [options.entry_points]
 console_scripts =
@@ -31,6 +30,7 @@ test =
 docs =
     sphinx != 4.1.0
     docutils == 0.16
+    sphinx-astropy
     sphinx_rtd_theme >= 0.5.2
 
 [options.package_data]
@@ -41,7 +41,7 @@ testpaths = "astrocut" "docs"
 astropy_header = true
 doctest_plus = enabled
 text_file_format = rst
-addopts = --doctest-modules
+addopts = --doctest-rst
 
 [flake8]
 exclude = extern,sphinx,*parsetab.py,astrocut

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ install_requires =
     astropy >=3.0
     scipy
     Pillow
+    sphinx-astropy
 
 [options.entry_points]
 console_scripts =
@@ -30,7 +31,6 @@ test =
 docs =
     sphinx != 4.1.0
     docutils == 0.16
-    sphinx-astropy
     sphinx_rtd_theme >= 0.5.2
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
+    sphinx-astropy >= 1.7.0
 isolated_build = true
 
 [testenv]
@@ -70,7 +71,7 @@ commands =
 changedir = docs
 description = invoke sphinx-build to build the HTML docs
 extras = docs
-deps= sphinx_rtd_theme
+deps = sphinx_rtd_theme
 commands =
     pip freeze
     sphinx-build -W -b html . _build/html

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
-    sphinx-astropy >= 1.7.0
+    
 isolated_build = true
 
 [testenv]
@@ -59,7 +59,7 @@ deps =
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
     test
-    alldeps: all
+    alldeps: docs
 
 commands =
     pip freeze


### PR DESCRIPTION
Fixing deprecated scripts that are causing CI tests to break. Changes include:

- [x] run `apt-get update` before `apt-get install` step in CI workflow
- [x] fix `ERROR: the documentation requires the sphinx-astropy package to be installed`

Tests are passing except for the allowed failure for python 3.7, so I will mark this PR as ready for review. Thanks in advance! 