### PR TITLE
Update cube and cutout unittests

### DIFF
--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -431,9 +431,11 @@ def test_tica_cutout_error(tmp_path):
     Test cutouts created from existing TICA cubes (i.e., those with
     error arrays)
 
-    Write test to check cutouts made from TICA cubes that still have
-    the error array. Needed to verify that CutoutFactory will work on
-    the cubes that have not been remade yet.
+    Write test to check that cutouts can be made from *both* the TICA
+    cubes that still have the error array, as well as cubes that
+    *have* been updated and no longer have the error array. Needed to
+    verify that CutoutFactory will work on the cubes that have not 
+    been remade yet.
     """
 
     tmpdir = str(tmp_path)
@@ -691,6 +693,8 @@ def test_s3_tica_cube_cut(tmp_path: Path):
     2
     >>> cut[0][0].header['CCD']  # doctest: +SKIP
     1
+
+    TODO: Remove test `test_tica_cutout_error` when this test starts working
     """
     # Test case: RR Lyrae star in Sector 27 (Camera 2, CCD 1)
     coord = SkyCoord(299.27269, -67.14491, unit="deg", frame="icrs")

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -426,6 +426,17 @@ def test_target_pixel_file(cube_file, ffi_type, tmp_path):
     tpf.close()
 
 
+def test_tica_cutout_error(tmp_path):
+    """
+    Test cutouts created from existing TICA cubes (i.e., those with error arrays)
+
+    TODO: Write test to check cutouts made from TICA cubes that still have the error array. Needed to verify that CutoutFactory will work on the cubes that have not been remade yet.
+    """
+
+
+    assert True
+
+
 @pytest.mark.parametrize('ffi_type', ['SPOC', 'TICA'])
 def test_exceptions(cube_file, ffi_type):
     """

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -270,13 +270,13 @@ def test_header_keywords_diffs(cube_file, ffi_type, tmp_path):
             assert hdulist[0].header['TIMEREF'] == 'SOLARSYSTEM', 'TIMEREF keyword does not match expected'
             assert hdulist[0].header['TASSIGN'] == 'SPACECRAFT', 'TASSIGN keyword does not match expected'
             assert cols_dict['FLUX'] == 'e-/s', f'Expected `FLUX` units of "e-/s", got units of "{cols_dict["FLUX"]}"'
-            assert np.mean(hdulist[1].data.field('CADENCENO')) == 0.0
+            assert hdulist[1].data.field('CADENCENO').all() == 0.0
 
         if ffi_type == 'TICA':
             assert hdulist[0].header['TIMEREF'] is None, 'TIMEREF keyword does not match expected'
             assert hdulist[0].header['TASSIGN'] is None, 'TASSIGN keyword does not match expected'
             assert cols_dict['FLUX'] == 'e-', f'Expected `FLUX` units of "e-", got units of "{cols_dict["FLUX"]}"'
-            assert np.mean(hdulist[1].data.field('CADENCENO')) != 0.0
+            assert hdulist[1].data.field('CADENCENO').all() != 0.0
 
 
 @pytest.mark.parametrize("ffi_type", ["SPOC", "TICA"])

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -445,12 +445,16 @@ def test_tica_cutout_error(tmp_path):
     # Cube with TICA headers to copy to cube with error array
     spoc_cube_error = CubeFactory() 
     spoc_ffi_files = create_test_ffis(img_sz, num_im, dir_name=tmpdir)
-    cube_error_file = spoc_cube_error.make_cube(spoc_ffi_files, path.join(tmpdir, "out_dir", "test_error_cube.fits"), verbose=False)
+    cube_error_file = spoc_cube_error.make_cube(spoc_ffi_files, 
+                                                path.join(tmpdir, "out_dir", "test_error_cube.fits"), 
+                                                verbose=False)
 
     # Cube with error array
     tica_cube_no_error = TicaCubeFactory()
     tica_ffi_files = create_test_ffis(img_sz, num_im, dir_name=tmpdir, product='TICA')
-    tica_cube_no_error_file = tica_cube_no_error.make_cube(tica_ffi_files, path.join(tmpdir, "out_dir", "test_add_error_cube.fits"), verbose=False)
+    tica_cube_no_error_file = tica_cube_no_error.make_cube(tica_ffi_files, 
+                                                           path.join(tmpdir, "out_dir", "test_add_error_cube.fits"), 
+                                                           verbose=False)
 
     # Take ImageHDU from the cube with the error array, write into cube with TICA headers
     with fits.open(tica_cube_no_error_file, mode='update') as hdulist:

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -437,6 +437,35 @@ def test_tica_cutout_error(tmp_path):
     assert True
 
 
+@pytest.mark.parametrize("ffi_type", ["SPOC", "TICA"])
+def test_ffi_cube_header(cube_file, ffi_files, ffi_type):
+    """Test FFI headers versus cube headers"""
+
+    ffi_header_keys = list(fits.getheader(ffi_files[0], 0).keys())
+    cube_header_keys = list(fits.getheader(cube_file, 0).keys())
+
+    # Lists of expected keys for each product type
+    if ffi_type == 'SPOC':
+        # CHECKSUM in FFI header, not in cube header
+        # SECTOR, DATE, ORIGIN in cube header, not in FFI header
+        effi_keys = ['CHECKSUM']
+        ecube_keys = ['SECTOR', 'DATE', 'ORIGIN']
+
+    else:
+        # CHECKSUM, and image dimensions (NAXIS1, NAXIS2) in FFI header, not in cube header
+        # SECTOR, DATE, EXTNAME, ORIGIN in cube header, not in FFI header
+        effi_keys = ['CHECKSUM', 'NAXIS1', 'NAXIS2']
+        ecube_keys = ['SECTOR', 'DATE', 'EXTNAME', 'ORIGIN']
+
+    for k in effi_keys:
+        assert k in ffi_header_keys
+        assert k not in cube_header_keys
+
+    for k in ecube_keys:
+        assert k not in ffi_header_keys
+        assert k in cube_header_keys
+    
+
 @pytest.mark.parametrize('ffi_type', ['SPOC', 'TICA'])
 def test_exceptions(cube_file, ffi_type):
     """

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -268,13 +268,13 @@ def test_header_keywords_diffs(cube_file, ffi_type, tmp_path):
         # Checking for known keyword differences
         if ffi_type == 'SPOC':
             assert hdulist[0].header['TIMEREF'] == 'SOLARSYSTEM', 'TIMEREF keyword does not match expected'
