### PR TITLE
Add Test PyPI action to GitHub Publishing Workflow

### DIFF
--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -15,9 +15,8 @@ jobs:
         # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
         # I.e. A MERGE has been made into @spacetelescope/astrocut/main
         steps:
-            - uses: actions/setup-python@v2
-            - uses: actions/checkout@v3
             - name: Git checkout
+              uses: actions/checkout@v3
               with:
                   fetch-depth: 0
             - name: Make the test.pypi release tag
@@ -25,6 +24,7 @@ jobs:
                   git config user.name github-actions
                   git config user.email github-actions@github.com
                   git tag v0.10.0.dev3
+            - uses: actions/setup-python@v2
             - name: Install dependencies
               run: |
                 python -m pip install --upgrade pip

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -3,60 +3,37 @@ name: Building & Publishing to Test PyPI
     
 on:
     push:
-      branches: [main]
-      tags: ["*"]
+      branches: ["*"]
 
 permissions:
   contents: read
-  id-token: write
-  pull-requests: write
 
 jobs:
-    make_and_push_tag:
-    runs-on: ubuntu-latest
-
-    # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
-    # I.e. A MERGE has been made into @spacetelescope/astrocut/main
-    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-        - name: Git checkout
-        uses: actions/checkout@v3
-        with:
-            fetch-depth: 5
-        - name: Make the test.pypi release tag
-        run: |
-            git config user.name github-actions
-            git config user.email github-actions@github.com
-            TAG=$(date + '%Y%m%d%H%M%S' + '.dev')
-            git tag $TAG
-            echo "New tag made! $TAG"
-            git push origin $TAG
-            echo "Github ref:"
-            echo ${{ github.ref }}
+    make_tag:
+        runs-on: ubuntu-latest
+    
+        # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
+        # I.e. A MERGE has been made into @spacetelescope/astrocut/main
+        steps:
+            - name: Git checkout
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+            - name: Make the test.pypi release tag
+              run: |
+                  git config user.name github-actions
+                  git config user.email github-actions@github.com
+                  TAG=$(date + '%Y%m%d%H%M%S' + '.dev')
+                  git tag $TAG
 
     # Release to Test PyPI
     publish-to-test-pypi:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
-    name: Publish to Test PyPI
-    needs: make_and_push_tag
-
-    with:
-        # We DON'T want to upload to the official PyPI for this job
-        repository_url: https://test.pypi.org/legacy/
-        # Let's use the tag we generated wtih make_and_push_tag
-        upload_to_pypi: 'refs/tags/$TAG'
-
-    # Remove the tag and push that deletion to main
-    delete_tag:
-    runs-on: ubuntu-latest
-    # Runs the job consecutively after publish-to-test-pypi...
-    needs: publish-to-test-pypi
-    # ...even if it fails
-    if: always()
-    steps:
-        - uses: ClementTsang/delete-tag-and-release@v0.3.1
+        uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
+        name: Publish to Test PyPI
+        needs: make_tag
+    
         with:
-            delete_release: false
-            tag_name: $TAG
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            # We DON'T want to upload to the official PyPI for this job
+            repository_url: https://test.pypi.org/legacy/
+        secrets:
+            pypi_token: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -16,7 +16,7 @@ jobs:
     
         # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
         # I.e. A MERGE has been made into @spacetelescope/astrocut/main
-        if: github.event.pull_request.labels.*.name == 'publish-to-test' || (github.repository_owner == 'spacetelescope' && github.event_name == 'push')
+        if: contains(github.event.pull_request.labels.*.name, 'publish-to-test') || (github.repository_owner == 'spacetelescope' && github.event_name == 'push')
         steps:
             - name: Git checkout
               uses: actions/checkout@v3

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -16,7 +16,7 @@ jobs:
     
         # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
         # I.e. A MERGE has been made into @spacetelescope/astrocut/main
