### PR TITLE
drop python 3.8 support

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - name: Python 3.8 with minimal dependencies
+          - name: Python 3.9 with minimal dependencies
             os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-test
+            python: 3.9
+            toxenv: py39-test
 
           - name: Python 3.9 with all optional dependencies
             os: ubuntu-latest

--- a/astrocut/__init__.py
+++ b/astrocut/__init__.py
@@ -10,7 +10,7 @@ from ._astropy_init import *  # noqa
 # This is the same check as the one at the top of setup.py
 import sys
 
-__minimum_python_version__ = "3.8"
+__minimum_python_version__ = "3.9"
 
 
 class UnsupportedPythonError(Exception):

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ github_project = spacetelescope/astrocut
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires = setuptools_scm
 install_requires =
     astropy>=5.2 # astropy with s3fs support


### PR DESCRIPTION
asdf dependencies don't allow 3.8 (see PR: https://github.com/spacetelescope/astrocut/pull/105)

we can drop 3.8 (and probably should, since astropy has also dropped 3.8 for newer releases)
