### PR TITLE
Use GitHub Actions for publishing new releases to PyPI

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -9,8 +9,14 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
 
+  # TODO: Make it so that this only executes when publish-to-test-pypi executes
+  # TODO: Make it so that the tag gets deleted after publish-to-test-pypi finishes executing
   make_tag:
     runs-on: ubuntu-latest
 
@@ -18,9 +24,7 @@ jobs:
     - name: Make a release tag
       run: git tag -a v0.10.0dev -m "dev release"
 
-  # Release to Test PyPI after every MERGE into @spacetelescope/astrocut/main
-  # TODO: Make it so that this only executes when publish-to-test-pypi executes
-  # TODO: Make it so that the tag gets deleted after publish-to-test-pypi finishes executing    
+  # Release to Test PyPI after every MERGE into @spacetelescope/astrocut/main    
   publish-to-test-pypi:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
     name: Publish to Test PyPI

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -23,7 +23,7 @@ jobs:
     # I.e. A MERGE has been made into @spacetelescope/astrocut/main
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - name: Make the test.pypi release tag

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -19,6 +19,6 @@ jobs:
     if: github.repository_owner == 'spacetelescope' && github.event_name == 'push'
     with:
       test_extras: test
-      test_command: pytest astrocut
+      test_command: pytest --pyargs astrocut
     secrets:
       pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -48,6 +48,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip_existing: True
 
   # Upload to real PyPI on GitHub Releases.
   release-pypi:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -23,4 +23,4 @@ jobs:
     if: github.repository_owner == 'spacetelescope' && github.event_name == 'push'
     with:
       test_extras: test
-      test_command: pytest -p no:warngings astrocut/tests/test*.py
+      test_command: pytest astrocut/tests/test*.py

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -33,7 +33,7 @@ jobs:
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
     environment: release-test-pypi
-    if: github.repository_owner == 'spacetelescope' && github.event_name == 'pull_request'
+    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build-package
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -32,10 +32,11 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          TAG=$(date +'%Y%m%d%H%M%S')
+          TAG=$(date + '%Y%m%d%H%M%S' + '.dev')
           git tag $TAG
-          echo "new tag made! $TAG"
+          echo "New tag made! $TAG"
           git push origin $TAG
+          echo "Github ref:"
           echo ${{ github.ref }}
 
   # Release to Test PyPI
@@ -48,7 +49,7 @@ jobs:
       # We DON'T want to upload to the official PyPI for this job
       repository_url: https://test.pypi.org/legacy/
       # Let's use the tag we generated wtih make_and_push_tag
-      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/') }}
+      upload_to_pypi: 'refs/tags/$TAG'
 
   # Remove the tag and push that deletion to main
   delete_tag:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -14,31 +14,51 @@ permissions:
 
 jobs:
 
-  # TODO: Make it so that this only executes when publish-to-test-pypi executes
-  # TODO: Make it so that the tag gets deleted after publish-to-test-pypi finishes executing
-  make_tag:
+  make_and_push_tag:
     runs-on: ubuntu-latest
 
+    # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
+    # I.e. A MERGE has been made into @spacetelescope/astrocut/main
+    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-    - name: Make a release tag
-      run: echo "test"
+      - name: Make the test.pypi release tag
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          TAG=$(date +'%Y%m%d%H%M%S')
+      - name: Push the tag
+        run: git push origin $TAG
 
-  # Release to Test PyPI after every MERGE into @spacetelescope/astrocut/main    
+  # Release to Test PyPI
   publish-to-test-pypi:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
     name: Publish to Test PyPI
-    needs: make_tag
+    needs: make_and_push_tag
 
-    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     with:
       # We DON'T want to upload to the official PyPI for this job
       repository_url: https://test.pypi.org/legacy/
+      # Let's use the tag we generated wtih make_and_push_tag
+      upload_to_pypi: $TAG
+
+  # Remove the tag and push that deletion to main
+  delete_tag:
+    runs-on: ubuntu-latest
+    # This should only run after push-to-test-pypi successfully executed
+    needs: publish-to-test-pypi
+
+    steps:
+      - name: Remove the test.pypi release tag
+        run: |
+          git tag -d $TAG
+          git push origin --delete $TAG
 
   # Release to PyPI after a RELEASE gets PUBLISHED in @spacetelescope/astrocut/main
   publish-to-pypi:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
     name: Publish to PyPI
 
