### PR TITLE
Adapting `CutoutFactory` to account for error-less TICA Cubes

### DIFF
--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -448,7 +448,8 @@ class CutoutFactory():
             cutout = transposed_cube[xmin:xmax, ymin:ymax, :, :]
 
         img_cutout = cutout[:, :, :, 0].transpose((2, 0, 1))
-        uncert_cutout = cutout[:, :, :, 1].transpose((2, 0, 1))
+        if self.product == "SPOC":
+            uncert_cutout = cutout[:, :, :, 1].transpose((2, 0, 1))
     
         # Making the aperture array
         aperture = np.ones((xmax-xmin, ymax-ymin), dtype=np.int32)
@@ -456,14 +457,19 @@ class CutoutFactory():
         # Adding padding to the cutouts so that it's the expected size
         if padding.any():  # only do if we need to pad
             img_cutout = np.pad(img_cutout, padding, 'constant', constant_values=np.nan)
-            uncert_cutout = np.pad(uncert_cutout, padding, 'constant', constant_values=np.nan)
+            if self.product == "SPOC":
+                uncert_cutout = np.pad(uncert_cutout, padding, 'constant', constant_values=np.nan)
             aperture = np.pad(aperture, padding[1:], 'constant', constant_values=0)
 
         if verbose:
             print("Image cutout cube shape: {}".format(img_cutout.shape))
-            print("Uncertainty cutout cube shape: {}".format(uncert_cutout.shape))
+            if self.product == "SPOC":
+                print("Uncertainty cutout cube shape: {}".format(uncert_cutout.shape))
     
-        return img_cutout, uncert_cutout, aperture
+        if self.product == "SPOC":
+            return img_cutout, uncert_cutout, aperture
+        else:
+            return img_cutout, aperture
 
 
     def _update_primary_header(self, primary_header):

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -681,7 +681,8 @@ class CutoutFactory():
         img_cube : `numpy.array`
             The untransposed image cutout array
         uncert_cube : `numpy.array`
-            The untransposed uncertainty cutout array
+            The untransposed uncertainty cutout array.
+            This value is set to `None` by default for TICA cutouts.
         cutout_wcs_dict : dict
             Dictionary of wcs keyword/value pairs to be added to each array 
             column in the cutout table header.

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -702,8 +702,6 @@ class CutoutFactory():
         # The primary hdu is just the main header, which is the same
         # as the one on the cube file
         primary_hdu = cube_fits[0]
-        print(cube_fits)
-        print(primary_hdu.header)
         self._update_primary_header(primary_hdu.header)
 
         cols = list()
@@ -849,6 +847,7 @@ class CutoutFactory():
         if verbose:
             start_time = time()
 
+        # Declare the product type being used to make the cutouts
         self.product = product
 
         warnings.filterwarnings("ignore", category=wcs.FITSFixedWarning)

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -729,10 +729,10 @@ class CutoutFactory():
 
         # Adding flux and flux_err (data we actually have!)
         pixel_unit = 'e-/s' if self.product == 'SPOC' else 'e-'
+        flux_err_array = uncert_cube if self.product == 'SPOC' else empty_arr
         cols.append(fits.Column(name='FLUX', format=tform, dim=dims, unit=pixel_unit, disp='E14.7', array=img_cube))
-        if uncert_cube is not None:
-            cols.append(fits.Column(name='FLUX_ERR', format=tform, dim=dims, unit=pixel_unit, disp='E14.7',
-                                    array=uncert_cube)) 
+        cols.append(fits.Column(name='FLUX_ERR', format=tform, dim=dims, unit=pixel_unit, disp='E14.7',
+                                array=flux_err_array)) 
    
         # Adding the background info (zeros b.c we don't have this info)
         cols.append(fits.Column(name='FLUX_BKG', format=tform, dim=dims, unit=pixel_unit, disp='E14.7',

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -720,7 +720,8 @@ class CutoutFactory():
                                     array=cube_fits[2].columns['BARYCORR'].array))
 
         # Adding CADENCENO as zeros for SPOC b/c we don't have this info
