### PR TITLE
Make cubes out of TICA FFIs

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -85,11 +85,6 @@ jobs:
             python: 3.7
             toxenv: py37-test-devdeps
 
-          - name: (Allowed Failure) Python 3.8 with all optional dependencies (Windows)
-             os: windows-latest
-             python: 3.8
-             toxenv: py38-test-alldeps
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -85,6 +85,11 @@ jobs:
             python: 3.7
             toxenv: py37-test-devdeps
 
+          - name: Python 3.8 with all optional dependencies (Windows)
+             os: windows-latest
+             python: 3.8
+             toxenv: py38-test-alldeps
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -28,6 +28,11 @@ jobs:
             toxenv: py38-test-alldeps
             toxargs: -v --develop
 
+          # Commenting out the test below due to outdated ubuntu OS 
+          # (16.04) which is no longer supported, 
+          # and Python 3.6 is no longer being supported. 
+          # TODO: Might be worth keeping this test for users who 
+          # are still on 3.6 and just update the os to ubuntu-18.04
           #- name: Python 3.6 with oldest supported version of all dependencies
           #  os: ubuntu-16.04
           #  python: 3.6

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -85,7 +85,7 @@ jobs:
             python: 3.7
             toxenv: py37-test-devdeps
 
-          - name: Python 3.8 with all optional dependencies (Windows)
+          - name: (Allowed Failure) Python 3.8 with all optional dependencies (Windows)
              os: windows-latest
              python: 3.8
              toxenv: py38-test-alldeps

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - tica-make-cubes
     tags:
     - '*'
   pull_request:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - tica-make-cubes
     tags:
     - '*'
   pull_request:
@@ -37,11 +38,6 @@ jobs:
             os: ubuntu-latest
             python: 3.7
             toxenv: py37-test-alldeps-numpy121-cov
-
-          - name: Python 3.8 with all optional dependencies (Windows)
-            os: windows-latest
-            python: 3.8
-            toxenv: py38-test-alldeps
             
           - name: Python 3.7 with all optional dependencies (MacOS X)
             os: macos-latest

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -28,10 +28,10 @@ jobs:
             toxenv: py38-test-alldeps
             toxargs: -v --develop
 
-          - name: Python 3.6 with oldest supported version of all dependencies
-            os: ubuntu-16.04
-            python: 3.6
-            toxenv: py36-test-oldestdeps   
+          #- name: Python 3.6 with oldest supported version of all dependencies
+          #  os: ubuntu-16.04
+          #  python: 3.6
+          #  toxenv: py36-test-oldestdeps   
             
           - name: Python 3.7 with numpy 1.21 and full coverage
             os: ubuntu-latest