+    # We only want to upload to PyPI after a new release has been published on the @spacetelescope/astrocut repo
     if: github.repository_owner == 'spacetelescope' && github.event.action == 'published'
     with:
       repository_url: https://pypi.org/legacy/

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
     tags: ["*"]
+  pull_request:
+    branches: [main]
   release:
     types:
       - published
@@ -19,13 +21,14 @@ jobs:
 
     # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
     # I.e. A MERGE has been made into @spacetelescope/astrocut/main
-    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    #if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Make the test.pypi release tag
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           TAG=$(date +'%Y%m%d%H%M%S')
+          echo "new tag made! $TAG"
       - name: Push the tag
         run: git push origin $TAG
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -4,7 +4,7 @@ name: Prep for Astrocut Release on PyPI & TestPyPI
 on:
   push:
     branches: [gh-actions-publish]
-    tags: ["0.10.0dev"]
+    tags: ["v0.10.0dev"]
   pull_request:
     branches: [main]
   release:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -1,5 +1,5 @@
 ---
-name: Prep for Astrocut Release on PyPI/TestPyPI
+name: Prep for Astrocut Release on PyPI & TestPyPI
 
 on:
   push:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -36,6 +36,7 @@ jobs:
           git tag $TAG
           echo "new tag made! $TAG"
           git push origin $TAG
+          echo ${{ github.ref }}
 
   # Release to Test PyPI
   publish-to-test-pypi:
@@ -48,8 +49,6 @@ jobs:
       repository_url: https://test.pypi.org/legacy/
       # Let's use the tag we generated wtih make_and_push_tag
       upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/') }}
-    secrets:
-      pypi_token: ${{ secrets.pypi_token }}
 
   # Remove the tag and push that deletion to main
   delete_tag:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -39,7 +39,7 @@ jobs:
 
   # Release to Test PyPI
   publish-to-test-pypi:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     name: Publish to Test PyPI
     needs: make_and_push_tag
 
@@ -64,7 +64,7 @@ jobs:
 
   # Release to PyPI after a RELEASE gets PUBLISHED in @spacetelescope/astrocut/main
   publish-to-pypi:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     name: Publish to PyPI
 
     # We only want to upload to PyPI after a new release has been published on the @spacetelescope/astrocut repo

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -33,7 +33,7 @@ jobs:
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
     environment: release-test-pypi
-    if: github.event_name == 'pull_request'
+    if: github.repository_owner == 'spacetelescope' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: build-package
 
@@ -46,6 +46,8 @@ jobs:
 
       - name: Upload package to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
 
   # Upload to real PyPI on GitHub Releases.
   release-pypi:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -47,7 +47,7 @@ jobs:
       # We DON'T want to upload to the official PyPI for this job
       repository_url: https://test.pypi.org/legacy/
       # Let's use the tag we generated wtih make_and_push_tag
-      upload_to_pypi: refs/tags/$TAG
+      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/') }}
 
   # Remove the tag and push that deletion to main
   delete_tag:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -11,9 +11,6 @@ on:
 
 jobs:
 
-  # Release to Test PyPI after every MERGE into @spacetelescope/astrocut/main
-  # TODO: Make it so that this only executes when publish-to-test-pypi executes
-  # TODO: Make it so that the tag gets deleted after publish-to-test-pypi finishes executing
   make_tag:
     runs-on: ubuntu-latest
 
@@ -21,6 +18,9 @@ jobs:
     - name: Make a release tag
       run: git tag -a v0.10.0dev -m "dev release"
 
+  # Release to Test PyPI after every MERGE into @spacetelescope/astrocut/main
+  # TODO: Make it so that this only executes when publish-to-test-pypi executes
+  # TODO: Make it so that the tag gets deleted after publish-to-test-pypi finishes executing    
   publish-to-test-pypi:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
     name: Publish to Test PyPI
@@ -29,7 +29,6 @@ jobs:
     if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     with:
       # We DON'T want to upload to the official PyPI for this job
