### PR TITLE
Improve speed by using .section attribute rather than .data attribute

### DIFF
--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -279,7 +279,7 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, extension
         with fits.open(in_fle, mode='denywrite', memmap=True, fsspec_kwargs=fsspec_kwargs) as hdulist:
 
             # Sorting out which extension(s) to cutout
-            all_inds = np.where([x.is_image and (x.size > 0) for x in hdulist])[0]
+            all_inds = np.where([hdu.is_image and hdu.size > 0 for hdu in hdulist])[0]
             cutout_inds = _parse_extensions(all_inds, in_fle, extension)
 
             num_cutouts += len(cutout_inds)
@@ -537,7 +537,7 @@ def img_cut(input_files, coordinates, cutout_size, stretch='asinh', minmax_perce
         with fits.open(in_fle, mode='denywrite', memmap=True) as hdulist:
 
             # Sorting out which extension(s) to cutout
-            all_inds = np.where([x.is_image and (x.size > 0) for x in hdulist])[0]
+            all_inds = np.where([hdu.is_image and hdu.size > 0 for hdu in hdulist])[0]
             cutout_inds = _parse_extensions(all_inds, in_fle, extension)
 
             for ind in cutout_inds:   

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -279,7 +279,7 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, extension
         with fits.open(in_fle, mode='denywrite', memmap=True, fsspec_kwargs=fsspec_kwargs) as hdulist:
 
             # Sorting out which extension(s) to cutout
-            all_inds = np.where([x.is_image and (x.section.shape != ()) for x in hdulist])[0]
+            all_inds = np.where([x.is_image and (x.size > 0) for x in hdulist])[0]
             cutout_inds = _parse_extensions(all_inds, in_fle, extension)
 
             num_cutouts += len(cutout_inds)
@@ -537,7 +537,7 @@ def img_cut(input_files, coordinates, cutout_size, stretch='asinh', minmax_perce
         with fits.open(in_fle, mode='denywrite', memmap=True) as hdulist:
 
             # Sorting out which extension(s) to cutout
-            all_inds = np.where([x.is_image and (x.section.shape != ()) for x in hdulist])[0]
+            all_inds = np.where([x.is_image and (x.size > 0) for x in hdulist])[0]
             cutout_inds = _parse_extensions(all_inds, in_fle, extension)
 
             for ind in cutout_inds:   


### PR DESCRIPTION
Accessing the `.data` attribute on a compressed image causes the entire image to be decompressed and read into memory.  That defeats the ability of astrocut to reduce the IO requirements by reading only the necessary data.

Another benefit of the change is that it greatly reduces the memory requirements for the returned cutout.  The current version using the data section returns a subset of the full image array, which winds up dragging the entire array along with it.  The `.section` approach does not include the entire array.

This change instead uses the `.section` attribute to access the data, both when reading the pixels and when checking to see which extensions have images. The only remaining use of the `.data` attribute is for access to the cutout pixels. The implementation of the `section` attribute makes it efficient for accessing data in AWS S3 buckets as well.

The speedup ranges from a factor of 2 (for large cutouts) to at least a factor of 10 (for small cutouts).  

This change also fixes a bug in the application of the `memory_only` flag. When true, it should not write any output files to disk.  However, that was ignored when `single_outfile` is false.  This fixes that bug.  It was already working correctly when `single_outfile` is true.
