### PR TITLE
Handle an s3 URI in asdf_cut()

### DIFF
--- a/astrocut/asdf_cutouts.py
+++ b/astrocut/asdf_cutouts.py
@@ -250,7 +250,7 @@ def asdf_cut(input_file: str, ra: float, dec: float, cutout_size: int = 20,
 
     # if file comes from AWS cloud bucket, get URL
     file = input_file
-    if input_file.startswith('s3://'):
+    if isinstance(input_file, str) and input_file.startswith('s3://'):
         fs = s3fs.S3FileSystem()
         with fs.open(input_file, 'rb') as f:
             file = f.url()

--- a/astrocut/asdf_cutouts.py
+++ b/astrocut/asdf_cutouts.py
@@ -9,6 +9,7 @@ import asdf
 import astropy
 import gwcs
 import numpy as np
+import s3fs
 
 from astropy.coordinates import SkyCoord
 from astropy.modeling import models
@@ -247,8 +248,15 @@ def asdf_cut(input_file: str, ra: float, dec: float, cutout_size: int = 20,
         an image cutout object
     """
 
+    # if file comes from AWS cloud bucket, get URL
+    file = input_file
+    if input_file.startswith('s3://'):
+        fs = s3fs.S3FileSystem()
+        with fs.open(input_file, 'rb') as f:
+            file = f.url()
+
     # get the 2d image data
-    with asdf.open(input_file) as f:
+    with asdf.open(file) as f:
         data = f['roman']['data']
         gwcsobj = f['roman']['meta']['wcs']
 

--- a/astrocut/asdf_cutouts.py
+++ b/astrocut/asdf_cutouts.py
@@ -15,6 +15,22 @@ from astropy.coordinates import SkyCoord
 from astropy.modeling import models
 
 
+def _get_cloud_http(s3_uri: str) -> str:
+    """ Get the HTTP URI of a cloud resource from an S3 URI
+
+    Parameters
+    ----------
+    s3_uri : string
+        the S3 URI of the cloud resource
+    """
+    # create file system
+    fs = s3fs.S3FileSystem(anon=True)
+
+    # open resource and get URL
+    with fs.open(s3_uri, 'rb') as f:
+        return f.url()
+
+
 def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> tuple:
     """ Get the center pixel from a roman 2d science image
 
@@ -248,12 +264,10 @@ def asdf_cut(input_file: str, ra: float, dec: float, cutout_size: int = 20,
         an image cutout object
     """
 
-    # if file comes from AWS cloud bucket, get URL
+    # if file comes from AWS cloud bucket, get HTTP URL to open with asdf
     file = input_file
     if isinstance(input_file, str) and input_file.startswith('s3://'):
-        fs = s3fs.S3FileSystem()
-        with fs.open(input_file, 'rb') as f:
-            file = f.url()
+        file = _get_cloud_http(input_file)
 
     # get the 2d image data
     with asdf.open(file) as f:

--- a/astrocut/tests/test_asdf_cut.py
+++ b/astrocut/tests/test_asdf_cut.py
@@ -332,3 +332,4 @@ def test_get_cloud_http(mock_s3fs):
     mock_s3fs.assert_called_once_with(anon=True)
     mock_fs.open.assert_called_once_with(s3_uri, 'rb')
     mock_file.url.assert_called_once()
+    

--- a/astrocut/tests/test_asdf_cut.py
+++ b/astrocut/tests/test_asdf_cut.py
@@ -332,4 +332,3 @@ def test_get_cloud_http(mock_s3fs):
     mock_s3fs.assert_called_once_with(anon=True)
     mock_fs.open.assert_called_once_with(s3_uri, 'rb')
     mock_file.url.assert_called_once()
-    

--- a/astrocut/tests/test_make_cube.py
+++ b/astrocut/tests/test_make_cube.py
@@ -38,14 +38,14 @@ def test_make_cube(tmpdir):
         ecube[:, :, i, 0] = -plane
         ecube[:, :, i, 1] = plane
         plane += img_sz*img_sz
-    assert np.alltrue(cube == ecube), "Cube values do not match expected values"
+    assert np.all(cube == ecube), "Cube values do not match expected values"
     
     tab = Table(hdu[2].data)
-    assert np.alltrue(tab['TSTART'] == np.arange(num_im)), "TSTART mismatch in table"
-    assert np.alltrue(tab['TSTOP'] == np.arange(num_im)+1), "TSTOP mismatch in table"
+    assert np.all(tab['TSTART'] == np.arange(num_im)), "TSTART mismatch in table"
+    assert np.all(tab['TSTOP'] == np.arange(num_im)+1), "TSTOP mismatch in table"
 
     filenames = np.array([path.split(x)[1] for x in ffi_files])
-    assert np.alltrue(tab['FFI_FILE'] == np.array(filenames)), "FFI_FILE mismatch in table"
+    assert np.all(tab['FFI_FILE'] == np.array(filenames)), "FFI_FILE mismatch in table"
 
     hdu.close()
     
@@ -86,7 +86,7 @@ def test_make_and_update_cube(tmpdir):
         # ecube[:, :, i, 1] = plane
         plane += img_sz*img_sz
 
-    assert np.alltrue(cube == ecube), "Cube values do not match expected values"
+    assert np.all(cube == ecube), "Cube values do not match expected values"
 
     hdu.close()
 
@@ -110,14 +110,14 @@ def test_make_and_update_cube(tmpdir):
         # ecube[:, :, i, 1] = plane
         plane += img_sz*img_sz
 
-    assert np.alltrue(cube == ecube), "Cube values do not match expected values"
+    assert np.all(cube == ecube), "Cube values do not match expected values"
 
     tab = Table(hdu[2].data)
-    assert np.alltrue(tab['STARTTJD'] == np.arange(num_im)), "STARTTJD mismatch in table"
-    assert np.alltrue(tab['ENDTJD'] == np.arange(num_im)+1), "ENDTJD mismatch in table"
+    assert np.all(tab['STARTTJD'] == np.arange(num_im)), "STARTTJD mismatch in table"
+    assert np.all(tab['ENDTJD'] == np.arange(num_im)+1), "ENDTJD mismatch in table"
 
     filenames = np.array([path.split(x)[1] for x in ffi_files])
-    assert np.alltrue(tab['FFI_FILE'] == np.array(filenames)), "FFI_FILE mismatch in table"
+    assert np.all(tab['FFI_FILE'] == np.array(filenames)), "FFI_FILE mismatch in table"
 
     hdu.close()
 
@@ -156,7 +156,7 @@ def test_iteration(tmpdir, capsys):
     cube_2 = hdu_2[1].data
 
     assert cube_1.shape == cube_2.shape, "Mismatch between cube shape for 1 vs 2 iterations"
-    assert np.alltrue(cube_1 == cube_2), "Cubes made in 1 vs 2 iterations do not match"
+    assert np.all(cube_1 == cube_2), "Cubes made in 1 vs 2 iterations do not match"
 
     # expected values for cube
     ecube = np.zeros((img_sz, img_sz, num_im, 2))
@@ -168,7 +168,7 @@ def test_iteration(tmpdir, capsys):
         ecube[:, :, i, 1] = plane
         plane += img_sz*img_sz
 
-    assert np.alltrue(cube_1 == ecube), "Cube values do not match expected values"
+    assert np.all(cube_1 == ecube), "Cube values do not match expected values"
 
 
 @pytest.mark.parametrize("ffi_type", ["TICA", "SPOC"])


### PR DESCRIPTION
If an s3 URI is passed in as the `input_file` parameter to the `asdf_cut` function, open the resource with `s3fs` and use its http URL in `asdf.open()`.

This prevents users from having to open the resource themselves before passing the file into the `asdf_cut` function.