-      upload_to_pypi: false
       repository_url: https://test.pypi.org/legacy/
 
   # Release to PyPI after a RELEASE gets PUBLISHED in @spacetelescope/astrocut/main

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -31,6 +31,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           TAG=$(date +'%Y%m%d%H%M%S')
+          git tag $TAG
           echo "new tag made! $TAG"
           git push origin $TAG
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -47,7 +47,7 @@ jobs:
       # We DON'T want to upload to the official PyPI for this job
       repository_url: https://test.pypi.org/legacy/
       # Let's use the tag we generated wtih make_and_push_tag
-      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/$TAG') }}
+      upload_to_pypi: refs/tags/$TAG
 
   # Remove the tag and push that deletion to main
   delete_tag:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -21,4 +21,4 @@ jobs:
       test_extras: test
       test_command: pytest --pyargs astrocut
     secrets:
-      pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
+      pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags: 
     - "v*"
-    - '!*dev*'
-    - '!*pre*'
-    - '!*post*'
 
 permissions:
   contents: read

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -62,7 +62,10 @@ jobs:
         with:
           fetch-depth: 5
       - name: Remove the test.pypi release tag
-        run: git push origin --delete $TAG
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git push origin --delete $TAG
 
   # Release to PyPI after a RELEASE gets PUBLISHED in @spacetelescope/astrocut/main
   publish-to-pypi:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -4,7 +4,7 @@ name: Build & maybe upload PyPI package
 on:
   push:
     branches: [main]
-    tags: ["*"]
+    tags: ["0.9"]
   pull_request:
     branches: [main]
   release:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -11,8 +11,9 @@ on:
       - published
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -2,7 +2,11 @@ name: Building & Publishing
 
 on:
   push:
-    tags: ["v*"]
+    tags: 
+    - "v*"
+    - '!*dev*'
+    - '!*pre*'
+    - '!*post*'
 
 permissions:
   contents: read
@@ -19,4 +23,4 @@ jobs:
     if: github.repository_owner == 'spacetelescope' && github.event_name == 'push'
     with:
       test_extras: test
-      test_command: pytest astrocut/tests/test*.py
+      test_command: pytest -p no:warngings astrocut/tests/test*.py

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -21,3 +21,5 @@ jobs:
     with:
       test_extras: test
       test_command: pytest astrocut/tests/test*.py
+    secrets:
+      pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -22,7 +22,7 @@ jobs:
 
     # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
     # I.e. A MERGE has been made into @spacetelescope/astrocut/main
-    # if : github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Git checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -73,4 +73,3 @@ jobs:
     if: github.repository_owner == 'spacetelescope' && github.event.action == 'published'
     with:
       repository_url: https://pypi.org/legacy/
-      upload_to_pypi: /refs/tags/v

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -22,6 +22,10 @@ jobs:
     # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
     # I.e. A MERGE has been made into @spacetelescope/astrocut/main
     steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Make the test.pypi release tag
         run: |
           git config user.name "GitHub Actions"

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -2,8 +2,7 @@ name: Building & Publishing
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     tags: ["*"]
   release:
     types:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -4,7 +4,7 @@ name: Build & maybe upload PyPI package
 on:
   push:
     branches: [main]
-    tags: ["0.9"]
+    tags: ["*"]
   pull_request:
     branches: [main]
   release:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -47,7 +47,7 @@ jobs:
       # We DON'T want to upload to the official PyPI for this job
       repository_url: https://test.pypi.org/legacy/
       # Let's use the tag we generated wtih make_and_push_tag
-      upload_to_pypi: refs/tags/$TAG
+      upload_to_pypi: true
 
   # Remove the tag and push that deletion to main
   delete_tag:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -24,12 +24,10 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'
       - name: Make the test.pypi release tag
         run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           TAG=$(date +'%Y%m%d%H%M%S')
           echo "new tag made! $TAG"
       - name: Push the tag

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -61,6 +61,8 @@ jobs:
         with:
           delete_release: false
           tag_name: $TAG
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Release to PyPI after a RELEASE gets PUBLISHED in @spacetelescope/astrocut/main
   publish-to-pypi:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -30,8 +30,7 @@ jobs:
           git config user.email github-actions@github.com
           TAG=$(date +'%Y%m%d%H%M%S')
           echo "new tag made! $TAG"
-      - name: Push the tag
-        run: git push origin $TAG
+          git push origin $TAG
 
   # Release to Test PyPI
   publish-to-test-pypi:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -62,9 +62,7 @@ jobs:
         with:
           fetch-depth: 5
       - name: Remove the test.pypi release tag
