### PR TITLE
Add cron job to CI workflow

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - "*"
   pull_request:
+  schedule:
+    # Nightly build triggered at 2 AM EST
+    - cron: '0 7 * * *'
 
 jobs:
   tests:


### PR DESCRIPTION
Adding a cron job to CI workflows so that our test suite runs everyday at 2 AM EST. This will run our test suite more regularly so that we can identify issues faster.