-        cadence_array = empty_arr[:, 0, 0] if self.product == 'SPOC' else cube_fits[2].columns['CADENCE'].array
+        cadence_array = np.zeros(img_cube.shape)[:, 0, 0] if self.product == 'SPOC'\
+                        else cube_fits[2].columns['CADENCE'].array
         cols.append(fits.Column(name='CADENCENO', format='J', disp='I10', array=cadence_array))
 
         # Adding counts (-1 b/c we don't have data)

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -404,7 +404,7 @@ class CutoutFactory():
         -------
         response :  `numpy.array`, `numpy.array`, `numpy.array`
             The untransposed image cutout array,
-            the untransposeduncertainty cutout array,
+            the untransposed uncertainty cutout array (if `self.product` is SPOC, otherwise returns `None`),
             and the aperture array (an array the size of a single cutout
             that is 1 where there is image data and 0 where there isn't)
         """

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -402,7 +402,7 @@ class CutoutFactory():
 
         Returns
         -------
-        response :  `numpy.array`, `numpy.array`, `numpy.array`
+        response :  `numpy.array`, `numpy.array` (or `None`), `numpy.array`
             The untransposed image cutout array,
             the untransposed uncertainty cutout array (if `self.product` is SPOC, otherwise returns `None`),
             and the aperture array (an array the size of a single cutout

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -846,7 +846,7 @@ class CutoutFactory():
             start_time = time()
 
         # Declare the product type being used to make the cutouts
-        self.product = product
+        self.product = product.upper()
 
         warnings.filterwarnings("ignore", category=wcs.FITSFixedWarning)
         fits_options: Dict[str, Any] = {"mode": "denywrite", "lazy_load_hdus": True}

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -731,7 +731,7 @@ class CutoutFactory():
         # Adding flux and flux_err (data we actually have!)
         pixel_unit = 'e-/s' if self.product == 'SPOC' else 'e-'
         cols.append(fits.Column(name='FLUX', format=tform, dim=dims, unit=pixel_unit, disp='E14.7', array=img_cube))
-        if uncert_cube:
+        if uncert_cube is not None:
             cols.append(fits.Column(name='FLUX_ERR', format=tform, dim=dims, unit=pixel_unit, disp='E14.7',
                                     array=uncert_cube)) 
    

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -721,7 +721,7 @@ class CutoutFactory():
 
         # Adding CADENCENO as zeros for SPOC b/c we don't have this info
         cadence_array = np.zeros(img_cube.shape)[:, 0, 0] if self.product == 'SPOC'\
-                        else cube_fits[2].columns['CADENCE'].array
+            else cube_fits[2].columns['CADENCE'].array
         cols.append(fits.Column(name='CADENCENO', format='J', disp='I10', array=cadence_array))
 
         # Adding counts (-1 b/c we don't have data)

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -244,7 +244,7 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, extension
         start_time = time()
             
     # Making sure we have an array of images
-    if type(input_files) == str:
+    if isinstance(input_files, str):
         input_files = [input_files]
 
     # If a single extension is given, make it a list
@@ -512,7 +512,7 @@ def img_cut(input_files, coordinates, cutout_size, stretch='asinh', minmax_perce
         start_time = time()
             
     # Making sure we have an array of images
-    if type(input_files) == str:
+    if isinstance(input_files, str):
         input_files = [input_files]
             
     if not isinstance(coordinates, SkyCoord):

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -438,7 +438,8 @@ class TicaCubeFactory():
         self.block_size = int(image_shape[0]/self.num_blocks + 1)
         
         # Determining cube shape: 
-        # If it's a new cube, the shape is (nRows, nCols, nImages, 2)
+        # If it's a new TICA cube, the shape is (nRows, nCols, nImages, 1).
+        # Axis 4 is `1` instead of `2` because we do not work with error arrays for TICA.
         if not self.update:
             self.cube_shape = (image_shape[0], image_shape[1], len(self.file_list), 1)
             

--- a/astrocut/make_cube.py
+++ b/astrocut/make_cube.py
@@ -138,9 +138,9 @@ class CubeFactory():
             # set up the image info table
             cols = []
             for kwd, val, cmt in secondary_header.cards: 
-                if type(val) == str:
+                if isinstance(val, str):
                     tpe = "S" + str(len(val))  # TODO: Maybe switch to U?
-                elif type(val) == int:
+                elif isinstance(val, int):
                     tpe = np.int32
                 else:
                     tpe = np.float64
@@ -500,9 +500,9 @@ class TicaCubeFactory():
             cols = []
             length = len(self.file_list)
             for kwd, val, cmt in primary_header.cards: 
-                if type(val) == str:  
+                if isinstance(val, str):  
                     tpe = "S" + str(len(val))  # TODO: Maybe switch to U?
-                elif type(val) == int:
+                elif isinstance(val, int):
                     tpe = np.int32
                 else:
                     tpe = np.float64
@@ -652,9 +652,9 @@ class TicaCubeFactory():
             # set up the image info table
             cols = []
             for kwd, val, cmt in primary_header.cards: 
-                if type(val) == str:
+                if isinstance(val, str):
                     tpe = "S" + str(len(val))  # TODO: Maybe switch to U?
-                elif type(val) == int:
+                elif isinstance(val, int):
                     tpe = np.int32
                 else:
                     tpe = np.float64

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -367,7 +367,6 @@ def test_target_pixel_file(cube_file, ffi_type, tmp_path):
     assert len(tpf_table.columns) == ncols
     assert "TIME" in tpf_table.columns.names
     assert "FLUX" in tpf_table.columns.names
-    assert "FLUX_ERR" in tpf_table.columns.names
     assert "FFI_FILE" in tpf_table.columns.names
 
     cutout_img = tpf_table[0]['FLUX']

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -344,7 +344,7 @@ def test_fit_cutout_wcs(cube_file, ffi_type, tmp_path):
 
 
 @pytest.mark.parametrize("ffi_type", ["SPOC", "TICA"])
-def test_taget_pixel_file(cube_file, ffi_type, tmp_path):
+def test_target_pixel_file(cube_file, ffi_type, tmp_path):
     """Test target pixel file"""
     
     tmpdir = str(tmp_path)
@@ -362,8 +362,8 @@ def test_taget_pixel_file(cube_file, ffi_type, tmp_path):
     assert tpf[0].header["ORIGIN"] == 'STScI/MAST'
 
     tpf_table = tpf[1].data
-    # SPOC cutouts have one extra column in EXT 1
-    ncols = 12 if ffi_type == 'SPOC' else 11
+    # SPOC cutouts have 2 extra columns in EXT 1
+    ncols = 12 if ffi_type == 'SPOC' else 10
     assert len(tpf_table.columns) == ncols
     assert "TIME" in tpf_table.columns.names
     assert "FLUX" in tpf_table.columns.names

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -367,6 +367,10 @@ def test_target_pixel_file(cube_file, ffi_type, tmp_path):
     assert len(tpf_table.columns) == ncols
     assert "TIME" in tpf_table.columns.names
     assert "FLUX" in tpf_table.columns.names
+    if ffi_type == "SPOC":
+        assert "FLUX_ERR" in tpf_table.columns.names
+    else:
+        assert "FLUX_ERR" not in tpf_table.columns.names
     assert "FFI_FILE" in tpf_table.columns.names
 
     cutout_img = tpf_table[0]['FLUX']


### PR DESCRIPTION
### Summary

This PR updates `CutoutFactory` to account for the removed error array in `TicaCubeFactory` (work that was done in  #87). It involves turning the `product` kwarg from `cube_cut()` into a class attribute so that it doesn't have to be fed into every method as an argument before being called. It also involves using this new `self.product` class attribute to make conditionals that make the code dynamic and changes the logic depending on whether the product for the cutouts is `"TICA"` or `"SPOC"`. Unit test changes are also made where appropriate.

----

### Task List

- [x] Account for removed error array in `CutoutFactory`
- [x] Update `cube_cut` unit tests
- [x] Rebase onto #87

----

### Screenshots