-        run: |
-          git tag -d $TAG
-          git push origin --delete $TAG
+        run: git push origin --delete $TAG
 
   # Release to PyPI after a RELEASE gets PUBLISHED in @spacetelescope/astrocut/main
   publish-to-pypi:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -3,7 +3,7 @@ name: Building & Publishing
 on:
   push:
     branches: [main]
-    tags: ["*"]
+    tags: ["v*"]
 
 permissions:
   contents: read

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -33,7 +33,7 @@ jobs:
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
     environment: release-test-pypi
-    if: github.repository_owner == 'spacetelescope' && github.event_name == 'pull_request'
+    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: build-package
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -3,8 +3,8 @@ name: Prep for Astrocut Release on PyPI & TestPyPI
 
 on:
   push:
-    branches: [gh-actions-publish]
-    tags: ["v0.10.0dev"]
+    branches: [main]
+    tags: ["*"]
   pull_request:
     branches: [main]
   release:
@@ -33,7 +33,7 @@ jobs:
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
     environment: release-test-pypi
-    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push'
+    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build-package
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -4,67 +4,12 @@ on:
   push:
     branches: [main]
     tags: ["*"]
-  pull_request:
-    branches: [main]
-  release:
-    types:
-      - published
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
-  pull-requests: write
 
 jobs:
-
-  make_and_push_tag:
-    runs-on: ubuntu-latest
-
-    # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
-    # I.e. A MERGE has been made into @spacetelescope/astrocut/main
-    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 5
-      - name: Make the test.pypi release tag
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          TAG=$(date + '%Y%m%d%H%M%S' + '.dev')
-          git tag $TAG
-          echo "New tag made! $TAG"
-          git push origin $TAG
-          echo "Github ref:"
-          echo ${{ github.ref }}
-
-  # Release to Test PyPI
-  publish-to-test-pypi:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
-    name: Publish to Test PyPI
-    needs: make_and_push_tag
-
-    with:
-      # We DON'T want to upload to the official PyPI for this job
-      repository_url: https://test.pypi.org/legacy/
-      # Let's use the tag we generated wtih make_and_push_tag
-      upload_to_pypi: 'refs/tags/$TAG'
-
-  # Remove the tag and push that deletion to main
-  delete_tag:
-    runs-on: ubuntu-latest
-    # Runs the job consecutively after publish-to-test-pypi...
-    needs: publish-to-test-pypi
-    # ...even if it fails
-    if: always()
-    steps:
-      - uses: ClementTsang/delete-tag-and-release@v0.3.1
-        with:
-          delete_release: false
-          tag_name: $TAG
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Release to PyPI after a RELEASE gets PUBLISHED in @spacetelescope/astrocut/main
   publish-to-pypi:
@@ -72,6 +17,7 @@ jobs:
     name: Publish to PyPI
 
     # We only want to upload to PyPI after a new release has been published on the @spacetelescope/astrocut repo
-    if: github.repository_owner == 'spacetelescope' && github.event.action == 'published'
+    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push'
     with:
-      repository_url: https://pypi.org/legacy/
+      test_extras: test, all
+      test_command: pytest astrocut/test*.py

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+          git fetch --tags
           git push origin --delete $TAG
 
   # Release to PyPI after a RELEASE gets PUBLISHED in @spacetelescope/astrocut/main

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Make a release tag
-      run: git tag -a v0.10.0dev -m "dev release"
+      run: echo "test"
 
   # Release to Test PyPI after every MERGE into @spacetelescope/astrocut/main    
   publish-to-test-pypi:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -1,69 +1,42 @@
----
-name: Prep for Astrocut Release on PyPI & TestPyPI
+name: Building & Publishing
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
     tags: ["*"]
-  pull_request:
-    branches: [main]
   release:
     types:
       - published
-  workflow_dispatch:
-
-permissions:
-  contents: read
-  id-token: write
 
 jobs:
-  # Always build & lint package.
-  build-package:
-    name: Build & verify package
+
+  # Release to Test PyPI after every MERGE into @spacetelescope/astrocut/main
+  # TODO: Make it so that this only executes when publish-to-test-pypi executes
+  # TODO: Make it so that the tag gets deleted after publish-to-test-pypi finishes executing
+  make_tag:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - name: Make a release tag
+      run: git tag -a v0.10.0dev -m "dev release"
 