--- a/astrocut/__init__.py
+++ b/astrocut/__init__.py
@@ -22,7 +22,7 @@ if sys.version_info < tuple((int(val) for val in __minimum_python_version__.spli
 
 
 if not _ASTROPY_SETUP_:  # noqa
-    from .make_cube import CubeFactory  # noqa
+    from .make_cube import CubeFactory, TicaCubeFactory  # noqa
     from .cube_cut import CutoutFactory  # noqa
     from .cutouts import fits_cut, img_cut, normalize_img  # noqa
     from .cutout_processing import (path_to_footprints, center_on_path,  # noqa

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -635,7 +635,7 @@ class TicaCubeFactory():
         self.cube_file = cube_file
 
         if verbose:
-            print(f'Working on cube file: {cube_file}')
+            print(f'Updating cube file: {cube_file}')
 
         # Ensure that none of the files in file_list are in the cube already, to avoid duplicates
         in_cube = list(fits.getdata(self.cube_file, 2)['FFI_FILE'])
@@ -647,7 +647,7 @@ class TicaCubeFactory():
         self._configure_cube(file_list)
 
         if verbose:
-            print(f"Cube will be appended in {self.num_blocks} blocks of {self.block_size} rows each.")
+            print(f"FFIs will be appended in {self.num_blocks} blocks of {self.block_size} rows each.")
         
         # Preparing to update the info table to hold image header keywords of the new FFIs
         self.info_table = fits.getdata(self.cube_file, 2)

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -555,16 +555,24 @@ class TicaCubeFactory():
             if verbose:
                 st = time()
 
+            # In this section we will take the SCI data from self.file_list above
+            # and "paste" a cutout of the full SCI array into a 4d array called 
+            # sub_cube. We iterate this process until the full SCI array for each 
+            # FFI is copied onto the cube. Usually the sub_cube is ~1/3 the size of 
+            # the full SCI array, so there are 3 iterations. 
+            # For TICA, the SCI data exists in the 0th extension. 
             with fits.open(fle, mode='denywrite', memmap=True) as ffi_data:
 
-                # add the image and info to the arrays
+                # Add the image and info to the arrays
                 sub_cube[:, :, i, 0] = ffi_data[0].data[start_row:end_row, :]
 
                 del ffi_data[0].data
                
-                if fill_info_table:  # Also save the header info in the info table
+                # Also save the header info in the info table
+                if fill_info_table:
 
-                    for kwd in self.info_table.columns:  # Iterate over every keyword in the TICA FFI primary header
+                    # Iterate over every keyword in the TICA FFI primary header
+                    for kwd in self.info_table.columns:
                         if kwd == "FFI_FILE":
                             self.info_table[kwd][i] = os.path.basename(fle)
                             

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -454,8 +454,8 @@ class TicaCubeFactory():
         else:
             with fits.open(self.cube_file, mode='update', memmap=True) as cube_hdu:
                 header = cube_hdu[0].header 
-                header['HISTORY'] = f'Updated on {str(date.today())} with new FFI delivery.' 
-                header['HISTORY'] = f'First FFI is {str(os.path.basename(self.file_list[0]))}'
+                #header['HISTORY'] = f'Updated on {str(date.today())} with new FFI delivery.' 
+                #header['HISTORY'] = f'First FFI is {str(os.path.basename(self.file_list[0]))}'
 
         # Adding the keywords from the last file
         with fits.open(self.file_list[-1], mode='denywrite', memmap=True) as last_file:
@@ -634,8 +634,6 @@ class TicaCubeFactory():
         if not self.update:
             cube_hdu[1].data[start_row:end_row, :, :, :] = sub_cube
         else:
-            print(self.cube_append[start_row:end_row, :, :, :].shape)
-            print(sub_cube.shape)
             self.cube_append[start_row:end_row, :, :, :] = sub_cube
 
         if (version_info <= (3, 8)) or (platform == "win32"):
@@ -770,9 +768,9 @@ class TicaCubeFactory():
             hdul[1].data = new_cube
 
         # Add the info table to the cube file
-        self._write_info_table()
-        if verbose:
-            print(f"Total time elapsed: {(time() - startTime)/60:.2f} min")
+        #self._write_info_table()
+        #if verbose:
+        #    print(f"Total time elapsed: {(time() - startTime)/60:.2f} min")
 
         return self.cube_file
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -730,7 +730,7 @@ class TicaCubeFactory():
             cube_hdus.append(table_hdu)
 
 
-    def update_cube(self, file_list, cube_file, verbose=True):
+    def update_cube(self, file_list, cube_file, sector=None, verbose=True):
         """ Updates an existing cube file if one has already been made and a new delivery is being appended to it. 
         Same functionality as make_cube(...), but working on an already existing file rather than building a new one. 
         This function will: 
@@ -770,7 +770,9 @@ class TicaCubeFactory():
                     print(f'FFI {file} is already in the cube. Removing it from ``file_list``.')
                 file_list.remove(file)
         
-        self._configure_cube(file_list)
+        # Set up the basic cube parameters
+        sector = (sector, "Observing sector")
+        self._configure_cube(file_list, sector=sector)
 
         if verbose:
             print(f"FFIs will be appended in {self.num_blocks} blocks of {self.block_size} rows each.")
@@ -839,7 +841,7 @@ class TicaCubeFactory():
         return self.cube_file
 
 
-    def make_cube(self, file_list, cube_file='img-cube.fits', verbose=True, max_memory=50):
+    def make_cube(self, file_list, cube_file="img-cube.fits", sector=None, max_memory=50, verbose=True):
 
         if verbose:
             startTime = time()
@@ -847,7 +849,8 @@ class TicaCubeFactory():
         self.max_memory = max_memory
 
         # Set up the basic cube parameters
-        self._configure_cube(file_list)
+        sector = (sector, "Observing sector")
+        self._configure_cube(file_list, sector=sector)
 
         if verbose:
             print("Using {} to initialize the image header table.".format(os.path.basename(self.template_file)))

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -427,6 +427,7 @@ class TicaCubeFactory():
         # If it's a new cube, the shape is (nRows, nCols, nImages, 2)
         if not self.update:
             self.cube_shape = (image_shape[0], image_shape[1], len(self.file_list), 2)
+            
         # Else, if it's an update to an existing cube, the shape is (nRows, nCols, nImages + nNewImages, 2)
         else: 
             self.cube_shape = self.cube_append.shape

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -562,11 +562,11 @@ class TicaCubeFactory():
                             elif self.info_table[kwd].dtype.char == "S":  # hacky way to check if it's a string
                                 nulval = ""
                             
-                            # A header keyword in TICA was found to return a string 
-                            # value in the form of a _HeaderCommentaryCard, which 
-                            # could not be fed into the info table because the info table 
+                            # A header keyword ('COMMENT') in TICA returns a keyword 
+                            # value in the form of a _HeaderCommentaryCard instead of a STRING. 
+                            # This breaks the info table because the info table 
                             # doesn't understand what a FITS header commentary card is. 
-                            # This try/except is a way to catch when these instances happen 
+                            # Adding a try/except is a way to catch when these instances happen 
                             # and turn the keyword value from a _HeaderCommentaryCard to a
                             # string, which is what it's meant to be in the info table. 
                             #
@@ -583,7 +583,7 @@ class TicaCubeFactory():
                 print(f"Completed file {i} in {time()-st:.3} sec.")
 
         # Fill block and flush to disk
-        cube_hdu[1].data[start_row:end_row, :, :, :] = sub_cube
+        cube_hdu[0].data[start_row:end_row, :, :, :] = sub_cube
 
         if (version_info <= (3, 8)) or (platform == "win32"):
             cube_hdu.flush()

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -719,7 +719,7 @@ class TicaCubeFactory():
         og_cube = fits.getdata(cube_file, 1)
         dimensions = list(og_cube.shape)
         dimensions[2] = len(file_list)
-        self.cube_append = np.zeros(tuple(dimensions))
+        self.cube_append = np.zeros(dimensions)
 
         # Next locate the existing cube file and assign it a variable
         err_msg = 'Location of the cube file was unsuccessful. Please ensure the correct path was provided.'

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -654,13 +654,17 @@ class TicaCubeFactory():
         # Make table hdu 
         cols = []
         for kwd in self.info_table.columns:
+            #print(self.info_table[kwd].dtype)
+            
             if self.info_table[kwd].dtype == np.float64:
                 tpe = 'D'
             elif self.info_table[kwd].dtype == np.int32:
                 tpe = 'J'
             else:
                 tpe = str(self.info_table[kwd].dtype).replace("S", "A").strip("|")
-    
+            print(kwd)
+            print(self.info_table[kwd].dtype)
+            print(tpe)
             cols.append(fits.Column(name=kwd, format=tpe, array=self.info_table[kwd]))
         
         col_def = fits.ColDefs(cols)
@@ -776,8 +780,8 @@ class TicaCubeFactory():
         # Add the info table to the cube file
         for kwd in self.info_table.columns:
             self.info_table[kwd] = np.array(self.old_cols[kwd])
-            print(self.info_table[kwd])
-        #print(self.old_cols['FFI_FILE'])
+            #print(self.info_table[kwd])
+        print(self.info_table['ACS_MODE'])
         self._write_info_table()
         if verbose:
             print(f"Total time elapsed: {(time() - startTime)/60:.2f} min")

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -474,7 +474,7 @@ class TicaCubeFactory():
             primary_header = ffi_data[0].header
 
             # set up the image info table
-            already_there = []
+            existing_cols = []
             cols = []
             for kwd, val, cmt in primary_header.cards: 
                 if type(val) == str:  
@@ -485,11 +485,9 @@ class TicaCubeFactory():
                     tpe = np.float64
                     
                 length = len(self.file_list)
-                if kwd not in already_there:
-                    already_there.append(kwd)
-                else: 
-                    continue
-                cols.append(Column(name=kwd, dtype=tpe, length=length, meta={"comment": cmt}))
+                if kwd not in existing_cols:
+                    existing_cols.append(kwd)
+                    cols.append(Column(name=kwd, dtype=tpe, length=length, meta={"comment": cmt}))
 
             cols.append(Column(name="FFI_FILE", dtype="S" + str(len(os.path.basename(self.template_file))),
                                length=length))

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -531,11 +531,9 @@ class TicaCubeFactory():
         cubesize_in_bytes = ((np.prod(self.cube_shape) * 4 + 2880 - 1) // 2880) * 2880
         filelen = os.path.getsize(cube_file)
         
+        # Seek to end of file and write null byte
         with open(cube_file, 'r+b') as CUBE:
-            # What is this .seek?
-            # Looks like it's expanding the buffer size of the file?
             CUBE.seek(filelen + cubesize_in_bytes - 1)
-            # b for buffer?
             CUBE.write(b'\0')
         
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -382,6 +382,7 @@ class TicaCubeFactory():
         self.old_cols = None
 
         self.update = False
+        self.cube_append = None
 
     def _configure_cube(self, file_list, **extra_keywords):
         """ Run through all the files and set up the  basic parameters for the cube.
@@ -676,6 +677,11 @@ class TicaCubeFactory():
         """
 
         self.update = True # we're updating!
+
+        cube = fits.getdata(cube_file, 1)
+        dimensions = list(cube.shape)
+        dimensions[2] = len(file_list)
+        self.cube_append = np.zeros(tuple(dimensions))
 
         if verbose:
             startTime = time()

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -353,6 +353,19 @@ class CubeFactory():
 
 
 class TicaCubeFactory():
+    """
+    Class for creating TICA image cubes.
+    
+    This class emcompasses all of the cube making functionality.  
+    In the current version this means creating image cubes fits files from TESS full frame image sets.
+    Future versions will include more generalized cubing functionality.
+
+    The TESS Image CAlibrator (TICA) products are high level science products (HLSPs) 
+    developed by the MIT Quick Look Pipeline (https://github.com/mmfausnaugh/tica). These 
+    images are produced and delivered up to 4x sooner than their SPOC counterparts (as of TESS EM2),
+    and can therefore be used to produce the most up-to-date cutouts of a target. 
+    More information on TICA can be found here: https://archive.stsci.edu/hlsp/tica
+    """
 
     def __init__(self, max_memory=50):
         """ Setting up the class members."""

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -397,7 +397,7 @@ class TicaCubeFactory():
         for i, ffi in enumerate(file_list):
             ffi_data = fits.open(ffi, mode='denywrite', memmap=True)
             
-            start_times[i] = ffi_data[0].header.get('STARTTJD')
+            start_times[i] = ffi_data[0].header.get(self.time_keyword)
 
             if image_shape is None:  # Only need to fill this once
                 image_shape = ffi_data[0].data.shape
@@ -455,8 +455,8 @@ class TicaCubeFactory():
         else:
             with fits.open(self.cube_file, mode='update', memmap=True) as cube_hdu:
                 header = cube_hdu[0].header 
-                # header['HISTORY'] = f'Updated on {str(date.today())} with new FFI delivery.' 
-                # header['HISTORY'] = f'First FFI is {str(os.path.basename(self.file_list[0]))}'
+                header['HISTORY'] = f'Updated on {str(date.today())} with new FFI delivery.' 
+                header['HISTORY'] = f'First FFI is {str(os.path.basename(self.file_list[0]))}'
 
         # Adding the keywords from the last file
         with fits.open(self.file_list[-1], mode='denywrite', memmap=True) as last_file:

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -579,8 +579,7 @@ class TicaCubeFactory():
                     for kwd in self.info_table.columns: # Iterate over every keyword in the TICA FFI primary header
                         if kwd == "FFI_FILE":
                             self.info_table[kwd][i] = os.path.basename(fle)
-                            print('FILE BEING APPENDED')
-                            print(fle)
+                            
                         else:
                             nulval = None
                             if self.info_table[kwd].dtype.name == "int32":
@@ -653,7 +652,6 @@ class TicaCubeFactory():
         del sub_cube
     
     def _update_info_table(self):
-
         """ Updating an existing info table with newly created
         """
 
@@ -687,11 +685,11 @@ class TicaCubeFactory():
 
             with fits.open(self.cube_file, mode='readonly') as hdul:
 
-                    og_table = hdul[2].data
-                    appended_column = np.concatenate((og_table['FFI_FILE'], self.info_table['FFI_FILE']))
+                og_table = hdul[2].data
+                appended_column = np.concatenate((og_table['FFI_FILE'], self.info_table['FFI_FILE']))
 
-            cols.append(Column(name="FFI_FILE", dtype="S" + str(len(os.path.basename(self.template_file))),
-                               length=length))
+                cols.append(Column(appended_column, name="FFI_FILE", dtype="S" + str(len(os.path.basename(self.template_file))),
+                                length=length))
     
             self.info_table = Table(cols)
 
@@ -815,7 +813,7 @@ class TicaCubeFactory():
 
                 if verbose:
                     print(f"Completed block {i+1} of {self.num_blocks}")
-
+       
         # Append the new cube to the existing cube
         new_cube = np.concatenate((og_cube, self.cube_append), axis=2)
 
@@ -825,14 +823,15 @@ class TicaCubeFactory():
             if verbose:
                 print(f'Original cube of size: {str(og_cube.shape)}')
                 print(f'will now be replaced with cube of size: {str(new_cube.shape)}')
-                print(f'for file {cube_file}')
+                print(f'for file ``{cube_file}``')
             hdul[1].data = new_cube
 
         # Appending new info table to original 
         self._update_info_table()
         
-        print(self.info_table['FFI_FILE'])
+        # Writing the info table to EXT2 of the FITS file 
         self._write_info_table()
+
         if verbose:
             print(f"Total time elapsed: {(time() - startTime)/60:.2f} min")
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -354,15 +354,7 @@ class CubeFactory():
 class TicaCubeFactory():
 
     def __init__(self, max_memory=50):
-        """ Setting up the class members. NOTE: Later down the line 
-        we might want to generalize CubeFactory so that we no longer need 
-        a separate class for the TICA cubes. 
-        
-        Modifying the __init__ 
-        in CubeFactory so that it can switch parameters based on whether 
-        we want cubes for TICA or TESS will probably be the route I take.
-        Or see how this is generalized when Zcut wraps CubeFactory? 
-        """
+        """ Setting up the class members."""
 
         self.max_memory = max_memory  # in GB
         self.block_size = None  # Number of rows

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -223,7 +223,7 @@ class CubeFactory():
                             elif self.info_table[kwd].dtype.char == "S":  # hacky way to check if it's a string
                                 nulval = ""
                             self.info_table[kwd][i] = ffi_data[1].header.get(kwd, nulval)
-                    
+
             if verbose:
                 print(f"Completed file {i} in {time()-st:.3} sec.")
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -612,7 +612,7 @@ class TicaCubeFactory():
         with fits.open(self.cube_file, mode='update', memmap=True) as cube_hdu:
             
             if (version_info >= (3, 8)) and (platform != "win32"):
-                mm = fits.util._get_array_mmap(cube_hdu[0].data)
+                mm = fits.util._get_array_mmap(cube_hdu[1].data)
                 mm.madvise(MADV_SEQUENTIAL)
 
             for i in range(self.num_blocks):

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -476,6 +476,7 @@ class TicaCubeFactory():
             # set up the image info table
             existing_cols = []
             cols = []
+            length = len(self.file_list)
             for kwd, val, cmt in primary_header.cards: 
                 if type(val) == str:  
                     tpe = "S" + str(len(val))  # TODO: Maybe switch to U?
@@ -484,7 +485,6 @@ class TicaCubeFactory():
                 else:
                     tpe = np.float64
                     
-                length = len(self.file_list)
                 if kwd not in existing_cols:
                     existing_cols.append(kwd)
                     cols.append(Column(name=kwd, dtype=tpe, length=length, meta={"comment": cmt}))

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -522,8 +522,7 @@ class TicaCubeFactory():
         header = hdu.header
         header["NAXIS4"], header["NAXIS3"], header["NAXIS2"], header["NAXIS1"] = self.cube_shape
 
-        # I think this part increases the buffer size of ext1 and writes 
-        # the cube in there?
+        # Writes the header into the cube as an array of bytes
         with open(cube_file, 'ab') as CUBE:
             CUBE.write(bytearray(header.tostring(), encoding="utf-8"))
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -437,6 +437,8 @@ class TicaCubeFactory():
 
                 # Adding factory specific keywords
                 for kwd in self.image_header_keywords:
+                    # TICA file structure differs from SPOC in that factory-specific kwds 
+                    # are in the 0th extension, along with the science data. 
                     header[kwd] = (first_file[0].header[kwd], first_file[0].header.comments[kwd])
 
                 # Adding the extra keywords passed in

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -62,6 +62,7 @@ class CubeFactory():
         image_shape = None
         start_times = np.zeros(len(file_list))
         for i, ffi in enumerate(file_list):
+
             ffi_data = fits.open(ffi, mode='denywrite', memmap=True)
             
             start_times[i] = ffi_data[1].header.get(self.time_keyword)
@@ -307,12 +308,12 @@ class CubeFactory():
             startTime = time()
 
         self.max_memory = max_memory
-            
+
         # Set up the basic cube parameters
         sector = (sector, "Observing sector")
+    
         self._configure_cube(file_list, sector=sector)
     
-        
         if verbose:
             print("Using {} to initialize the image header table.".format(os.path.basename(self.template_file)))
             print(f"Cube will be made in {self.num_blocks} blocks of {self.block_size} rows each.")
@@ -382,7 +383,7 @@ class TicaCubeFactory():
         """ Run through all the files and set up the basic parameters for the cube.
         Set up the cube primary header.
         """
-
+        
         file_list = np.array(file_list)
         image_shape = None
         start_times = np.zeros(len(file_list))
@@ -801,7 +802,42 @@ class TicaCubeFactory():
 
 
     def make_cube(self, file_list, cube_file="img-cube.fits", sector=None, max_memory=50, verbose=True):
-        
+        """
+        Analogous to CubeFactory.make_cube(...). 
+        Turns a list of fits image files into one large data-cube.
+        Input images must all have the same footprint and resolution.
+        The resulting datacube is transposed for quicker cutouts.
+        This function can take some time to run, exactly how much time will depend on the number
+        of input files and the maximum allowed memory. The runtime will be fastest if the
+        entire data cube can be held in memory, however that can be quite large (~40GB for a full
+        TESS main mission sector, 3 times that for a TESS extended mission sector).
+
+        Parameters
+        ----------
+        file_list : array
+            The list of fits image files to cube.  
+            Assumed to have the format of a TESS FFI:
+            - A primary HDU consisting only of a primary header
+            - An image HDU containing the image
+            - A second image HDU containing the uncertainty image
+        cube_file : string
+            Optional.  The filename/path to save the output cube in. 
+        sector : int
+            Optional.  TESS sector to add as header keyword (not present in FFI files).
+        max_memory : float
+            Optional, default is 50. The maximum amount of memory to make available for building
+            the data cube in GB. Note, this is the maximum amount of space to be used for the cube
+            array only, so should not be set to the full amount of memory on the system.
+        verbose : bool
+            Optional. If true intermediate information is printed. 
+
+        Returns
+        -------
+        response: string or None
+            If successful, returns the path to the cube fits file, 
+            if unsuccessful returns None.
+        """
+
         if verbose:
             startTime = time()
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -479,24 +479,15 @@ class TicaCubeFactory():
             # set up the image info table
             cols = []
             for kwd, val, cmt in secondary_header.cards: 
-                if type(val) == str:
+                if type(val) == str:  
                     tpe = "S" + str(len(val))  # TODO: Maybe switch to U?
                 elif type(val) == int:
                     tpe = np.int32
                 else:
                     tpe = np.float64
                     
-                # If there's already an info table, this means we are
-                # updating a cube instead of making a new one, so expanding 
-                # the length by the new FFIs (hence +self.file_list)
-
                 length = len(self.file_list)
-                """
-                if not self.update: 
-                    length = len(self.file_list)
-                else: 
-                    length = len(self.info_table)+len(self.file_list)
-                """
+
                 cols.append(Column(name=kwd, dtype=tpe, length=length, meta={"comment": cmt}))
 
             cols.append(Column(name="FFI_FILE", dtype="S" + str(len(os.path.basename(self.template_file))),
@@ -607,37 +598,6 @@ class TicaCubeFactory():
                                 if isinstance(kwd_val, fits.header._HeaderCommentaryCards):
                                     self.info_table[kwd][i] = str(kwd_val)
 
-                            
-                """
-                elif self.update:
-                    
-                    for kwd in self.info_table.columns:
-                        
-                        if kwd == "FFI_FILE":
-                            self.old_cols[kwd].append(fle)
-                           
-                        else:
-                            nulval = None
-                            dtype_name = self.info_table[kwd].dtype.name
-                            dtype_char = self.info_table[kwd].dtype.char
-
-                            if dtype_name == "int32":
-                                nulval = 0
-                            elif dtype_char == "S":  # hacky way to check if it's a string
-                                nulval = ""
-                            
-                            # Updating the already-existing list of kwd vals for 
-                            # all the FFIs, with the latest entry 
-
-                            kwd_val = ffi_data[0].header.get(kwd)
-                            if isinstance(kwd_val, fits.header._HeaderCommentaryCards):
-                                self.old_cols[kwd].append(str(kwd_val))
-                            else:
-                                self.old_cols[kwd].append(ffi_data[0].header.get(kwd, nulval))
-
-                            if kwd == 'SIMPLE':
-                                self.old_cols[kwd] = [float(bool(x)) for x in self.old_cols[kwd]]
-                """ 
             if verbose:
                 print(f"Completed file {i} in {time()-st:.3} sec.")
 
@@ -777,15 +737,6 @@ class TicaCubeFactory():
         if verbose:
             print(f"FFIs will be appended in {self.num_blocks} blocks of {self.block_size} rows each.")
         
-        # Expanding the length of the info table to accomodate new FFIs
-        #self.info_table = fits.getdata(self.cube_file, 2)
-        """
-        self.old_cols = {}
-        for column in self.info_table.columns:
-            
-            col = list(self.info_table[column.name])
-            self.old_cols[column.name] = col
-        """
         # Starting a new info table from scratch with new rows
         self._build_info_table()
 
@@ -842,7 +793,7 @@ class TicaCubeFactory():
 
 
     def make_cube(self, file_list, cube_file="img-cube.fits", sector=None, max_memory=50, verbose=True):
-
+        
         if verbose:
             startTime = time()
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -379,7 +379,7 @@ class TicaCubeFactory():
         self.cube_append = None
 
     def _configure_cube(self, file_list, **extra_keywords):
-        """ Run through all the files and set up the  basic parameters for the cube.
+        """ Run through all the files and set up the basic parameters for the cube.
         Set up the cube primary header.
         """
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -9,7 +9,7 @@ import numpy as np
 import os
 
 from astropy.io import fits
-from astropy.table import Table, Column, vstack
+from astropy.table import Table, Column
 
 from time import time
 from datetime import date
@@ -20,6 +20,7 @@ if (version_info >= (3, 8)) and (platform != "win32"):
     from mmap import MADV_SEQUENTIAL
 
 __all__ = ['CubeFactory', 'TicaCubeFactory']
+
 
 class CubeFactory():
     """
@@ -349,6 +350,7 @@ class CubeFactory():
 
         return self.cube_file
 
+
 class TicaCubeFactory():
 
     def __init__(self, max_memory=50):
@@ -369,10 +371,9 @@ class TicaCubeFactory():
         
         self.time_keyword = 'STARTTJD'  # Start time in TJD. TICA-specific.
         self.last_file_keywords = ['ENDTJD']  # Stop time in TJD. TICA-specific (assumed to be in extension 0)                  
-        self.image_header_keywords = ['CAMNUM', 'CCDNUM'] # Camera number and CCD number being used for the sector observation. 
-                                                       # TICA-specific (assumed to be in extension 0)
-        self.template_requirements = {'NAXIS': 2} # Using NAXIS instead of WCSAXES because TICA headers dont have WCSAXES kw.
-                                              # Assuming NAXIS and WCSAXES would always have same values.
+        self.image_header_keywords = ['CAMNUM', 'CCDNUM']  # Camera number and CCD number being used for the sector observation. 
+        self.template_requirements = {'NAXIS': 2}  # Using NAXIS instead of WCSAXES. JENNY: Verify this is OK.
+                                                   
         self.file_list = None
         self.template_file = None
         
@@ -454,8 +455,8 @@ class TicaCubeFactory():
         else:
             with fits.open(self.cube_file, mode='update', memmap=True) as cube_hdu:
                 header = cube_hdu[0].header 
-                #header['HISTORY'] = f'Updated on {str(date.today())} with new FFI delivery.' 
-                #header['HISTORY'] = f'First FFI is {str(os.path.basename(self.file_list[0]))}'
+                # header['HISTORY'] = f'Updated on {str(date.today())} with new FFI delivery.' 
+                # header['HISTORY'] = f'First FFI is {str(os.path.basename(self.file_list[0]))}'
 
         # Adding the keywords from the last file
         with fits.open(self.file_list[-1], mode='denywrite', memmap=True) as last_file:
@@ -568,7 +569,7 @@ class TicaCubeFactory():
                
                 if fill_info_table:  # Also save the header info in the info table
 
-                    for kwd in self.info_table.columns: # Iterate over every keyword in the TICA FFI primary header
+                    for kwd in self.info_table.columns:  # Iterate over every keyword in the TICA FFI primary header
                         if kwd == "FFI_FILE":
                             self.info_table[kwd][i] = os.path.basename(fle)
                             
@@ -649,8 +650,8 @@ class TicaCubeFactory():
                 og_table = hdul[2].data
                 appended_column = np.concatenate((og_table['FFI_FILE'], self.info_table['FFI_FILE']))
 
-                cols.append(Column(appended_column, name="FFI_FILE", dtype="S" + str(len(os.path.basename(self.template_file))),
-                                length=length))
+                str_length = str(len(os.path.basename(self.template_file)))
+                cols.append(Column(appended_column, name="FFI_FILE", dtype="S" + str_length, length=length))
     
             self.info_table = Table(cols)
 
@@ -663,8 +664,7 @@ class TicaCubeFactory():
         # Make table hdu 
         cols = []
         for kwd in self.info_table.columns:
-            #print(self.info_table[kwd].dtype)
-            
+
             if self.info_table[kwd].dtype == np.float64:
                 tpe = 'D'
             elif self.info_table[kwd].dtype == np.int32:
@@ -702,7 +702,7 @@ class TicaCubeFactory():
 
         """
 
-        self.update = True # we're updating!
+        self.update = True  # we're updating!
 
         if verbose:
             startTime = time()
@@ -714,7 +714,8 @@ class TicaCubeFactory():
         self.cube_append = np.zeros(tuple(dimensions))
 
         # Next locate the existing cube file and assign it a variable
-        assert os.path.exists(cube_file), 'Location of the cube file was unsuccessful. Please ensure the correct path was provided. If file does not exist, create a new cube using ``~TicaCubeFactory.make_cube()``.'
+        err_msg = 'Location of the cube file was unsuccessful. Please ensure the correct path was provided.'
+        assert os.path.exists(cube_file), err_msg
         self.cube_file = cube_file
 
         if verbose:

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -478,6 +478,7 @@ class TicaCubeFactory():
             secondary_header = ffi_data[0].header
 
             # set up the image info table
+            already_there = []
             cols = []
             for kwd, val, cmt in secondary_header.cards: 
                 if type(val) == str:  
@@ -488,12 +489,15 @@ class TicaCubeFactory():
                     tpe = np.float64
                     
                 length = len(self.file_list)
-
+                if kwd not in already_there:
+                    already_there.append(kwd)
+                else: 
+                    continue
                 cols.append(Column(name=kwd, dtype=tpe, length=length, meta={"comment": cmt}))
 
             cols.append(Column(name="FFI_FILE", dtype="S" + str(len(os.path.basename(self.template_file))),
                                length=length))
-    
+            
             self.info_table = Table(cols)
 
     def _build_cube_file(self, cube_file):

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -364,7 +364,7 @@ class TicaCubeFactory():
         self.time_keyword = 'STARTTJD'  # Start time in TJD. TICA-specific.
         self.last_file_keywords = ['ENDTJD']  # Stop time in TJD. TICA-specific (assumed to be in extension 0)                  
         self.image_header_keywords = ['CAMNUM', 'CCDNUM']  # Camera number and CCD number 
-        self.template_requirements = {'NAXIS': 2}  # Using NAXIS instead of WCSAXES. JENNY: Verify this is OK.
+        self.template_requirements = {'NAXIS': 2}  # Using NAXIS instead of WCSAXES. 
                                                    
         self.file_list = None
         self.template_file = None

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -411,7 +411,7 @@ class TicaCubeFactory():
         # Working out the block size and number of blocks needed for writing the cube
         # without using too much memory
         slice_size = image_shape[1] * len(self.file_list) * 2 * 4  # in bytes (float32)
-        max_block_size = int((self.max_memory * 1e9)//slice_size)
+        max_block_size = (self.max_memory * 1e9) // slice_size
         
         self.num_blocks = int(image_shape[0]/max_block_size + 1)
         self.block_size = int(image_shape[0]/self.num_blocks + 1)

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -471,12 +471,12 @@ class TicaCubeFactory():
         with fits.open(self.template_file, mode='denywrite', memmap=True) as ffi_data:
             
             # The image specific header information will be saved in a table in the second extension
-            secondary_header = ffi_data[0].header
+            primary_header = ffi_data[0].header
 
             # set up the image info table
             already_there = []
             cols = []
-            for kwd, val, cmt in secondary_header.cards: 
+            for kwd, val, cmt in primary_header.cards: 
                 if type(val) == str:  
                     tpe = "S" + str(len(val))  # TODO: Maybe switch to U?
                 elif type(val) == int:

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -371,7 +371,7 @@ class TicaCubeFactory():
         
         self.time_keyword = 'STARTTJD'  # Start time in TJD. TICA-specific.
         self.last_file_keywords = ['ENDTJD']  # Stop time in TJD. TICA-specific (assumed to be in extension 0)                  
-        self.image_header_keywords = ['CAMNUM', 'CCDNUM']  # Camera number and CCD number being used for the sector observation. 
+        self.image_header_keywords = ['CAMNUM', 'CCDNUM']  # Camera number and CCD number 
         self.template_requirements = {'NAXIS': 2}  # Using NAXIS instead of WCSAXES. JENNY: Verify this is OK.
                                                    
         self.file_list = None

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -394,7 +394,6 @@ class TicaCubeFactory():
 
             if image_shape is None:  # Only need to fill this once
                 image_shape = ffi_data[0].data.shape
-                print(image_shape)
             
             if self.template_file is None:  # Only check this if we don't already have it
 
@@ -420,8 +419,6 @@ class TicaCubeFactory():
         #                  NROWS,           NCOLS,         Num. Images,       
         self.cube_shape = (image_shape[0], image_shape[1], len(self.file_list), 2)
 
-        print('cube shape')
-        print(self.cube_shape)
         # Making the primary header
         with fits.open(self.file_list[0], mode='denywrite', memmap=True) as first_file:
             header = deepcopy(first_file[0].header)
@@ -505,8 +502,6 @@ class TicaCubeFactory():
         # I think this part increases the buffer size of ext1 and writes 
         # the cube in there?
         with open(cube_file, 'ab') as CUBE:
-            print('~~~~~')
-            print(bytearray(header.tostring(), encoding="utf-8"))
             CUBE.write(bytearray(header.tostring(), encoding="utf-8"))
 
         # Expanding the file to fit the full data cube
@@ -544,10 +539,8 @@ class TicaCubeFactory():
 
                 # add the image and info to the arrays
                 sub_cube[:, :, i, 0] = ffi_data[0].data[start_row:end_row, :]
-                #sub_cube[:, :, i, 1] = ffi_data[2].data[start_row:end_row, :]
 
                 del ffi_data[0].data
-                #del ffi_data[2].data
                
                 if fill_info_table:  # Also save the header info in the info table
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -690,6 +690,8 @@ class TicaCubeFactory():
 
         # Appending to the cube file
         with fits.open(self.cube_file, mode='update', memmap=True) as cube_hdus:
+            # If we're updating the cube, get rid of the existing table 
+            # so we can replace it with the new one. 
             if self.update:
                 cube_hdus.pop(index=2)
             cube_hdus.append(table_hdu)

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -437,8 +437,8 @@ class TicaCubeFactory():
 
                 # Adding factory specific keywords
                 for kwd in self.image_header_keywords:
-                    # TICA file structure differs from SPOC in that factory-specific kwds 
-                    # are in the 0th extension, along with the science data. 
+                    # TICA file structure differs from SPOC in that factory-specific kwds
+                    # are in the 0th extension, along with the science data.
                     header[kwd] = (first_file[0].header[kwd], first_file[0].header.comments[kwd])
 
                 # Adding the extra keywords passed in
@@ -455,6 +455,8 @@ class TicaCubeFactory():
         # Adding the keywords from the last file
         with fits.open(self.file_list[-1], mode='denywrite', memmap=True) as last_file:
             for kwd in self.last_file_keywords:
+                # TICA file structure differs from SPOC in that factory-specific kwds
+                # are in the 0th extension, along with the science data.
                 header[kwd] = (last_file[0].header[kwd], last_file[0].header.comments[kwd])
 
         header["EXTNAME"] = "PRIMARY"

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -601,6 +601,8 @@ class TicaCubeFactory():
                                 kwd_val = ffi_data[0].header.get(kwd)
                                 if isinstance(kwd_val, fits.header._HeaderCommentaryCards):
                                     self.info_table[kwd][i] = str(kwd_val)
+                                else:
+                                    raise
 
             if verbose:
                 print(f"Completed file {i} in {time()-st:.3} sec.")
@@ -623,11 +625,11 @@ class TicaCubeFactory():
         with fits.open(self.template_file, mode='denywrite', memmap=True) as ffi_data:
             
             # The image specific header information will be saved in a table in the second extension
-            secondary_header = ffi_data[0].header
+            primary_header = ffi_data[0].header
 
             # set up the image info table
             cols = []
-            for kwd, val, cmt in secondary_header.cards: 
+            for kwd, val, cmt in primary_header.cards: 
                 if type(val) == str:
                     tpe = "S" + str(len(val))  # TODO: Maybe switch to U?
                 elif type(val) == int:

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -63,14 +63,9 @@ def test_update_cube(tmpdir):
     
     ffi_files = create_test_ffis(img_sz, num_im, product='tica', dir_name=tmpdir)
 
-    cube_file = path.join(tmpdir, "out_dir", "test_update_cube.fits")
+    cube_file = path.join(os.getcwd(), "out_dir", "test_update_cube.fits")
 
     cube_maker.make_cube(ffi_files[0:num_im//2], cube_file, verbose=False)
-    try:
-        os.system(f'TASKKILL /F /IM {cube_file}')
-
-    except Exception:
-       pass
 
     cube_file = cube_maker.update_cube(ffi_files[num_im//2:], cube_file, verbose=False)
 
@@ -100,6 +95,8 @@ def test_update_cube(tmpdir):
     assert np.alltrue(tab['FFI_FILE'] == np.array(filenames)), "FFI_FILE mismatch in table"
 
     hdu.close()
+
+    os.remove(cube_file)
     
 
 def test_iteration(tmpdir, capsys):

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 
 from astropy.io import fits
 from astropy.table import Table
@@ -63,7 +64,10 @@ def test_update_cube(tmpdir):
     ffi_files = create_test_ffis(img_sz, num_im, product='tica', dir_name=tmpdir)
 
     cube_file = path.join(tmpdir, "out_dir", "test_update_cube.fits")
+
     cube_maker.make_cube(ffi_files[0:num_im//2], cube_file, verbose=False)
+    os.chmod(cube_file, 0o777)
+
     cube_file = cube_maker.update_cube(ffi_files[num_im//2:], cube_file, verbose=False)
 
     hdu = fits.open(cube_file)

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -47,6 +47,7 @@ def test_make_cube(tmpdir):
 
     hdu.close()
     
+
 def test_update_cube(tmpdir):
     """
     Testing the make cube and update cube functionality for TICACubeFactory by making a bunch of test FFIs, 
@@ -61,8 +62,9 @@ def test_update_cube(tmpdir):
     
     ffi_files = create_test_ffis(img_sz, num_im, product='tica', dir_name=tmpdir)
 
-    cube_maker.make_cube(ffi_files[0:num_im//2], path.join(tmpdir, "out_dir", "test_update_cube.fits"), verbose=False)
-    cube_file = cube_maker.update_cube(ffi_files[num_im//2:], path.join(tmpdir, "out_dir", "test_update_cube.fits"), verbose=False)
+    cube_file = path.join(tmpdir, "out_dir", "test_update_cube.fits")
+    cube_maker.make_cube(ffi_files[0:num_im//2], cube_file, verbose=False)
+    cube_file = cube_maker.update_cube(ffi_files[num_im//2:], cube_file, verbose=False)
 
     hdu = fits.open(cube_file)
     cube = hdu[1].data
@@ -77,7 +79,7 @@ def test_update_cube(tmpdir):
         ecube[:, :, i, 0] = -plane
         # we don't need to test error array because TICA doesnt come with error arrays
         # so index 1 will always be blank
-        #ecube[:, :, i, 1] = plane
+        # ecube[:, :, i, 1] = plane
         plane += img_sz*img_sz
 
     assert np.alltrue(cube == ecube), "Cube values do not match expected values"
@@ -91,6 +93,7 @@ def test_update_cube(tmpdir):
 
     hdu.close()
     
+
 def test_iteration(tmpdir, capsys):
     """
     Testing cubes made with different numbers of iterations against each other.

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -47,7 +47,7 @@ def test_make_cube(tmpdir):
     hdu.close()
     
 
-def test_update_cube(tmpdir):
+def test_make_and_update_cube(tmpdir):
     """
     Testing the make cube and update cube functionality for TICACubeFactory by making a bunch of test FFIs, 
     making the cube with first half of the FFIs, updating the same cube with the second half,

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -63,17 +63,41 @@ def test_make_and_update_cube(tmpdir):
 
     cube_file = path.join(os.getcwd(), "out_dir", "test_update_cube.fits")
 
-    cube_maker.make_cube(ffi_files[0:num_im//2], cube_file, verbose=False)
-
-    cube_file = cube_maker.update_cube(ffi_files[num_im//2:], cube_file, verbose=False)
+    # Testing make_cube
+    
+    cube_maker.make_cube(ffi_files[0:num_im // 2], cube_file, verbose=False)
 
     hdu = fits.open(cube_file)
     cube = hdu[1].data
 
-    # expected values for cube
+    # expected values for cube before update_cube
+    ecube = np.zeros((img_sz, img_sz, num_im // 2, 2))
+    plane = np.arange(img_sz*img_sz, dtype=np.float32).reshape((img_sz, img_sz))
+
+    assert cube.shape == ecube.shape, "Mismatch between cube shape and expected shape"
+
+    for i in range(num_im // 2):
+        ecube[:, :, i, 0] = -plane
+        # we don't need to test error array because TICA doesnt come with error arrays
+        # so index 1 will always be blank
+        # ecube[:, :, i, 1] = plane
+        plane += img_sz*img_sz
+
+    assert np.alltrue(cube == ecube), "Cube values do not match expected values"
+
+    hdu.close()
+
+    # Testing update_cube
+
+    cube_file = cube_maker.update_cube(ffi_files[num_im // 2:], cube_file, verbose=False)
+
+    hdu = fits.open(cube_file)
+    cube = hdu[1].data
+    
+    # expected values for cube after update_cube
     ecube = np.zeros((img_sz, img_sz, num_im, 2))
     plane = np.arange(img_sz*img_sz, dtype=np.float32).reshape((img_sz, img_sz))
-    
+
     assert cube.shape == ecube.shape, "Mismatch between cube shape and expected shape"
 
     for i in range(num_im):

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -23,7 +23,6 @@ def test_make_cube(tmpdir):
     
     ffi_files = create_test_ffis(img_sz, num_im, dir_name=tmpdir)
     cube_file = cube_maker.make_cube(ffi_files, path.join(tmpdir, "out_dir", "test_cube.fits"), verbose=False)
- 
     hdu = fits.open(cube_file)
     cube = hdu[1].data
     

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -66,7 +66,11 @@ def test_update_cube(tmpdir):
     cube_file = path.join(tmpdir, "out_dir", "test_update_cube.fits")
 
     cube_maker.make_cube(ffi_files[0:num_im//2], cube_file, verbose=False)
-    os.chmod(cube_file, 0o777)
+    try:
+        os.system(f'TASKKILL /F /IM {cube_file}')
+
+    except Exception:
+       pass
 
     cube_file = cube_maker.update_cube(ffi_files[num_im//2:], cube_file, verbose=False)
 

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -35,7 +35,6 @@ def test_make_cube(tmpdir):
         ecube[:, :, i, 0] = -plane
         ecube[:, :, i, 1] = plane
         plane += img_sz*img_sz
-   
     assert np.alltrue(cube == ecube), "Cube values do not match expected values"
     
     tab = Table(hdu[2].data)

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -6,7 +6,7 @@ from re import findall
 from os import path
 
 from .utils_for_test import create_test_ffis
-from ..make_cube import CubeFactory
+from ..make_cube import CubeFactory, TicaCubeFactory
 
 
 def test_make_cube(tmpdir):
@@ -22,7 +22,7 @@ def test_make_cube(tmpdir):
     
     ffi_files = create_test_ffis(img_sz, num_im, dir_name=tmpdir)
     cube_file = cube_maker.make_cube(ffi_files, path.join(tmpdir, "out_dir", "test_cube.fits"), verbose=False)
-
+ 
     hdu = fits.open(cube_file)
     cube = hdu[1].data
     
@@ -35,9 +35,9 @@ def test_make_cube(tmpdir):
         ecube[:, :, i, 0] = -plane
         ecube[:, :, i, 1] = plane
         plane += img_sz*img_sz
-
+   
     assert np.alltrue(cube == ecube), "Cube values do not match expected values"
-        
+    
     tab = Table(hdu[2].data)
     assert np.alltrue(tab['TSTART'] == np.arange(num_im)), "TSTART mismatch in table"
     assert np.alltrue(tab['TSTOP'] == np.arange(num_im)+1), "TSTOP mismatch in table"
@@ -47,7 +47,50 @@ def test_make_cube(tmpdir):
 
     hdu.close()
     
+def test_update_cube(tmpdir):
+    """
+    Testing the make cube and update cube functionality for TICACubeFactory by making a bunch of test FFIs, 
+    making the cube with first half of the FFIs, updating the same cube with the second half,
+    and checking the results.
+    """
 
+    cube_maker = TicaCubeFactory()
+
+    img_sz = 10
+    num_im = 100
+    
+    ffi_files = create_test_ffis(img_sz, num_im, product='tica', dir_name=tmpdir)
+
+    cube_maker.make_cube(ffi_files[0:num_im//2], path.join(tmpdir, "out_dir", "test_update_cube.fits"), verbose=False)
+    cube_file = cube_maker.update_cube(ffi_files[num_im//2:], path.join(tmpdir, "out_dir", "test_update_cube.fits"), verbose=False)
+
+    hdu = fits.open(cube_file)
+    cube = hdu[1].data
+
+    # expected values for cube
+    ecube = np.zeros((img_sz, img_sz, num_im, 2))
+    plane = np.arange(img_sz*img_sz, dtype=np.float32).reshape((img_sz, img_sz))
+    
+    assert cube.shape == ecube.shape, "Mismatch between cube shape and expected shape"
+
+    for i in range(num_im):
+        ecube[:, :, i, 0] = -plane
+        # we don't need to test error array because TICA doesnt come with error arrays
+        # so index 1 will always be blank
+        #ecube[:, :, i, 1] = plane
+        plane += img_sz*img_sz
+
+    assert np.alltrue(cube == ecube), "Cube values do not match expected values"
+
+    tab = Table(hdu[2].data)
+    assert np.alltrue(tab['STARTTJD'] == np.arange(num_im)), "STARTTJD mismatch in table"
+    assert np.alltrue(tab['ENDTJD'] == np.arange(num_im)+1), "ENDTJD mismatch in table"
+
+    filenames = np.array([path.split(x)[1] for x in ffi_files])
+    assert np.alltrue(tab['FFI_FILE'] == np.array(filenames)), "FFI_FILE mismatch in table"
+
+    hdu.close()
+    
 def test_iteration(tmpdir, capsys):
     """
     Testing cubes made with different numbers of iterations against each other.

--- a/astrocut/tests/utils_for_test.py
+++ b/astrocut/tests/utils_for_test.py
@@ -56,8 +56,55 @@ def add_keywords(hdu, extname, time_increment, primary=False):
         hdu.header['A_DMAX'] = 44.72893589844534
         hdu.header['B_DMAX'] = 44.62692873032506
 
+def add_tica_keywords(hdu, time_increment):
+    """
+    Add a bunch of required keywords (mostly fake values). TICA specific. 
+    """
+    
+    hdu.header['CAMNUM'] = 1
+    hdu.header['CCDNUM'] = 1
+    hdu.header['STARTTJD'] = float(time_increment)
+    hdu.header['ENDTJD'] = float(time_increment+1)
+    hdu.header['QUAL_BIT'] = 0
 
-def create_test_ffis(img_size, num_images, dir_name=".", basename='make_cube-test{:04d}.fits'):
+    # WCS keywords just copied from example
+    #hdu.header['RADESYS'] = 'ICRS    '
+    hdu.header['EQUINOX'] = 2000.0
+    #hdu.header['WCSAXES'] = 2
+    hdu.header['CTYPE1'] = ('RA---TAN-SIP', "Gnomonic projection + SIP distortions")
+    hdu.header['CTYPE2'] = ('DEC--TAN-SIP', "Gnomonic projection + SIP distortions")
+    hdu.header['CRVAL1'] = 250.3497414839765200
+    hdu.header['CRVAL2'] = 2.2809255996090630
+    hdu.header['CRPIX1'] = 1045.0
+    hdu.header['CRPIX2'] = 1001.0
+    hdu.header['CD1_1'] = -0.005564478186178
+    hdu.header['CD1_2'] = -0.001042099258152
+    hdu.header['CD2_1'] = 0.001181441465850
+    hdu.header['CD2_2'] = -0.005590816683583
+    hdu.header['A_ORDER'] = 2
+    hdu.header['B_ORDER'] = 2
+    hdu.header['A_2_0'] = 2.024511892340E-05
+    hdu.header['A_0_2'] = 3.317603337918E-06
+    hdu.header['A_1_1'] = 1.73456334971071E-5
+    hdu.header['B_2_0'] = 3.331330003472E-06
+    hdu.header['B_0_2'] = 2.042474824825892E-5
+    hdu.header['B_1_1'] = 1.714767108041439E-5
+    hdu.header['AP_ORDER'] = 2
+    hdu.header['BP_ORDER'] = 2
+    hdu.header['AP_1_0'] = 9.047002963896363E-4
+    hdu.header['AP_0_1'] = 6.276607155847164E-4
+    hdu.header['AP_2_0'] = -2.023482905861E-05
+    hdu.header['AP_0_2'] = -3.332285841011E-06
+    hdu.header['AP_1_1'] = -1.731636633824E-05
+    hdu.header['BP_1_0'] = 6.279608820532116E-4
+    hdu.header['BP_0_1'] = 9.112228860848081E-4
+    hdu.header['BP_2_0'] = -3.343918167224E-06
+    hdu.header['BP_0_2'] = -2.041598249021E-05
+    hdu.header['BP_1_1'] = -1.711876336719E-05
+    hdu.header['A_DMAX'] = 44.72893589844534
+    hdu.header['B_DMAX'] = 44.62692873032506
+
+def create_test_ffis(img_size, num_images, dir_name=".", product='spoc', basename='make_cube-test{:04d}.fits'):
     """
     Create test fits files
 
@@ -73,16 +120,28 @@ def create_test_ffis(img_size, num_images, dir_name=".", basename='make_cube-tes
         
         file_list.append(basename.format(i))
 
-        primary_hdu = fits.PrimaryHDU()
-        add_keywords(primary_hdu, "PRIMARY", i, primary=True)
-           
-        hdu = fits.ImageHDU(-img)
-        add_keywords(hdu, 'CAMERA.CCD 1.1 cal', i)
-        
-        ehdu = fits.ImageHDU(img)
-        add_keywords(ehdu, 'CAMERA.CCD 1.1 uncert', i)
-        
-        hdulist = fits.HDUList([primary_hdu, hdu, ehdu])
+        if product=='spoc':
+            primary_hdu = fits.PrimaryHDU()
+        elif product=='tica':
+            primary_hdu = fits.PrimaryHDU(-img)
+
+        if product=='spoc':
+            add_keywords(primary_hdu, "PRIMARY", i, primary=True)
+        elif product=='tica':
+            add_tica_keywords(primary_hdu, i)
+
+        if product=='spoc':   
+            hdu = fits.ImageHDU(-img)
+            add_keywords(hdu, 'CAMERA.CCD 1.1 cal', i)
+            
+            ehdu = fits.ImageHDU(img)
+            add_keywords(ehdu, 'CAMERA.CCD 1.1 uncert', i)
+            
+            hdulist = fits.HDUList([primary_hdu, hdu, ehdu])
+
+        elif product=='tica':
+            hdulist = fits.HDUList([primary_hdu])   
+
         hdulist.writeto(file_list[-1], overwrite=True, checksum=True)
         
         img = img + img_size*img_size

--- a/astrocut/tests/utils_for_test.py
+++ b/astrocut/tests/utils_for_test.py
@@ -56,6 +56,7 @@ def add_keywords(hdu, extname, time_increment, primary=False):
         hdu.header['A_DMAX'] = 44.72893589844534
         hdu.header['B_DMAX'] = 44.62692873032506
 
+
 def add_tica_keywords(hdu, time_increment):
     """
     Add a bunch of required keywords (mostly fake values). TICA specific. 
@@ -68,9 +69,9 @@ def add_tica_keywords(hdu, time_increment):
     hdu.header['QUAL_BIT'] = 0
 
     # WCS keywords just copied from example
-    #hdu.header['RADESYS'] = 'ICRS    '
+    # hdu.header['RADESYS'] = 'ICRS    '
     hdu.header['EQUINOX'] = 2000.0
-    #hdu.header['WCSAXES'] = 2
+    # hdu.header['WCSAXES'] = 2
     hdu.header['CTYPE1'] = ('RA---TAN-SIP', "Gnomonic projection + SIP distortions")
     hdu.header['CTYPE2'] = ('DEC--TAN-SIP', "Gnomonic projection + SIP distortions")
     hdu.header['CRVAL1'] = 250.3497414839765200
@@ -104,6 +105,7 @@ def add_tica_keywords(hdu, time_increment):
     hdu.header['A_DMAX'] = 44.72893589844534
     hdu.header['B_DMAX'] = 44.62692873032506
 
+
 def create_test_ffis(img_size, num_images, dir_name=".", product='spoc', basename='make_cube-test{:04d}.fits'):
     """
     Create test fits files
@@ -120,17 +122,17 @@ def create_test_ffis(img_size, num_images, dir_name=".", product='spoc', basenam
         
         file_list.append(basename.format(i))
 
-        if product=='spoc':
+        if product == 'spoc':
             primary_hdu = fits.PrimaryHDU()
-        elif product=='tica':
+        elif product == 'tica':
             primary_hdu = fits.PrimaryHDU(-img)
 
-        if product=='spoc':
+        if product == 'spoc':
             add_keywords(primary_hdu, "PRIMARY", i, primary=True)
-        elif product=='tica':
+        elif product == 'tica':
             add_tica_keywords(primary_hdu, i)
 
-        if product=='spoc':   
+        if product == 'spoc':   
             hdu = fits.ImageHDU(-img)
             add_keywords(hdu, 'CAMERA.CCD 1.1 cal', i)
             
@@ -139,7 +141,7 @@ def create_test_ffis(img_size, num_images, dir_name=".", product='spoc', basenam
             
             hdulist = fits.HDUList([primary_hdu, hdu, ehdu])
 
-        elif product=='tica':
+        elif product == 'tica':
             hdulist = fits.HDUList([primary_hdu])   
 
         hdulist.writeto(file_list[-1], overwrite=True, checksum=True)

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
-    
+
 isolated_build = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38}-test-numpy{118,119,121}
-    py{36,37,38}-test-astropy{40,41,lts}
+    py{36,37}-test{,-alldeps,-devdeps}{,-cov}
+    py{36,37}-test-numpy{118,119,121}
+    py{36,37}-test-astropy{40,41,lts}
     build_docs
     linkcheck
     codestyle

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37}-test-numpy{118,119,121}
-    py{36,37}-test-astropy{40,41,lts}
+    py{36,37,38}-test{,-alldeps,-devdeps}{,-cov}
+    py{36,37,38}-test-numpy{118,119,121}
+    py{36,37,38}-test-astropy{40,41,lts}
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
Implements a class based off the existing `CubeFactory` class that can generate cubes out of TICA FFIs. 

Note: This is one of the core four projects for MAST Q3 and must be implemented before June 30. 

- [x] Implement TICACubeFactory
- [x] Verify file structural similarity between TICA and TESS Cubes
- [x] Verify image similarity between TICA and TESS Cubes
- [x] Add functionality to append incoming FFIs to existing cubes (starting in Sept we get new ones every week, EM1 we get them ever 2 weeks...?)
- [x] Fix truncated string issue: `StringTruncateWarning: truncated right side string(s) longer than 9 character(s) during assignment
  self.info_table[kwd][i] = ffi_data[0].header.get(kwd, nulval)`
- [x] First test that the duplicate columns issue is still an issue in delivery 1 of future sectors - so far I think I've only seen it in sector 27. ~Fix duplicate columns issue in build_info_table(). For some reason there are duplicate columns in the order 1 deliveries for keywords: TESS_X, TESS_Y, TESS_VX, TESS_VY etc~
- [x] Code cleanup: Make sure class variables are under _init_ so they get reset for every run. There was an issue with cube_shape being too small, that would get fixed when I reinitialized the class, investigate that. 
- [x] Unit test(s)

UPDATE: After investigating TruncatedString warning, I found the source of the issue being under `_build_info_table` where the default length of a string keyword value is set based on the length of the string keyword value in the designated `template_file` . In the event that the string kwd value in one FFI is longer than the string kwd value in the template file, a stringTruncated Warning will pop up. I fixed the default value and compared the generated `info_table` with the `info_table` before fixing, and it doesn't seem to clip off the kwd value the way I expected it would. So I'm going to leave this error alone and avoid fiddling with the string column length in case that creates a memory issue. The Warning will be noted here for future reference in case I need to revisit. 

Screenshot below shows the `DATASUM` values for 2 FFIs in an info table where one value is 9 characters and the other is 10. This is the string column causing the Warnings. 
<img width="605" alt="image" src="https://user-images.githubusercontent.com/32107699/171684308-16194021-10d5-4935-9a3e-5c419d04f21b.png">

----
----
# TICA vs SPOC Cube Analysis 

### HDU Lists for SPOC and TICA cubes (respectively)

<img width="1253" alt="image" src="https://user-images.githubusercontent.com/32107699/169399994-2c320a8e-7348-417d-9949-4481a2e06400.png">

----

### Image comparison between SPOC and TICA FFis within the cubes

#### Sector 27, Camera 1, CCD 2

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/32107699/169400176-e279021a-a17c-4b7d-b6f7-9485979151d8.png">

#### Normalized (`Array/MEDIAN(Array)`)

<img width="1246" alt="image" src="https://user-images.githubusercontent.com/32107699/169400245-4e30015f-21a4-4f49-9e7c-aab6b7039345.png">

#### Using this star as a reference point to verify alignment between two FFIs within the respective cubes

<img width="1246" alt="image" src="https://user-images.githubusercontent.com/32107699/169400516-0c61f7a0-d3c9-443f-97e2-c5eee084de96.png">

#### Ratio image (TESS/TICA) between exact cutouts of that star for both SPOC and TICA

<img width="1243" alt="image" src="https://user-images.githubusercontent.com/32107699/169400663-26c6dc72-f1f9-41b9-bdfc-ae28e75d6706.png">

#### Verifying time-cadence between SPOC and TESS. Start time between consecutive FFIs lapsed for 10 minutes. Consistent with the EM1 protocol. 

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/32107699/169400833-c2384203-45f1-4ba1-9822-dc493012f468.png">
