### PR TITLE
Better tests for writing to memory only

### DIFF
--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -311,7 +311,7 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, extension
         raise InvalidQueryError("Cutout contains no data! (Check image footprint.)")
 
     # Make sure the output directory exists
-    if not os.path.exists(output_dir):
+    if not memory_only and not os.path.exists(output_dir):
         os.makedirs(output_dir)
         
     # Setting up the output file(s) and writing them

--- a/astrocut/tests/test_cutouts.py
+++ b/astrocut/tests/test_cutouts.py
@@ -82,9 +82,9 @@ def test_fits_cut(tmpdir, caplog, ffi_type):
     assert not path.exists(nonexisting_dir)  # no files should be written
 
     # Output directory that has to be created
-    new_dir = "cutout_files"  # non-existing directory to write files to
+    new_dir = path.join(tmpdir, "cutout_files")  # non-existing directory to write files to
     cutout_files = cutouts.fits_cut(test_images, center_coord, cutout_size,
-                                    output_dir=path.join(tmpdir, new_dir), single_outfile=False)
+                                    output_dir=new_dir, single_outfile=False)
 
     assert isinstance(cutout_files, list)
     assert len(cutout_files) == len(test_images)

--- a/astrocut/tests/test_cutouts.py
+++ b/astrocut/tests/test_cutouts.py
@@ -1,7 +1,7 @@
 import pytest
 
 import numpy as np
-from os import path, listdir
+from os import path
 from re import findall
 
 from astropy.io import fits


### PR DESCRIPTION
Modified unit tests after discovery of bug in #132. Now, tests check that no files are written if the `memory_only` flag is set to `True` for both a single output file and multiple output files.

Also, only makes a new directory for output if `memory_only` is `False`. 