-      - uses: hynek/build-and-inspect-python-package@v1
+  publish-to-test-pypi:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    name: Publish to Test PyPI
+    needs: make_tag
 
-  # Upload to Test PyPI on every commit on main.
-  release-test-pypi:
-    name: Publish in-dev package to test.pypi.org
-    environment: release-test-pypi
     if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    needs: build-package
+    with:
+      # We DON'T want to upload to the official PyPI for this job
+      upload_to_pypi: false
+      repository_url: https://test.pypi.org/legacy/
 
-    steps:
-      - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v3
-        with:
-          name: Packages
-          path: dist
+  # Release to PyPI after a RELEASE gets PUBLISHED in @spacetelescope/astrocut/main
+  publish-to-pypi:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    name: Publish to PyPI
 
-      - name: Upload package to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: True
-
-  # Upload to real PyPI on GitHub Releases.
-  release-pypi:
-    name: Publish released package to pypi.org
-    environment: release-pypi
     if: github.repository_owner == 'spacetelescope' && github.event.action == 'published'
-    runs-on: ubuntu-latest
-    needs: build-package
-
-    steps:
-      - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v3
-        with:
-          name: Packages
-          path: dist
-
-      - name: Upload package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+    with:
+      repository_url: https://pypi.org/legacy/

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -19,6 +19,6 @@ jobs:
     if: github.repository_owner == 'spacetelescope' && github.event_name == 'push'
     with:
       test_extras: test
-      test_command: pytest astrocut/tests/test*.py
+      test_command: pytest astrocut
     secrets:
       pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -1,5 +1,5 @@
 ---
-name: Build & maybe upload PyPI package
+name: Prep for Astrocut Release on PyPI/TestPyPI
 
 on:
   push:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -3,8 +3,8 @@ name: Prep for Astrocut Release on PyPI & TestPyPI
 
 on:
   push:
-    branches: [main]
-    tags: ["*"]
+    branches: [gh-actions-publish]
+    tags: ["0.10.0dev"]
   pull_request:
     branches: [main]
   release:
@@ -33,7 +33,7 @@ jobs:
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
     environment: release-test-pypi
-    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.repository_owner == 'spacetelescope' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: build-package
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -2,7 +2,6 @@ name: Building & Publishing
 
 on:
   push:
-    branches: [main]
     tags: ["v*"]
 
 permissions:
@@ -19,5 +18,5 @@ jobs:
     # We only want to upload to PyPI after a new release has been published on the @spacetelescope/astrocut repo
     if: github.repository_owner == 'spacetelescope' && github.event_name == 'push'
     with:
-      test_extras: test, all
-      test_command: pytest astrocut/test*.py
+      test_extras: test
+      test_command: pytest astrocut/tests/test*.py

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -57,16 +57,10 @@ jobs:
     # ...even if it fails
     if: always()
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v3
+      - uses: ClementTsang/delete-tag-and-release@v0.3.1
         with:
-          fetch-depth: 5
-      - name: Remove the test.pypi release tag
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git fetch --tags
-          git push origin --delete $TAG
+          delete_release: false
+          tag_name: $TAG
 
   # Release to PyPI after a RELEASE gets PUBLISHED in @spacetelescope/astrocut/main
   publish-to-pypi:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -21,7 +21,6 @@ jobs:
 
     # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
     # I.e. A MERGE has been made into @spacetelescope/astrocut/main
-    #if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Make the test.pypi release tag
         run: |

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -48,7 +48,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip_existing: True
+          skip-existing: True
 
   # Upload to real PyPI on GitHub Releases.
   release-pypi:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -48,6 +48,8 @@ jobs:
       repository_url: https://test.pypi.org/legacy/
       # Let's use the tag we generated wtih make_and_push_tag
       upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/') }}
+    secrets:
+      pypi_token: ${{ secrets.pypi_token }}
 
   # Remove the tag and push that deletion to main
   delete_tag:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -52,11 +52,15 @@ jobs:
   # Remove the tag and push that deletion to main
   delete_tag:
     runs-on: ubuntu-latest