-            assert hdulist[0].header['TASSIGN']== 'SPACECRAFT', 'TASSIGN keyword does not match expected'
+            assert hdulist[0].header['TASSIGN'] == 'SPACECRAFT', 'TASSIGN keyword does not match expected'
             assert cols_dict['FLUX'] == 'e-/s', f'Expected `FLUX` units of "e-/s", got units of "{cols_dict["FLUX"]}"'
             assert np.mean(hdulist[1].data.field('CADENCENO')) == 0.0
 
         if ffi_type == 'TICA':
-            assert hdulist[0].header['TIMEREF'] == None, 'TIMEREF keyword does not match expected'
-            assert hdulist[0].header['TASSIGN']== None, 'TASSIGN keyword does not match expected'
+            assert hdulist[0].header['TIMEREF'] is None, 'TIMEREF keyword does not match expected'
+            assert hdulist[0].header['TASSIGN'] is None, 'TASSIGN keyword does not match expected'
             assert cols_dict['FLUX'] == 'e-', f'Expected `FLUX` units of "e-", got units of "{cols_dict["FLUX"]}"'
             assert np.mean(hdulist[1].data.field('CADENCENO')) != 0.0
 
@@ -428,9 +428,12 @@ def test_target_pixel_file(cube_file, ffi_type, tmp_path):
 
 def test_tica_cutout_error(tmp_path):
     """
-    Test cutouts created from existing TICA cubes (i.e., those with error arrays)
+    Test cutouts created from existing TICA cubes (i.e., those with
+    error arrays)
 
-    TODO: Write test to check cutouts made from TICA cubes that still have the error array. Needed to verify that CutoutFactory will work on the cubes that have not been remade yet.
+    Write test to check cutouts made from TICA cubes that still have
+    the error array. Needed to verify that CutoutFactory will work on
+    the cubes that have not been remade yet.
     """
 
 

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -224,6 +224,18 @@ def test_header_keywords_quality(cube_file, ffi_type, tmp_path):
         assert primary_header['CREATOR'] == 'astrocut'
         assert primary_header['BJDREFI'] == 2457000
 
+        # Get units from BinTableHDU
+        cols = hdulist[1].columns.info('name, unit', output=False)
+        cols_dict = dict(zip(*cols.values()))
+
+        ncols = 12 if ffi_type == 'SPOC' else 11
+        assert len(cols_dict) == ncols
+
+        if ffi_type == 'SPOC':
+            assert hdulist[0].header['TIMEREF'] == 'SOLARSYSTEM', 'TIMEREF keyword does not match expected'
+            assert hdulist[0].header['TASSIGN']== 'SPACECRAFT', 'TASSIGN keyword does not match expected'
+            assert cols_dict['FLUX'] == 'e-/s', f'Expected `FLUX` units of "e-/s", got units of "{cols_dict["FLUX"]}"'
+
         if ffi_type == 'TICA':
             # Verifying DATE-OBS calculation in TICA
             date_obs = primary_header['DATE-OBS']
@@ -234,6 +246,10 @@ def test_header_keywords_quality(cube_file, ffi_type, tmp_path):
             date_end = primary_header['DATE-END']
             tstop = Time(date_end).jd - primary_header['BJDREFI']
             assert primary_header['TSTOP'] == tstop
+
+            assert primary_header['TIMEREF'] == None, 'TIMEREF keyword does not match expected'
+            assert primary_header['TASSIGN']== None, 'TASSIGN keyword does not match expected'
+            assert cols_dict['FLUX'] == 'e-', f'Expected `FLUX` units of "e-", got units of "{cols_dict["FLUX"]}"'
 
         # Checking for header keyword propagation in EXT 1 and 2
         ext1_header = hdulist[1].header


### PR DESCRIPTION
Updates to existing unit tests and adding new tests to account for changes in `CutoutFactory` (made in #88). Tests verify that cutouts are being made correctly from the new TICA cubes (without error arrays) and verify known differences in TICA vs. SPOC FFIs, cubes, and cutouts.

Note, there is a placeholder unittest (`test_cube_cut.py::test_tica_cutout_error`) to remind us to go back to look at whether we can/should point the test to an existing TICA cube (one that *does* have the error array and will be among the last cubes to me re-built, e.g., Sector 27) that will be re-built later, to verify that cutouts can still be made from cubes with error array.