### PR TITLE
Clear cache for gc

### DIFF
--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -941,7 +941,7 @@ class CutoutFactory():
             # Write the TPF
             tpf_object.writeto(target_pixel_file, overwrite=True, checksum=True)
 
-        if fits_options["use_fsspec"]:
+        if fits_options.get("use_fsspec"):
             cube._file._file.fs.clear_instance_cache()
 
         if verbose:

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -10,7 +10,6 @@ from time import time
 from typing import Any, Dict, Literal, Union
 
 import astropy.units as u
-import fsspec
 import numpy as np
 from astropy import wcs
 from astropy.coordinates import SkyCoord
@@ -943,7 +942,7 @@ class CutoutFactory():
             tpf_object.writeto(target_pixel_file, overwrite=True, checksum=True)
 
         if fits_options["use_fsspec"]:
-            fsspec.AbstractFileSystem.clear_instance_cache()
+            cube._file._file.fs.clear_instance_cache()
 
         if verbose:
             print("Write time: {:.2} sec".format(time()-write_time))

--- a/astrocut/cube_cut.py
+++ b/astrocut/cube_cut.py
@@ -10,6 +10,7 @@ from time import time
 from typing import Any, Dict, Literal, Union
 
 import astropy.units as u
+import fsspec
 import numpy as np
 from astropy import wcs
 from astropy.coordinates import SkyCoord
@@ -940,6 +941,9 @@ class CutoutFactory():
         
             # Write the TPF
             tpf_object.writeto(target_pixel_file, overwrite=True, checksum=True)
+
+        if fits_options["use_fsspec"]:
+            fsspec.AbstractFileSystem.clear_instance_cache()
 
         if verbose:
             print("Write time: {:.2} sec".format(time()-write_time))


### PR DESCRIPTION
The code:

```python
cube._file._file.fs.clear_instance_cache()
```

Effectively is calling `s3fs.core.S3FileSystem.clear_instance_cache`. This clears the cache on the `s3fs.core.S3FileSystem` class. If this is not done, the cache continues to grow, and repeated calls to cube_cut results in effectively a memory leak.

This problem was made obvious with TESSCut, where the service performs cutouts over the lifetime of the server process. Even with cutouts of the exact same location, the cache continued to grow and would grow to multiple gigabytes.

We are not testing with other types of cloud storage, but this should work for any fsspec compatible file system, since they all inherit from the base class:

https://github.com/fsspec/filesystem_spec/blob/45a6aec7da1407243f9767c6ab0cff40efee72eb/fsspec/spec.py#L1412-L1425

When making repeated cutouts, to the same location, the cache is useful to have, at it seems to retrieve data from the cache first before making the external requests. 

It's not clear to me what extent cutouts made by an individual user would benefit from this cache, though, since most cutouts are unique.

Within tesscut, with multiple users, it's possible that cutouts could be made to the same locations, but probably not very likely. Additionally, the cutouts would also have to be made inside the same process. 

We could consider making the call to `s3fs.core.S3FileSystem.clear_instance_cache()` from within TESSCut itself instead of in the `cube_cut()` function, if we didn't believe that it would useful for individual users to clear their cache. If we did this, then TESSCut could choose how often to clear it's own cache.