-    # This should only run after push-to-test-pypi successfully executed
+    # Runs the job consecutively after publish-to-test-pypi...
     needs: publish-to-test-pypi
-    # Runs the job consecutively after publish-to-test-pypi, even if it fails
+    # ...even if it fails
     if: always()
     steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
       - name: Remove the test.pypi release tag
         run: |
           git tag -d $TAG

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -47,7 +47,7 @@ jobs:
       # We DON'T want to upload to the official PyPI for this job
       repository_url: https://test.pypi.org/legacy/
       # Let's use the tag we generated wtih make_and_push_tag
-      upload_to_pypi: refs/tags/$TAG
+      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/$TAG') }}
 
   # Remove the tag and push that deletion to main
   delete_tag:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -47,7 +47,7 @@ jobs:
       # We DON'T want to upload to the official PyPI for this job
       repository_url: https://test.pypi.org/legacy/
       # Let's use the tag we generated wtih make_and_push_tag
-      upload_to_pypi: true
+      upload_to_pypi: refs/tags/$TAG
 
   # Remove the tag and push that deletion to main
   delete_tag:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -47,7 +47,7 @@ jobs:
       # We DON'T want to upload to the official PyPI for this job
       repository_url: https://test.pypi.org/legacy/
       # Let's use the tag we generated wtih make_and_push_tag
-      upload_to_pypi: $TAG
+      upload_to_pypi: refs/tags/$TAG
 
   # Remove the tag and push that deletion to main
   delete_tag:
@@ -73,3 +73,4 @@ jobs:
     if: github.repository_owner == 'spacetelescope' && github.event.action == 'published'
     with:
       repository_url: https://pypi.org/legacy/
+      upload_to_pypi: /refs/tags/v

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -22,6 +22,7 @@ jobs:
 
     # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
     # I.e. A MERGE has been made into @spacetelescope/astrocut/main
+    # if : github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -53,7 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     # This should only run after push-to-test-pypi successfully executed
     needs: publish-to-test-pypi
-
+    # Runs the job consecutively after publish-to-test-pypi, even if it fails
+    if: always()
     steps:
       - name: Remove the test.pypi release tag
         run: |

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -30,7 +30,10 @@ jobs:
           git config user.email github-actions@github.com
           TAG=$(date +'%Y%m%d%H%M%S')
           echo "new tag made! $TAG"
-          git push origin $TAG
+      - name: Push tag
+        uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: $TAG
 
   # Release to Test PyPI
   publish-to-test-pypi:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -24,16 +24,15 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
       - name: Make the test.pypi release tag
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           TAG=$(date +'%Y%m%d%H%M%S')
           echo "new tag made! $TAG"
-      - name: Push tag
-        uses: actions-ecosystem/action-push-tag@v1
-        with:
-          tag: $TAG
+          git push origin $TAG
 
   # Release to Test PyPI
   publish-to-test-pypi:

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Developer Documentation
 -----------------------
 
 Installation
-^^^^^^^^^^^^
+============
 
 .. code-block:: bash
 
@@ -53,7 +53,7 @@ For active developement intall in develop mode
     $ pip install -e .
     
 Testing
-^^^^^^^
+=======
 Testing is now run with `tox <https://tox.readthedocs.io>`_ (``pip install tox``).
 Tests can be found in ``astrocut/tests/``.
 
@@ -69,7 +69,7 @@ Tests can also be run directly with pytest:
     $ pytest
     
 Documentation
-^^^^^^^^^^^^^
+=============
 Documentation files are found in ``docs/``.
 
 We now build the documentation with `tox <https://tox.readthedocs.io>`_ (``pip install tox``):
@@ -90,9 +90,19 @@ The built docs will be in ``docs/_build/html/``, to view them go to ``file:///pa
     
 
 Release Protocol
-^^^^^^^^^^^^^^^^
+================
 
-Follow the `Astropy template release instructions <https://docs.astropy.org/en/latest/development/astropy-package-template.html>`_. 
+GitHub Action Releases
+^^^^^^^^^^^^^^^^^^
+
+The `pypi-package.yml` GitHub workflow is built to make a package release off the latest commit hash in `main`. The job in this workflow is triggered when a
+release tag is generated and pushed to `main`, and uses `OpenAstronomy`'s `GitHub action workflow <https://github.com/OpenAstronomy/github-actions-workflows>`_
+for publishing pure Python packages (`see here <https://github-actions-workflows.openastronomy.org/en/stable/publish_pure_python.html>`_ for documentation).
+
+Manual Releases
+^^^^^^^^^^^^^^^
+
+For making releases manually, follow the `Astropy template release instructions <https://docs.astropy.org/en/latest/development/astropy-package-template.html>`_. 
 
 *Requirements:*
 

