### PR TITLE
Error handling for `CubeFactory` and `TicaCubeFactory`

### DIFF
--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -19,8 +19,7 @@ if (version_info >= (3, 8)) and (platform != "win32"):
     from mmap import MADV_SEQUENTIAL
 
 __all__ = ['CubeFactory', 'TicaCubeFactory']
-ERROR_MSG = "One or more incorrect file types were input. Please input TICA FFI files when using\
-                   ``TicaCubeFactory``, and SPOC FFI files when using ``CubeFactory``."
+ERROR_MSG = "One or more incorrect file types were input."
 
 class CubeFactory():
     """

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -19,7 +19,9 @@ if (version_info >= (3, 8)) and (platform != "win32"):
     from mmap import MADV_SEQUENTIAL
 
 __all__ = ['CubeFactory', 'TicaCubeFactory']
-ERROR_MSG = "One or more incorrect file types were input."
+ERROR_MSG = "One or more incorrect file types were input. Please input TICA FFI files when using\
+                   ``TicaCubeFactory``, and SPOC FFI files when using ``CubeFactory``."
+
 
 class CubeFactory():
     """

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -19,7 +19,8 @@ if (version_info >= (3, 8)) and (platform != "win32"):
     from mmap import MADV_SEQUENTIAL
 
 __all__ = ['CubeFactory', 'TicaCubeFactory']
