### PR TITLE
removing error array dimension from TicaCubeFactory

### DIFF
--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -440,7 +440,7 @@ class TicaCubeFactory():
         # Determining cube shape: 
         # If it's a new cube, the shape is (nRows, nCols, nImages, 2)
         if not self.update:
-            self.cube_shape = (image_shape[0], image_shape[1], len(self.file_list), 2)
+            self.cube_shape = (image_shape[0], image_shape[1], len(self.file_list), 1)
             
         # Else, if it's an update to an existing cube, the shape is (nRows, nCols, nImages + nNewImages, 2)
         else: 

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -74,7 +74,7 @@ def test_make_and_update_cube(tmpdir):
     cube = hdu[1].data
 
     # expected values for cube before update_cube
-    ecube = np.zeros((img_sz, img_sz, num_im // 2, 2))
+    ecube = np.zeros((img_sz, img_sz, num_im // 2, 1))
     plane = np.arange(img_sz*img_sz, dtype=np.float32).reshape((img_sz, img_sz))
 
     assert cube.shape == ecube.shape, "Mismatch between cube shape and expected shape"
@@ -98,7 +98,7 @@ def test_make_and_update_cube(tmpdir):
     cube = hdu[1].data
     
     # expected values for cube after update_cube
-    ecube = np.zeros((img_sz, img_sz, num_im, 2))
+    ecube = np.zeros((img_sz, img_sz, num_im, 1))
     plane = np.arange(img_sz*img_sz, dtype=np.float32).reshape((img_sz, img_sz))
 
     assert cube.shape == ecube.shape, "Mismatch between cube shape and expected shape"


### PR DESCRIPTION
Addressing ticket ASB-22318. Created a test cube using 500 FFIs from TICA Sector 67, cam1-ccd1. Created cube has expected dimensions, see output from `fitsinfo` below. Cube created without error array is ~1/2 the size of a cube created with the error array (8.68 vs 17.35 GB).
 ```
Filename: /home/halewis/hlsp/tica/tica_cubes/s0067/tica-s0067-1-1-cube.fits
No.    Name      Ver    Type      Cards   Dimensions   Format
  0  PRIMARY       1 PrimaryHDU     198   ()      
  1                1 ImageHDU         9   (1, 500, 2136, 2078)   float32   
  2                1 BinTableHDU    598   500R x 198C   [D, J, J, J, J, D, J, J, 2A, D, D, D, D, D, D, D, D, D, D, D, D, J, J, J, J, J, J, J, D, J, D, D, D, D, D, D, D, D, 3A, J, J, 16A, D, D, D, D, 9A, 5A, D, 15A, 4A, 4A, D, D, D, D, D, D, D, D, 12A, 12A, D, D, D, D, J, J, J, J, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, J, J, J, 16A, 10A, 49A, 64A]
```