--- a/README.rst
+++ b/README.rst
@@ -95,8 +95,7 @@ Release Protocol
 GitHub Action Releases
 ^^^^^^^^^^^^^^^^^^
 
-The `pypi-package.yml` GitHub workflow is built to make a package release off the latest commit hash in `main`. The job in this workflow is triggered when a
-release tag is generated and pushed to `main`, and uses `OpenAstronomy`'s `GitHub action workflow <https://github.com/OpenAstronomy/github-actions-workflows>`_
+The `pypi-package.yml <.github/workflows/pypi-package.yml>`_ GitHub workflow creates a PyPI release. The job in this workflow is triggered when a tag is pushed or a GH release (+tag) is created, and uses `OpenAstronomy`'s `GitHub action workflow <https://github.com/OpenAstronomy/github-actions-workflows>`_
 for publishing pure Python packages (`see here <https://github-actions-workflows.openastronomy.org/en/stable/publish_pure_python.html>`_ for documentation).
 
 Manual Releases

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if 'build_docs' in sys.argv or 'build_sphinx' in sys.argv:
     sys.exit(1)
 
 VERSION_TEMPLATE = """
-# Note that we need to fall back to the hard-coded version if either
+# Note that we need to fall back to the hard-coded version if eitherr
 # setuptools_scm can't be imported or setuptools_scm can't determine the
 # version, so we catch the generic 'Exception'.
 try:

--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,13 @@ VERSION_TEMPLATE = """
 # Note that we need to fall back to the hard-coded version if either
 # setuptools_scm can't be imported or setuptools_scm can't determine the
 # version, so we catch the generic 'Exception'.
+
+# We run ``.split("+")[0]`` to catch cases where a local-version segment
+# (e.g. ``+g40d0d7c``) is found when getting the version number, which 
+# is not compliant with PEP 440 (see more here: https://packaging.python.org/specifications/core-metadata)
 try:
     from setuptools_scm import get_version
-    version = get_version(root='..', relative_to=__file__)
+    version = get_version(root='..', relative_to=__file__).split("+")[0]
 except Exception:
     version = '{version}'
 """.lstrip()

--- a/setup.py
+++ b/setup.py
@@ -67,13 +67,9 @@ VERSION_TEMPLATE = """
 # Note that we need to fall back to the hard-coded version if either
 # setuptools_scm can't be imported or setuptools_scm can't determine the
 # version, so we catch the generic 'Exception'.
-
-# We run ``.split("+")[0]`` to catch cases where a local-version segment
-# (e.g. ``+g40d0d7c``) is found when getting the version number, which 
-# is not compliant with PEP 440 (see more here: https://packaging.python.org/specifications/core-metadata)
 try:
     from setuptools_scm import get_version
-    version = get_version(root='..', relative_to=__file__).split("+")[0]
+    version = get_version(root='..', relative_to=__file__)
 except Exception:
     version = '{version}'
 """.lstrip()

--- a/setup.py
+++ b/setup.py
@@ -83,4 +83,4 @@ def read_file(*parts):
 setup(use_scm_version={'write_to': os.path.join('astrocut', 'version.py'),
                        'write_to_template': VERSION_TEMPLATE},
      long_description=read_file('README.rst'),
-     long_description_content_type='text/markdown')
+     long_description_content_type='text/x-rst')

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if 'build_docs' in sys.argv or 'build_sphinx' in sys.argv:
     sys.exit(1)
 
 VERSION_TEMPLATE = """
-# Note that we need to fall back to the hard-coded version if eitherr
+# Note that we need to fall back to the hard-coded version if either
 # setuptools_scm can't be imported or setuptools_scm can't determine the
 # version, so we catch the generic 'Exception'.
 try:


### PR DESCRIPTION
Created a GitHub workflow to build wheels, test package, and publish package to the official PyPI, all triggered by the creation and push of a new tag on @spacetelescope/astrocut.