-
+ERROR_MSG = "One or more incorrect file types were input. Please input TICA FFI files when using\
+                   ``TicaCubeFactory``, and SPOC FFI files when using ``CubeFactory``."
 
 class CubeFactory():
     """
@@ -88,7 +89,7 @@ class CubeFactory():
         try:
             slice_size = image_shape[1] * len(self.file_list) * 2 * 4  # in bytes (float32)
         except IndexError:
-            raise ValueError("One or more TICA FFIs were input. Please use ``TicaCubeFactory`` to process TICA FFIs.")
+            raise ValueError(ERROR_MSG)
         max_block_size = int((self.max_memory * 1e9)//slice_size)
         
         self.num_blocks = int(image_shape[0]/max_block_size + 1)
@@ -407,12 +408,11 @@ class TicaCubeFactory():
             
             start_times[i] = ffi_data[0].header.get(self.time_keyword)
 
-            error_msg = "One or more SPOC FFIs were input. Please use ``CubeFactory`` to process SPOC FFIs."
             if image_shape is None:  # Only need to fill this once
                 try:
                     image_shape = ffi_data[0].data.shape
                 except AttributeError:
-                    raise ValueError(error_msg)
+                    raise ValueError(ERROR_MSG)
             
             if self.template_file is None:  # Only check this if we don't already have it
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -411,7 +411,8 @@ class TicaCubeFactory():
                 try:
                     image_shape = ffi_data[0].data.shape
                 except AttributeError:
-                    raise ValueError("One or more SPOC FFIs were input. Please use ``CubeFactory`` to process SPOC FFIs.")
+                    raise ValueError("One or more SPOC FFIs were input. Please use ``CubeFactory``\
+                                     to process SPOC FFIs.")
             
             if self.template_file is None:  # Only check this if we don't already have it
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -407,12 +407,12 @@ class TicaCubeFactory():
             
             start_times[i] = ffi_data[0].header.get(self.time_keyword)
 
+            error_msg = "One or more SPOC FFIs were input. Please use ``CubeFactory`` to process SPOC FFIs."
             if image_shape is None:  # Only need to fill this once
                 try:
                     image_shape = ffi_data[0].data.shape
                 except AttributeError:
-                    raise ValueError("One or more SPOC FFIs were input. Please use ``CubeFactory``\
-                                     to process SPOC FFIs.")
+                    raise ValueError(error_msg)
             
             if self.template_file is None:  # Only check this if we don't already have it
 

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -85,7 +85,10 @@ class CubeFactory():
 
         # Working out the block size and number of blocks needed for writing the cube
         # without using too much memory
-        slice_size = image_shape[1] * len(self.file_list) * 2 * 4  # in bytes (float32)
+        try:
+            slice_size = image_shape[1] * len(self.file_list) * 2 * 4  # in bytes (float32)
+        except IndexError:
+            raise ValueError("One or more TICA FFIs were input. Please use ``TicaCubeFactory`` class to process TICA FFIs.")
         max_block_size = int((self.max_memory * 1e9)//slice_size)
         
         self.num_blocks = int(image_shape[0]/max_block_size + 1)
@@ -310,7 +313,7 @@ class CubeFactory():
 
         # Set up the basic cube parameters
         sector = (sector, "Observing sector")
-    
+
         self._configure_cube(file_list, sector=sector)
     
         if verbose:

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -88,7 +88,7 @@ class CubeFactory():
         try:
             slice_size = image_shape[1] * len(self.file_list) * 2 * 4  # in bytes (float32)
         except IndexError:
-            raise ValueError("One or more TICA FFIs were input. Please use ``TicaCubeFactory`` class to process TICA FFIs.")
+            raise ValueError("One or more TICA FFIs were input. Please use ``TicaCubeFactory`` to process TICA FFIs.")
         max_block_size = int((self.max_memory * 1e9)//slice_size)
         
         self.num_blocks = int(image_shape[0]/max_block_size + 1)
@@ -408,7 +408,10 @@ class TicaCubeFactory():
             start_times[i] = ffi_data[0].header.get(self.time_keyword)
 
             if image_shape is None:  # Only need to fill this once
-                image_shape = ffi_data[0].data.shape
+                try:
+                    image_shape = ffi_data[0].data.shape
+                except AttributeError:
+                    raise ValueError("One or more SPOC FFIs were input. Please use ``CubeFactory`` to process SPOC FFIs.")
             
             if self.template_file is None:  # Only check this if we don't already have it
 

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -178,8 +178,7 @@ def test_invalid_inputs(tmpdir, ffi_type):
 
     # Assigning some variables
     target_name = "TICA FFI" if ffi_type == "TICA" else "TESS FFI"
-    value_error = "One or more incorrect file types were input. Please input TICA FFI files when using\
-                   ``TicaCubeFactory``, and SPOC FFI files when using ``CubeFactory``."
+    value_error = "One or more incorrect file types were input."
 
     # Getting TESS sector 27 observations for the given coordinate
     observations = Observations.query_criteria(coordinates=coordinates,

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -190,7 +190,7 @@ def test_invalid_inputs(tmpdir, ffi_type):
     # Getting a list of products. Keeping it small so we don't have to download so many.
     products = Observations.get_product_list(observations[0])[:2]
 
-    manifest = Observations.download_products(products, download_dir=tmpdir)
+    manifest = Observations.download_products(products, download_dir=str(tmpdir))
 
     if ffi_type == "TICA":
         cube_maker = CubeFactory()

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -178,7 +178,8 @@ def test_invalid_inputs(tmpdir, ffi_type):
 
     # Assigning some variables
     target_name = "TICA FFI" if ffi_type == "TICA" else "TESS FFI"
-    value_error = "One or more incorrect file types were input."
+    value_error = "One or more incorrect file types were input. Please input TICA FFI files when using\
+                   ``TicaCubeFactory``, and SPOC FFI files when using ``CubeFactory``."
 
     # Getting TESS sector 27 observations for the given coordinate
     observations = Observations.query_criteria(coordinates=coordinates,

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -1,8 +1,11 @@
 import numpy as np
 import os
+import pytest
 
+from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Table
+from astroquery.mast import Observations
 from re import findall
 from os import path
 
@@ -167,7 +170,37 @@ def test_iteration(tmpdir, capsys):
 
     assert np.alltrue(cube_1 == ecube), "Cube values do not match expected values"
 
+
+@pytest.mark.parametrize("ffi_type", ["TICA", "SPOC"])
+def test_invalid_inputs(tmpdir, ffi_type):
+
+    coordinates = SkyCoord(289.0979, -29.3370, unit="deg")
+
+    # Assigning some variables
+    target_name = "TICA FFI" if ffi_type == "TICA" else "TESS FFI"
+    class_name = "``TicaCubeFactory``" if ffi_type == "TICA" else "``CubeFactory``"
+    value_error = f"One or more {ffi_type} FFIs were input. Please use {class_name} to process {ffi_type} FFIs."
+
+    # Getting TESS sector 27 observations for the given coordinate
+    observations = Observations.query_criteria(coordinates=coordinates,
+                                               target_name=target_name,
+                                               dataproduct_type="image",
+                                               sequence_number=27)
     
+    # Getting a list of products. Keeping it small so we don't have to download so many.
+    products = Observations.get_product_list(observations[0])[:2]
+
+    manifest = Observations.download_products(products, download_dir=tmpdir)
+
+    if ffi_type == "TICA":
+        cube_maker = CubeFactory()
+    elif ffi_type == "SPOC":
+        cube_maker = TicaCubeFactory()
+
+    with pytest.raises(ValueError) as error_msg:
+        cube_maker.make_cube(manifest["Local Path"])
+    assert value_error in str(error_msg.value)
+
     
 
     

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -178,8 +178,8 @@ def test_invalid_inputs(tmpdir, ffi_type):
 
     # Assigning some variables
     target_name = "TICA FFI" if ffi_type == "TICA" else "TESS FFI"
-    class_name = "``TicaCubeFactory``" if ffi_type == "TICA" else "``CubeFactory``"
-    value_error = f"One or more {ffi_type} FFIs were input. Please use {class_name} to process {ffi_type} FFIs."
+    value_error = "One or more incorrect file types were input. Please input TICA FFI files when using\
+                   ``TicaCubeFactory``, and SPOC FFI files when using ``CubeFactory``."
 
     # Getting TESS sector 27 observations for the given coordinate
     observations = Observations.query_criteria(coordinates=coordinates,

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
     astropy>=5.2 # astropy with s3fs support
+    astroquery>=0.4.6 # for testing
     fsspec[http]>=2022.8.2  # for remote cutouts
     s3fs>=2022.8.2  # for remote cutouts
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
     astropy>=5.2 # astropy with s3fs support
-    astroquery>=0.4.6 # for testing
     fsspec[http]>=2022.8.2  # for remote cutouts
     s3fs>=2022.8.2  # for remote cutouts
     scipy
@@ -30,6 +29,7 @@ console_scripts =
 [options.extras_require]
 test =
     pytest-astropy
+    astroquery>=0.4.6
 docs =
     sphinx != 4.1.0
     docutils == 0.16

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ description =
     astropy52: with astropy 5.2.*
     numpy120: with numpy 1.20.*
     numpy123: with numpy 1.23.*
+    astroquery04: with astroquery 0.4.*
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -45,6 +46,8 @@ deps =
     numpy123: numpy==1.23.*
 
     astropy52: astropy==5.2.*
+
+    astroquery04: astroquery==0.4.*
 
     devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ deps =
 
     devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: git+https://github.com/astropy/astroquery.git
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
### Summary 

Currently the errors that get returned when SPOC FFIs are fed into `TicaCubeFactory` and vice versa are vague and not helpful to the user. This PR updates the error handling by raising an error when the wrong type of FFI is fed into either `CubeFactory` or `TicaCubeFactory` to make TESS cubes.

----

### Task List

- [x] Update `CubeFactory` error handling 
- [x] Update `TicaCubeFactory` error handling
- [x] Add unit test(s)

----

### Screenshots (as of July 14, 2023)

The following two screenshots show the error that gets thrown when feeding the wrong type of FFI to `CubeFactory` and `TicaCubeFactory`:

<img width="1068" alt="image" src="https://github.com/spacetelescope/astrocut/assets/32107699/a94a3de5-6f51-4da8-a77c-098fe6c6bb52">

<img width="1069" alt="image" src="https://github.com/spacetelescope/astrocut/assets/32107699/4fc94b66-c676-4bf4-bdfd-d123d48db942">