### PR TITLE
CI job to check for changelog update

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,0 +1,21 @@
+name: Changelog check
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changelog:
+    name: Check changelog entry
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check change log entry
+      uses: scientific-python/action-check-changelogfile@064f2005176e1622e7c2bd9776140406609097d1
+      env:
+        CHANGELOG_FILENAME: CHANGES.rst
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CHECK_MILESTONE: false


### PR DESCRIPTION
A GitHub Actions workflow to check if a new changelog entry has been made for the requested changes. Building this workflow off of https://github.com/astropy/astroquery/blob/main/.github/workflows/changelog.yml

Ensure this job only fails when a changelog entry isn't added for a new feature (unit tests/documentation updates don't need changelog entries).