-        if: ${{ (github.event.label.name == 'publish-to-test') || (github.repository_owner == 'spacetelescope' && github.event_name == 'push'}}
+        if: ${{ (github.event.pull_request.labels.*.name == 'publish-to-test') || (github.repository_owner == 'spacetelescope' && github.event_name == 'push'}}
         steps:
             - name: Git checkout
               uses: actions/checkout@v3

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -26,7 +26,8 @@ jobs:
               run: |
                   git config user.name github-actions
                   git config user.email github-actions@github.com
-                  git tag v0.10.0.dev4
+                  TAG=$(date +v'%Y%m%d.%H%M%S'.dev)
+                  git tag $TAG
             - uses: actions/setup-python@v2
             - name: Install dependencies
               run: |

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -23,7 +23,7 @@ jobs:
               run: |
                   git config user.name github-actions
                   git config user.email github-actions@github.com
-                  TAG=$(date + '%Y%m%d%H%M%S' + '.dev')
+                  TAG=$(date + '%Y%m%d%H%M%S')
                   git tag $TAG
 
     # Release to Test PyPI

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -24,15 +24,15 @@ jobs:
                   git config user.name github-actions
                   git config user.email github-actions@github.com
                   git tag v0.10.0.dev2
-
-    # Release to Test PyPI
-    publish-to-test-pypi:
-        uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
-        name: Publish to Test PyPI
-        needs: make_tag
-    
-        with:
-            # We DON'T want to upload to the official PyPI for this job
-            repository_url: https://test.pypi.org/legacy/
-        secrets:
-            pypi_token: ${{ secrets.TEST_PYPI_TOKEN }}
+            - uses: actions/setup-python@v2
+            - name: Install dependencies
+              run: |
+                python -m pip install --upgrade pip
+                pip install setuptools wheel twine
+            - name: Build and publish
+              env:
+                TWINE_USERNAME: __token__
+                TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+              run: |
+                python setup.py sdist bdist_wheel
+                twine upload dist/*

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -1,0 +1,62 @@
+---
+name: Building & Publishing to Test PyPI
+    
+on:
+    push:
+      branches: [main]
+      tags: ["*"]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+    make_and_push_tag:
+    runs-on: ubuntu-latest
+
+    # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
+    # I.e. A MERGE has been made into @spacetelescope/astrocut/main
+    if: github.repository_owner == 'spacetelescope' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+        - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+            fetch-depth: 5
+        - name: Make the test.pypi release tag
+        run: |
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            TAG=$(date + '%Y%m%d%H%M%S' + '.dev')
+            git tag $TAG
+            echo "New tag made! $TAG"
+            git push origin $TAG
+            echo "Github ref:"
+            echo ${{ github.ref }}
+
+    # Release to Test PyPI
+    publish-to-test-pypi:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
+    name: Publish to Test PyPI
+    needs: make_and_push_tag
+
+    with:
+        # We DON'T want to upload to the official PyPI for this job
+        repository_url: https://test.pypi.org/legacy/
+        # Let's use the tag we generated wtih make_and_push_tag
+        upload_to_pypi: 'refs/tags/$TAG'
+
+    # Remove the tag and push that deletion to main
+    delete_tag:
+    runs-on: ubuntu-latest
+    # Runs the job consecutively after publish-to-test-pypi...
+    needs: publish-to-test-pypi
+    # ...even if it fails
+    if: always()
+    steps:
+        - uses: ClementTsang/delete-tag-and-release@v0.3.1
+        with:
+            delete_release: false
+            tag_name: $TAG
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -35,4 +35,4 @@ jobs:
                 TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
               run: |
                 python setup.py sdist bdist_wheel
-                twine upload dist/*
+                twine upload --repository-url https://test.pypi.org/legacy/ dist/*

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -5,7 +5,7 @@ on:
     push:
       branches: "main"
     pull_request:
-      types: labeled
+      types: [ labeled ]
 
 permissions:
   contents: read

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -24,7 +24,7 @@ jobs:
               run: |
                   git config user.name github-actions
                   git config user.email github-actions@github.com
-                  git tag v0.10.0.dev2
+                  git tag v0.10.0.dev3
             - name: Install dependencies
               run: |
                 python -m pip install --upgrade pip

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -3,7 +3,9 @@ name: Building & Publishing to Test PyPI
     
 on:
     push:
-      branches: ["*"]
+      branches: "main"
+    pull_request:
+      types: labeled
 
 permissions:
   contents: read
@@ -14,6 +16,7 @@ jobs:
     
         # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
         # I.e. A MERGE has been made into @spacetelescope/astrocut/main
+        if: ${{ (github.event.label.name == 'publish-to-test') || (github.repository_owner == 'spacetelescope' && github.event_name == 'push'}}
         steps:
             - name: Git checkout
               uses: actions/checkout@v3

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: read
 
 jobs:
     make_tag:

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -26,7 +26,7 @@ jobs:
               run: |
                   git config user.name github-actions
                   git config user.email github-actions@github.com
-                  git tag v0.10.0.dev3
+                  git tag v0.10.0.dev4
             - uses: actions/setup-python@v2
             - name: Install dependencies
               run: |

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -16,7 +16,7 @@ jobs:
     
         # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
         # I.e. A MERGE has been made into @spacetelescope/astrocut/main
-        if: (github.event.pull_request.labels.*.name == 'publish-to-test' || (github.repository_owner == 'spacetelescope' && github.event_name == 'push'))
+        if: github.event.pull_request.labels.*.name == 'publish-to-test' || (github.repository_owner == 'spacetelescope' && github.event_name == 'push')
         steps:
             - name: Git checkout
               uses: actions/checkout@v3

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  id-token: read
 
 jobs:
     make_tag:
@@ -24,8 +23,7 @@ jobs:
               run: |
                   git config user.name github-actions
                   git config user.email github-actions@github.com
-                  TAG=$(date + '%Y%m%d%H%M%S')
-                  git tag $TAG
+                  git tag v0.10.0.dev2
 
     # Release to Test PyPI
     publish-to-test-pypi:

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -9,14 +9,15 @@ permissions:
   contents: read
 
 jobs:
-    make_tag:
+    make_tag_and_publish:
         runs-on: ubuntu-latest
     
         # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
         # I.e. A MERGE has been made into @spacetelescope/astrocut/main
         steps:
+            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v3
             - name: Git checkout
-              uses: actions/checkout@v3
               with:
                   fetch-depth: 0
             - name: Make the test.pypi release tag
@@ -24,7 +25,6 @@ jobs:
                   git config user.name github-actions
                   git config user.email github-actions@github.com
                   git tag v0.10.0.dev2
-            - uses: actions/setup-python@v2
             - name: Install dependencies
               run: |
                 python -m pip install --upgrade pip

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -16,7 +16,7 @@ jobs:
     
         # We want a new tag to be made ONLY if we are ready to release to Test PyPI.
         # I.e. A MERGE has been made into @spacetelescope/astrocut/main
-        if: ${{ (github.event.pull_request.labels.*.name == 'publish-to-test') || (github.repository_owner == 'spacetelescope' && github.event_name == 'push'}}
+        if: (github.event.pull_request.labels.*.name == 'publish-to-test' || (github.repository_owner == 'spacetelescope' && github.event_name == 'push'))
         steps:
             - name: Git checkout
               uses: actions/checkout@v3


### PR DESCRIPTION
Closes #102

- [x] Successful upload to Test PyPI with Twine instead of OpenAstronomy action
- [x] Trigger run after being labeled `publish-to-test`
- [ ] Incrementally increase version number based on what already exists in Test PyPI
