### PR TITLE
Updating `.readthedocs.yml` with Python3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   image: latest
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,6 @@
 version: 2
 
 build:
-  image: latest
   os: ubuntu-22.04
   tools:
     python: "3.11"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 
 build:
   image: latest
-  os: macos-latest
+  os: ubuntu-22.04
   tools:
     python: "3.11"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,8 +6,8 @@ build:
     python: "3.11"
 
 python:
-  install:
-    - requirements: docs
+  extra_requirements:
+    - docs
 
 formats: []
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,14 +2,13 @@ version: 2
 
 build:
   image: latest
+  os: macos-latest
+  tools:
+    python: "3.11"
 
 python:
-  version: 3.11
   install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+    - requirements: docs
 
 formats: []
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,8 +4,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-    extra_requirements:
-    - docs
+      extra_requirements:
+        - docs
 
 formats: []
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   image: latest
 
 python:
-  version: 3.8
+  version: 3.11
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+
+python:
+  install:
+    - method: pip
+      path: .
       extra_requirements:
         - docs
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,9 +4,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-
-python:
-  extra_requirements:
+    extra_requirements:
     - docs
 
 formats: []

--- a/astrocut/__init__.py
+++ b/astrocut/__init__.py
@@ -10,7 +10,7 @@ from ._astropy_init import *  # noqa
 # This is the same check as the one at the top of setup.py
 import sys
 
-__minimum_python_version__ = "3.6"
+__minimum_python_version__ = "3.8"
 
 
 class UnsupportedPythonError(Exception):

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ github_project = spacetelescope/astrocut
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
     astropy>=5.2 # astropy with s3fs support


### PR DESCRIPTION
The Astrocut RTD maintainers received an e-mail notification about adding a `.readthedocs.yml` v2 configuration file to our project, as they will no longer be supporting projects with implicit dependencies. More info can be found in this article: https://blog.readthedocs.com/migrate-configuration-v2/ . 

@ceb8 already built us a `.readthedocs.yml` v2 file, so we are good to go. The reason we actually got that e-mail was because we had the following checkbox checked off in the `Advanced Settings` of the `Astrocut` project, which is the feature that will be deprecated in September 2023:

<img width="509" alt="image" src="https://github.com/spacetelescope/astrocut/assets/32107699/addedaf2-6b3b-4c5b-9f6d-f83ddc40c6ee">

All it needed was to be updated to require python 3.8 instead of 3.7, because 3.7 does not jive with `astropy>=5.2`, which caused our documentation to break for the past 4 months, and is the actual reason for this PR:

**TLDR; This PR updates the `.readthedocs.yml` to build documentation on python `3.8` (as opposed to the original `3.7`), because our minimum `astropy` requirement of `>=5.2` doesn't work with `py37`. This PR also updates the minimum python version requested in the `setup.cfg`.**