### PR TITLE
hotfix for `cube_cut` checking for valid WCS info

### DIFF
--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -7,7 +7,6 @@ import warnings
 from itertools import product
 from time import time
 
-# Note: Use the astropy function if available, TODO: fix > 4.3 astropy fitting
 import astropy
 import astropy.units as u
 import numpy as np
@@ -19,6 +18,7 @@ from astropy.time import Time
 from . import __version__
 from .exceptions import InputWarning, InvalidQueryError
 
+# Note: Use the astropy function if available, TODO: fix > 4.3 astropy fitting
 if astropy.utils.minversion(astropy, "4.0.2") and (float(astropy.__version__[:3]) < 4.3):
     from astropy.wcs.utils import fit_wcs_from_points
 else:

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -4,23 +4,21 @@
 
 import os
 import warnings
-
-from time import time
 from itertools import product
+from time import time
 
+# Note: Use the astropy function if available, TODO: fix > 4.3 astropy fitting
+import astropy
 import astropy.units as u
 import numpy as np
-
 from astropy import wcs
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.time import Time
 
-from . import __version__ 
+from . import __version__
 from .exceptions import InputWarning, InvalidQueryError
 
-# Note: Use the astropy function if available, TODO: fix > 4.3 astropy fitting
-import astropy
 if astropy.utils.minversion(astropy, "4.0.2") and (float(astropy.__version__[:3]) < 4.3):
     from astropy.wcs.utils import fit_wcs_from_points
 else:
@@ -115,8 +113,8 @@ class CutoutFactory():
             table_row = table_data[data_ind]
 
             # Making sure we have a row with wcs info.
-            wcsaxes_keyword = 'WCSAXES' if product == 'SPOC' else 'WCAX3' 
-            if table_row[wcsaxes_keyword] != 2:
+            wcsaxes_keyword = 'CTYPE2'
+            if table_row[wcsaxes_keyword] != 'DEC--TAN-SIP':
                 table_row = None
                 data_ind += 1
                 if data_ind == len(table_data):

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -1,17 +1,17 @@
-import pytest
-import numpy as np
 from os import path
 
-from astropy.io import fits
+import astropy.units as u
+import numpy as np
+import pytest
 from astropy import wcs
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from astropy.time import Time
-import astropy.units as u
 
-from .utils_for_test import create_test_ffis
-from ..make_cube import CubeFactory, TicaCubeFactory
 from ..cube_cut import CutoutFactory
-from ..exceptions import InvalidQueryError, InputWarning
+from ..exceptions import InputWarning, InvalidQueryError
+from ..make_cube import CubeFactory, TicaCubeFactory
+from .utils_for_test import create_test_ffis
 
 
 def checkcutout(product, cutfile, pixcrd, world, csize, ecube, eps=1.e-7):
@@ -343,12 +343,12 @@ def test_exceptions(tmpdir, ffi_type):
     cube_table = hdu[2].data
      
     # Testing when none of the FFIs have good wcs info
-    wcsaxes = 'WCSAXES' if ffi_type == 'SPOC' else 'WCAX3'
-    cube_table[wcsaxes] = 0
+    wcsaxes = 'CTYPE2'
+    cube_table[wcsaxes] = 'N/A'
     with pytest.raises(Exception, match='No FFI rows contain valid WCS keywords.') as e:
         cutout_maker._parse_table_info(product=ffi_type, table_data=cube_table)
         assert e.type is wcs.NoWcsKeywordsFoundError
-    cube_table[wcsaxes] = 2
+    cube_table[wcsaxes] = 'DEC--TAN-SIP'
 
     # Testing when nans are present 
     cutout_maker._parse_table_info(product=ffi_type, table_data=cube_table)


### PR DESCRIPTION
`_parse_table_info` was calling for a keyword in the cube that does not exist until after the cutout file is made. Updated this WCS validation check accordingly, to work with a header keyword that SPOC and TICA both have, and is always the same value, and implies that other relevant WCS info is also in the header of the FFI. 

Import restructuring from VSCode's `isort`