### PR TITLE
Generalization classes for FITS cutouts

### DIFF
--- a/astrocut/Cutout.py
+++ b/astrocut/Cutout.py
@@ -1,0 +1,149 @@
+from abc import abstractmethod, ABC
+from pathlib import Path
+from typing import List, Union, Tuple
+
+from astropy import wcs
+import astropy.units as u
+from s3path import S3Path
+from astropy.coordinates import SkyCoord
+import numpy as np
+
+from astrocut.exceptions import InvalidInputError, InvalidQueryError
+
+from . import log
+from .utils.utils import _handle_verbose, parse_size_input
+
+
+class Cutout(ABC):
+    """
+    Abstract class for creating cutouts. This class defines attributes and methods that are common to all
+    cutout classes.
+
+    Attributes
+    ----------
+    input_files : list
+        List of input image files.
+    coordinates : str | `~astropy.coordinates.SkyCoord`
+        Coordinates of the center of the cutout.
+    cutout_size : int | array | list | tuple | `~astropy.units.Quantity`
+        Size of the cutout array.
+    fill_value : int | float
+        Value to fill the cutout with if the cutout is outside the image.
+    memory_only : bool
+        If True, the cutout is written to memory instead of disk.
+    output_dir : str | Path
+        Directory to write the cutout file(s) to.
+    limit_rounding_method : str
+        Method to use for rounding the cutout limits. Options are 'round', 'ceil', and 'floor'.
+    verbose : bool
+        If True, log messages are printed to the console.
+
+    Methods
+    -------
+    get_cutout_limits(img_wcs)
+        Returns the x and y pixel limits for the cutout.
+    cutout()
+        Generate the cutouts.
+    """
+
+    def __init__(self, input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
+                 cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]] = 25,
+                 fill_value: Union[int, float] = np.nan, memory_only: bool = False,
+                 output_dir: Union[str, Path] = '.', limit_rounding_method: str = 'round', verbose: bool = True):
+        
+        # Log messages according to verbosity
+        _handle_verbose(verbose)
+
+        # Ensure that input files are in a list
+        if isinstance(input_files, str) or isinstance(input_files, Path):
+            input_files = [input_files]
+        self._input_files = input_files
+
+        # Get coordinates as a SkyCoord object
+        if coordinates and not isinstance(coordinates, SkyCoord):
+            coordinates = SkyCoord(coordinates, unit='deg')
+        self._coordinates = coordinates
+        log.debug('Coordinates: %s', self._coordinates)
+
+        # Turning the cutout size into an array of two values
+        self._cutout_size = parse_size_input(cutout_size)
+        log.debug('Cutout size: %s', self._cutout_size)
+
+        # Assigning other attributes
+        valid_rounding = ['round', 'ceil', 'floor']
+        if not isinstance(limit_rounding_method, str) or limit_rounding_method.lower() not in valid_rounding:
+            raise InvalidInputError(f'Limit rounding method {limit_rounding_method} is not recognized. '
+                                    'Valid options are {valid_rounding}.')
+        self._limit_rounding_method = limit_rounding_method
+        self._fill_value = fill_value
+        self._memory_only = memory_only
+        self._output_dir = output_dir
+        self._verbose = verbose
+
+    def _get_cutout_limits(self, img_wcs: wcs.WCS) -> np.ndarray:
+        """
+        Returns the x and y pixel limits for the cutout.
+
+        Note: This function does no bounds checking, so the returned limits are not 
+            guaranteed to overlap the original image.
+
+        Parameters
+        ----------
+        img_wcs : `~astropy.wcs.WCS`
+            The WCS for the image that the cutout is being cut from.
+
+        Returns
+        -------
+        response : `numpy.array`
+            The cutout pixel limits in an array of the form [[xmin,xmax],[ymin,ymax]]
+        """
+        # Calculate pixel corresponding to coordinate
+        try:
+            center_pixel = self._coordinates.to_pixel(img_wcs)
+        except wcs.NoConvergence:  # If wcs can't converge, center coordinate is far from the footprint
+            raise InvalidQueryError("Cutout location is not in image footprint!")
+
+        # Sometimes, we may get nans without a NoConvergence error
+        if np.isnan(center_pixel).any():
+            raise InvalidQueryError("Cutout location is not in image footprint!")
+        
+        lims = np.zeros((2, 2), dtype=int)
+        for axis, size in enumerate(self._cutout_size):
+            
+            if not isinstance(size, u.Quantity):  # assume pixels
+                dim = size / 2
+            elif size.unit == u.pixel:  # also pixels
+                dim = size.value / 2
+            elif size.unit.physical_type == 'angle':  # angular size
+                pixel_scale = u.Quantity(wcs.utils.proj_plane_pixel_scales(img_wcs)[axis],
+                                         img_wcs.wcs.cunit[axis])
+                dim = (size / pixel_scale).decompose() / 2
+            else:
+                raise InvalidInputError(f'Cutout size units {size.unit} are not supported.')
+
+            # Round the limits according to the requested method
+            rounding_funcs = {
+                'round': np.round,
+                'ceil': np.ceil,
+                'floor': np.floor
+            }
+            round_func = rounding_funcs[self._limit_rounding_method]
+
+            lims[axis, 0] = int(round_func(center_pixel[axis] - dim))
+            lims[axis, 1] = int(round_func(center_pixel[axis] + dim))
+
+            # The case where the requested area is so small it rounds to zero
+            if self._limit_rounding_method == 'round' and lims[axis, 0] == lims[axis, 1]:
+                lims[axis, 0] = int(np.floor(center_pixel[axis] - 1))
+                lims[axis, 1] = lims[axis, 0] + 1
+
+        return lims
+
+    @abstractmethod
+    def cutout(self):
+        """
+        Generate the cutout(s).
+
+        This method is abstract and should be defined in subclasses.
+        """
+        pass

--- a/astrocut/FITSCutout.py
+++ b/astrocut/FITSCutout.py
@@ -486,7 +486,7 @@ class FITSCutout(ImageCutout):
 
             return cutouts_fits
 
-    def _write_as_fits(self) -> str | List[str]:
+    def _write_as_fits(self) -> Union[str, List[str]]:
         """
         Write the cutouts to a file in FITS format.
 

--- a/astrocut/FITSCutout.py
+++ b/astrocut/FITSCutout.py
@@ -357,6 +357,7 @@ class FITSCutout(ImageCutout):
         # Check that there is data in the cutout image
         if (img_cutout == 0).all() or (np.isnan(img_cutout)).all():
             hdu_header["EMPTY"] = (True, "Indicates no data in cutout image.")
+            self._num_empty += 1
 
         return fits.ImageHDU(header=hdu_header, data=img_cutout)
 
@@ -374,6 +375,7 @@ class FITSCutout(ImageCutout):
 
         # Create HDU cutouts
         cutouts = []
+        self._num_cutouts += len(cutout_inds)
         for ind in cutout_inds:
             try:
                 # Get HDU, header, and WCS
@@ -404,13 +406,16 @@ class FITSCutout(ImageCutout):
             except OSError as err:
                 warnings.warn((f"Error {err} encountered when performing cutout on {file}, "
                                f"extension {ind}, skipping..."), DataWarning)
+                self._num_empty += 1
             except NoOverlapError:
                 warnings.warn((f"Cutout footprint does not overlap with data in {file}, "
                                f"extension {ind}, skipping..."), DataWarning)
+                self._num_empty += 1
             except ValueError as err:
                 if "Input position contains invalid values" in str(err):
                     warnings.warn((f"Cutout footprint does not overlap with data in {file}, "
                                    f"extension {ind}, skipping..."), DataWarning)
+                    self._num_empty += 1
                 else:
                     raise
         

--- a/astrocut/FITSCutout.py
+++ b/astrocut/FITSCutout.py
@@ -1,0 +1,529 @@
+from datetime import date
+from pathlib import Path
+from typing import List, Literal, Optional, Tuple, Union
+import warnings
+
+from astropy import log as astropy_log
+from astropy.coordinates import SkyCoord
+from astropy.nddata import NoOverlapError
+from astropy.io import fits
+from astropy.units import Quantity
+from astropy.wcs import WCS
+import numpy as np
+from s3path import S3Path
+
+from .exceptions import DataWarning, InputWarning, InvalidQueryError
+from .ImageCutout import ImageCutout
+from . import __version__, log
+
+
+class FITSCutout(ImageCutout):
+    """
+    Class for creating cutouts from FITS files.
+
+    Attributes
+    ----------
+    input_files : list
+        List of input image files.
+    coordinates : str | `~astropy.coordinates.SkyCoord`
+        Coordinates of the center of the cutout.
+    cutout_size : int | array | list | tuple | `~astropy.units.Quantity`
+        Size of the cutout array.
+    fill_value : int | float
+        Value to fill the cutout with if the cutout is outside the image.
+    memory_only : bool
+        If True, the cutout is written to memory instead of disk.
+    output_dir : str | Path
+        Directory to write the cutout file(s) to.
+    limit_rounding_method : str
+        Method to use for rounding the cutout limits. Options are 'round', 'ceil', and 'floor'.
+    stretch : str
+        Optional, default 'asinh'. The stretch to apply to the image array.
+        Valid values are: asinh, sinh, sqrt, log, linear.
+    minmax_percent : list
+        Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric) 
+        when scaling the image. The format is [lower percentile, upper percentile], where pixel
+        values below the lower percentile and above the upper percentile are clipped.
+        Only one of minmax_percent and minmax_value should be specified.
+    minmax_value : list
+        Optional. Interval based on user-specified pixel values when scaling the image.
+        The format is [min value, max value], where pixel values below the min value and above
+        the max value are clipped.
+        Only one of minmax_percent and minmax_value should be specified.
+    invert : bool
+        Optional, default False.  If True the image is inverted (light pixels become dark and vice versa).
+    colorize : bool
+        Optional, default False.  If True a single color image is produced as output, and it is expected
+        that three files are given as input.
+    output_format : str
+        Optional, default '.jpg'. The format of the output image file.
+    cutout_prefix : str
+        Optional, default 'cutout'. The prefix to use for the output file name.
+    extension : int | list | 'all'
+        Optional, default None. The extension(s) to cutout from. If None, the first extension with data is used.
+    single_outfile : bool
+        Optional, default True. If True, all cutouts are written to a single file or HDUList.
+    verbose : bool
+        If True, log messages are printed to the console.
+
+    Methods
+    -------
+    _parse_extensions()
+        Determine which extension(s) to cutout from.
+    _load_file_data()
+        Load the data from an input file.
+    _get_img_wcs()
+        Get the WCS for an image.
+    _get_cutout_data()
+        Get the cutout data from an image.
+    _get_cutout_wcs()
+        Get the WCS for a cutout.
+    _hducut()
+        Create a cutout HDU from an image HDU.
+    _cutout_file()
+        Cutout an image file.
+    _construct_fits_from_hdus()
+        Make one or more cutout HDUs into a single HDUList object.
+    _write_to_memory()
+        Write the cutouts to memory.
+    _write_as_fits()
+        Write the cutouts to a file in FITS format.
+    _write_as_asdf()
+        Write the cutouts to a file in ASDF format.
+    """
+
+    def __init__(self, input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
+                 cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
+                 fill_value: Union[int, float] = np.nan, memory_only: bool = False,
+                 output_dir: Union[str, Path] = '.', limit_rounding_method: str = 'round', stretch: str = 'asinh', 
+                 minmax_percent: Optional[List[int]] = None, minmax_value: Optional[List[int]] = None, 
+                 invert: bool = False, colorize: bool = False, output_format: str = 'fits', 
+                 cutout_prefix: str = 'cutout', extension: Optional[Union[int, List[int], Literal['all']]] = None, 
+                 single_outfile: bool = True, verbose: bool = True):
+        super().__init__(input_files, coordinates, cutout_size, fill_value, memory_only, output_dir, 
+                         limit_rounding_method, stretch, minmax_percent, minmax_value, invert, colorize, 
+                         output_format, cutout_prefix, verbose)        
+        # If a single extension is given, make it a list
+        if isinstance(extension, int):
+            extension = [extension]
+        self._extension = extension
+
+        # Assigning other attributes
+        self._single_outfile = single_outfile
+        self._cutout_filenames = []
+
+    def _parse_extensions(self, input_file: Union[str, Path, S3Path], infile_exts: np.ndarray) -> List[int]:
+        """
+        Given a list of image extensions available in the file with infile_name, cross-match with
+        user input extensions to figure out which extensions to use for cutout.
+
+        Parameters
+        ----------
+        input_file : str | Path | S3Path
+            The path to the input file.
+        infile_exts : list
+            List of image extensions available in the file.
+
+        Returns
+        -------
+        cutout_exts : list
+            List of extensions to be cutout.
+        """
+        # Skip files with no image data
+        if len(infile_exts) == 0:
+            warnings.warn(f"No image extensions with data found in {input_file}, skipping...",
+                          DataWarning)
+            return []
+                
+        if self._extension is None:
+            cutout_exts = infile_exts[:1]  # Take the first image extension
+        elif self._extension == 'all':
+            cutout_exts = infile_exts  # Take all the extensions
+        else:  # User input extentions
+            cutout_exts = [x for x in infile_exts if x in self._extension]
+            if len(cutout_exts) < len(self._extension):
+                warnings.warn((f"Not all requested extensions in {input_file} are image extensions or have "
+                               f"data, extension(s) {','.join([x for x in self._extension if x not in cutout_exts])}"
+                               " will be skipped."), DataWarning)
+
+        return cutout_exts
+
+    def _load_file_data(self, input_file: Union[str, Path, S3Path]) -> Tuple[fits.HDUList, List[int]]:
+        """
+        Load the data from an input file and determine which extension(s) to cutout from.
+
+        Parameters
+        ----------
+        input_file : str | Path | S3Path
+            The path to the input file.
+
+        Returns
+        --------
+        hdulist : `~astropy.io.fits.HDUList`
+            The HDU list for the input file.
+        cutout_inds : list
+            The indices of the extension(s) to cutout from.
+        """
+        # Account for cloud-hosted files
+        fsspec_kwargs = {'anon': True} if 's3://' in input_file else None
+
+        # Open the file
+        hdulist = fits.open(input_file, mode='denywrite', memmap=True, fsspec_kwargs=fsspec_kwargs)
+
+        # Sorting out which extension(s) to cutout
+        infile_exts = np.where([hdu.is_image and hdu.size > 0 for hdu in hdulist])[0]
+        cutout_inds = self._parse_extensions(input_file, infile_exts)
+
+        return (hdulist, cutout_inds)
+    
+    def _get_img_wcs(self, hdu_header: fits.Header) -> Tuple[WCS, bool]:
+        """
+        Get the WCS for an image.
+
+        Parameters
+        ----------
+        hdu_header : `~astropy.io.fits.Header`
+            The header for the image HDU.
+        
+        Returns
+        --------
+        img_wcs : `~astropy.wcs.WCS`
+            The WCS for the image.
+        no_sip : bool
+            Whether the image WCS has no SIP information.
+        """
+        # We are going to reroute the logging to a string stream temporarily so we can
+        # intercept any message from astropy, chiefly the "Inconsistent SIP distortion information"
+        # INFO message which will indicate that we need to remove existing SIP keywords
+        # from a WCS whose CTYPE does not include SIP. In this we are taking the CTYPE to be
+        # correct and adjusting the header keywords to match.
+        hdlrs = astropy_log.handlers
+        astropy_log.handlers = []
+        with astropy_log.log_to_list() as log_list:        
+            img_wcs = WCS(hdu_header, relax=True)
+
+        for hd in hdlrs:
+            astropy_log.addHandler(hd)
+
+        no_sip = False
+        if (len(log_list) > 0):
+            if ("Inconsistent SIP distortion information" in log_list[0].msg):
+                # Remove sip coefficients
+                img_wcs.sip = None
+                no_sip = True
+            else:  # Message(s) we didn't prepare for we want to go ahead and display
+                for log_rec in log_list:
+                    astropy_log.log(log_rec.levelno, log_rec.msg, extra={"origin": log_rec.name})
+
+        return (img_wcs, no_sip)
+    
+    def _get_cutout_data(self, data: fits.Section, wcs: WCS) -> np.ndarray:
+        """
+        Get the cutout data from an image.
+
+        Parameters
+        ----------
+        data : `~astropy.io.fits.Section`
+            The data for the image.
+        wcs : `~astropy.wcs.WCS`
+            The WCS for the image.
+
+        Returns
+        --------
+        cutout_data : `numpy.ndarray`
+            The cutout data.
+        """
+        log.debug("Original image shape: %s", data.shape)
+
+        # Get the limits for the cutout
+        # These limits are not guaranteed to be within the image footprint
+        cutout_lims = self._get_cutout_limits(wcs)
+        xmin, xmax = cutout_lims[0]
+        ymin, ymax = cutout_lims[1]
+        ymax_img, xmax_img = data.shape
+
+        # Check the cutout is on the image
+        if (xmax <= 0) or (xmin >= xmax_img) or (ymax <= 0) or (ymin >= ymax_img):
+            raise InvalidQueryError("Cutout location is not in image footprint!")
+
+        # Adjust limits and figure out the padding
+        padding = np.zeros((2, 2), dtype=int)
+        if xmin < 0:
+            padding[1, 0] = -xmin
+            xmin = 0
+        if ymin < 0:
+            padding[0, 0] = -ymin
+            ymin = 0
+        if xmax > xmax_img:
+            padding[1, 1] = xmax - xmax_img
+            xmax = xmax_img
+        if ymax > ymax_img:
+            padding[0, 1] = ymax - ymax_img
+            ymax = ymax_img  
+            
+        img_cutout = data[ymin:ymax, xmin:xmax]
+
+        # Adding padding to the cutout so that it's the expected size
+        if padding.any():  # only do if we need to pad
+            img_cutout = np.pad(img_cutout, padding, 'constant', constant_values=self._fill_value)
+
+        log.debug("Image cutout shape: %s", img_cutout.shape)
+
+        return img_cutout
+    
+    def _get_cutout_wcs(self, img_wcs: WCS, cutout_lims: np.ndarray) -> WCS:
+        """
+        Starting with the full image WCS and adjusting it for the cutout WCS.
+        Adjusts CRPIX values and adds physical WCS keywords.
+
+        Parameters
+        ----------
+        img_wcs : `~astropy.wcs.WCS`
+            WCS for the image the cutout is being cut from.
+        cutout_lims : `numpy.ndarray`
+            The cutout pixel limits in an array of the form [[ymin,ymax],[xmin,xmax]]
+
+        Returns
+        --------
+        response :  `~astropy.wcs.WCS`
+            The cutout WCS object including SIP distortions if present.
+        """
+        # relax = True is important when the WCS has sip distortions, otherwise it has no effect
+        wcs_header = img_wcs.to_header(relax=True) 
+
+        # Adjusting the CRPIX values
+        wcs_header["CRPIX1"] -= cutout_lims[0, 0]
+        wcs_header["CRPIX2"] -= cutout_lims[1, 0]
+
+        # Adding the physical WCS keywords
+        wcs_header.set("WCSNAMEP", "PHYSICAL", "name of world coordinate system alternate P")
+        wcs_header.set("WCSAXESP", 2, "number of WCS physical axes")
+        
+        wcs_header.set("CTYPE1P", "RAWX", "physical WCS axis 1 type CCD col")
+        wcs_header.set("CUNIT1P", "PIXEL", "physical WCS axis 1 unit")
+        wcs_header.set("CRPIX1P", 1, "reference CCD column")
+        wcs_header.set("CRVAL1P", cutout_lims[0, 0] + 1, "value at reference CCD column")
+        wcs_header.set("CDELT1P", 1.0, "physical WCS axis 1 step")
+                    
+        wcs_header.set("CTYPE2P", "RAWY", "physical WCS axis 2 type CCD col")
+        wcs_header.set("CUNIT2P", "PIXEL", "physical WCS axis 2 unit")
+        wcs_header.set("CRPIX2P", 1, "reference CCD row")
+        wcs_header.set("CRVAL2P", cutout_lims[1, 0] + 1, "value at reference CCD row")
+        wcs_header.set("CDELT2P", 1.0, "physical WCS axis 2 step")
+        
+        return WCS(wcs_header)
+
+    def _hducut(self, img_hdu: fits.ImageHDU, img_wcs: WCS, hdu_header: fits.Header, no_sip: bool) -> fits.ImageHDU:
+        """
+        Create a cutout HDU from an image HDU.
+
+        Parameters
+        ----------
+        img_hdu : `~astropy.io.fits.ImageHDU`
+            The image HDU to cutout from.
+        img_wcs : `~astropy.wcs.WCS`
+            The WCS for the image.
+        hdu_header : `~astropy.io.fits.Header`
+            The header for the image HDU.
+        no_sip : bool   
+            Whether the image WCS has no SIP information.
+
+        Returns
+        -------
+        response : `~astropy.io.fits.ImageHDU`
+            The cutout HDU.
+        """
+        # Get the data for the cutout
+        img_cutout = self._get_cutout_data(img_hdu.section, img_wcs)
+
+        # Get the cutout WCS
+        # cutout_wcs = img_cutout.wcs
+        cutout_wcs = self._get_cutout_wcs(img_wcs, self._get_cutout_limits(img_wcs))
+
+        # Updating the header with the new wcs info
+        if no_sip:
+            hdu_header.update(cutout_wcs.to_header(relax=False))
+        else:
+            hdu_header.update(cutout_wcs.to_header(relax=True))  # relax arg is for sip distortions if they exist
+
+        # Naming the extension and preserving the original name
+        hdu_header["O_EXT_NM"] = (hdu_header.get("EXTNAME"), "Original extension name.")
+        hdu_header["EXTNAME"] = "CUTOUT"
+
+        # Moving the filename, if present, into the ORIG_FLE keyword
+        hdu_header["ORIG_FLE"] = (hdu_header.get("FILENAME"), "Original image filename.")
+        hdu_header.remove("FILENAME", ignore_missing=True)
+
+        # Check that there is data in the cutout image
+        if (img_cutout == 0).all() or (np.isnan(img_cutout)).all():
+            hdu_header["EMPTY"] = (True, "Indicates no data in cutout image.")
+
+        return fits.ImageHDU(header=hdu_header, data=img_cutout)
+
+    def _cutout_file(self, file: Union[str, Path, S3Path]):
+        """
+        Create cutouts from a single file.
+
+        Parameters
+        ----------
+        file : str | Path | S3Path
+            The path to the file.
+        """
+        # Load data
+        hdulist, cutout_inds = self._load_file_data(file)
+
+        # Create HDU cutouts
+        cutouts = []
+        for ind in cutout_inds:
+            try:
+                # Get HDU, header, and WCS
+                img_hdu = hdulist[ind] 
+                hdu_header = fits.Header(img_hdu.header, copy=True)
+                img_wcs, no_sip = self._get_img_wcs(hdu_header)
+
+                if self._output_format == '.fits':
+                    # Make a cutout hdu
+                    cutout = self._hducut(img_hdu, img_wcs, hdu_header, no_sip)
+
+                    # Adding a few more keywords
+                    cutout.header["ORIG_EXT"] = (ind, "Extension in original file.")
+                    if not cutout.header.get("ORIG_FLE") and hdulist[0].header.get("FILENAME"):
+                        cutout.header["ORIG_FLE"] = hdulist[0].header.get("FILENAME")
+                else:
+                    # We only need the data array for images
+                    cutout = self._get_cutout_data(img_hdu.section, img_wcs)
+
+                    # Apply the appropriate normalization parameters
+                    cutout = self.normalize_img(cutout, self._stretch, self._minmax_percent, self._minmax_value, 
+                                                self._invert)
+
+                    if (cutout == 0).all():
+                        continue
+
+                cutouts.append(cutout)
+            except OSError as err:
+                warnings.warn((f"Error {err} encountered when performing cutout on {file}, "
+                               f"extension {ind}, skipping..."), DataWarning)
+            except NoOverlapError:
+                warnings.warn((f"Cutout footprint does not overlap with data in {file}, "
+                               f"extension {ind}, skipping..."), DataWarning)
+            except ValueError as err:
+                if "Input position contains invalid values" in str(err):
+                    warnings.warn((f"Cutout footprint does not overlap with data in {file}, "
+                                   f"extension {ind}, skipping..."), DataWarning)
+                else:
+                    raise
+        
+        # Close HDUList
+        hdulist.close()
+
+        # Save cutouts
+        self._cutout_dict[file] = cutouts
+
+    def _construct_fits_from_hdus(self, cutout_hdus: List[fits.ImageHDU]) -> fits.HDUList:
+        """
+        Make one or more cutout HDUs into a single HDUList object.
+
+        Parameters
+        ----------
+        cutout_hdus : list
+            The `~astropy.io.fits.hdu.image.ImageHDU` object(s) to be written to the fits file.
+
+        Returns
+        -------
+        response : `~astropy.io.fits.HDUList`
+            The HDUList object.
+        """        
+        # Setting up the Primary HDU
+        keywords = dict()
+        if self._coordinates:
+            keywords = {"RA_OBJ": (self._coordinates.ra.deg, '[deg] right ascension'),
+                        "DEC_OBJ": (self._coordinates.dec.deg, '[deg] declination')}
+
+        # Build the primary HDU with keywords
+        primary_hdu = fits.PrimaryHDU()
+        primary_hdu.header.extend([("ORIGIN", 'STScI/MAST', "institution responsible for creating this file"),
+                                   ("DATE", str(date.today()), "file creation date"),
+                                   ('PROCVER', __version__, 'software version')])
+        for kwd in keywords:
+            primary_hdu.header[kwd] = keywords[kwd]
+
+        return fits.HDUList([primary_hdu] + cutout_hdus)
+
+    def _write_to_memory(self) -> List[fits.HDUList]:
+        """
+        Return the cutouts as a list of HDUList objects.
+
+        Returns
+        -------
+        cutout_fits : list
+            List of `~astropy.io.fits.HDUList` objects.
+        """
+        if self._single_outfile:
+            # Collect all cutout HDUs into a single HDUList object
+            cutout_hdus = [x for file in self._cutout_dict for x in self._cutout_dict[file]]
+            return [self._construct_fits_from_hdus(cutout_hdus)]
+        else:
+            # Write cutouts for each input file to a separate HDUList object
+            cutouts_fits = []
+
+            for file, cutout_list in self._cutout_dict.items():
+                if np.array([x.header.get("EMPTY") for x in cutout_list]).all():
+                    # Skip files with no data in the cutout images
+                    warnings.warn(f"Cutout of {file} contains no data and will not be returned.",
+                                  DataWarning)
+                    continue
+
+                if not self._memory_only:
+                    # If cutouts are being written to disk, we need to keep track of their
+                    # input filenames to name the cutout files appropriately
+                    self._cutout_filenames.append(file)
+
+                cutouts_fits.append(self._construct_fits_from_hdus(cutout_list))
+
+            return cutouts_fits
+
+    def _write_as_fits(self) -> str | List[str]:
+        """
+        Write the cutouts to a file in FITS format.
+
+        Returns
+        -------
+        cutout_paths : str | list
+            The path(s) to the cutout file(s).
+        """
+        # Get cutouts as memory objects
+        cutouts_fits = self._write_to_memory()
+
+        cutout_paths = []  # Cutout file paths
+        for i, cutout in enumerate(cutouts_fits):
+            # Naming the cutout file
+            if self._single_outfile:
+                filename = "{}_{:.7f}_{:.7f}_{}-x-{}_astrocut.fits".format(
+                    self._cutout_prefix,
+                    self._coordinates.ra.value,
+                    self._coordinates.dec.value,
+                    str(self._cutout_size[0]).replace(' ', ''),
+                    str(self._cutout_size[1]).replace(' ', ''))
+            else:
+                filename = "{}_{:.7f}_{:.7f}_{}-x-{}_astrocut.fits".format(
+                    Path(self._cutout_filenames[i]).stem,
+                    self._coordinates.ra.value,
+                    self._coordinates.dec.value,
+                    str(self._cutout_size[0]).replace(' ', ''), 
+                    str(self._cutout_size[1]).replace(' ', ''))
+
+            # Write the cutout file to disk
+            cutout_path = Path(self._output_dir, filename)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore") 
+                cutout.writeto(cutout_path, overwrite=True, checksum=True)
+            log.debug("Cutout fits file: %s", cutout_path)
+            cutout_paths.append(cutout_path.as_posix())
+
+        return cutout_paths if len(cutout_paths) > 1 else cutout_paths[0]
+
+    def _write_as_asdf(self):
+        """ASDF output is not yet implemented for FITS files."""
+        warnings.warn("ASDF output not yet implemented for FITS files. File will not be written.",
+                      InputWarning)

--- a/astrocut/FITSCutout.py
+++ b/astrocut/FITSCutout.py
@@ -91,13 +91,14 @@ class FITSCutout(ImageCutout):
     _write_as_asdf()
         Write the cutouts to a file in ASDF format.
     """
-
+        
     def __init__(self, input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
                  cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
                  fill_value: Union[int, float] = np.nan, memory_only: bool = False,
-                 output_dir: Union[str, Path] = '.', limit_rounding_method: str = 'round', stretch: str = None, 
-                 minmax_percent: Optional[List[int]] = None, minmax_value: Optional[List[int]] = None, 
-                 invert: bool = None, colorize: bool = None, output_format: str = 'fits', 
+                 output_dir: Union[str, Path] = '.', limit_rounding_method: str = 'round', 
+                 stretch: Optional[str] = None, minmax_percent: Optional[List[int]] = None, 
+                 minmax_value: Optional[List[int]] = None, invert: Optional[bool] = None, 
+                 colorize: Optional[bool] = None, output_format: str = '.fits',
                  cutout_prefix: str = 'cutout', extension: Optional[Union[int, List[int], Literal['all']]] = None, 
                  single_outfile: bool = True, verbose: bool = False):
         # Superclass constructor 

--- a/astrocut/FITSCutout.py
+++ b/astrocut/FITSCutout.py
@@ -100,17 +100,6 @@ class FITSCutout(ImageCutout):
                  invert: bool = None, colorize: bool = None, output_format: str = 'fits', 
                  cutout_prefix: str = 'cutout', extension: Optional[Union[int, List[int], Literal['all']]] = None, 
                  single_outfile: bool = True, verbose: bool = False):
-        # Warn if image processing parameters are provided for FITS output
-        if (output_format == 'fits' or output_format == '.fits') and (stretch or minmax_percent or 
-                                                                      minmax_value or invert or colorize):
-            warnings.warn('Stretch, minmax_percent, minmax_value, invert, and colorize are not supported '
-                          'for FITS output and will be ignored.', InputWarning)
-        else:
-            # Assign defaults if not provided
-            stretch = stretch or 'asinh'
-            invert = invert or False
-            colorize = colorize or False
-
         # Superclass constructor 
         super().__init__(input_files, coordinates, cutout_size, fill_value, memory_only, output_dir, 
                          limit_rounding_method, stretch, minmax_percent, minmax_value, invert, colorize, 

--- a/astrocut/FITSCutout.py
+++ b/astrocut/FITSCutout.py
@@ -298,13 +298,11 @@ class FITSCutout(ImageCutout):
         # Adding the physical WCS keywords
         wcs_header.set("WCSNAMEP", "PHYSICAL", "name of world coordinate system alternate P")
         wcs_header.set("WCSAXESP", 2, "number of WCS physical axes")
-        
         wcs_header.set("CTYPE1P", "RAWX", "physical WCS axis 1 type CCD col")
         wcs_header.set("CUNIT1P", "PIXEL", "physical WCS axis 1 unit")
         wcs_header.set("CRPIX1P", 1, "reference CCD column")
         wcs_header.set("CRVAL1P", cutout_lims[0, 0] + 1, "value at reference CCD column")
         wcs_header.set("CDELT1P", 1.0, "physical WCS axis 1 step")
-                    
         wcs_header.set("CTYPE2P", "RAWY", "physical WCS axis 2 type CCD col")
         wcs_header.set("CUNIT2P", "PIXEL", "physical WCS axis 2 unit")
         wcs_header.set("CRPIX2P", 1, "reference CCD row")
@@ -530,5 +528,7 @@ class FITSCutout(ImageCutout):
 
     def _write_as_asdf(self):
         """ASDF output is not yet implemented for FITS files."""
-        warnings.warn("ASDF output not yet implemented for FITS files. File will not be written.",
+        warnings.warn("ASDF output not yet implemented for FITS files. "
+                      "Returning cutout(s) as a list of ~astropy.io.fits.HDUList objects.",
                       InputWarning)
+        return self._write_to_memory()

--- a/astrocut/ImageCutout.py
+++ b/astrocut/ImageCutout.py
@@ -4,13 +4,11 @@ from time import monotonic
 from typing import List, Optional, Union, Tuple
 import warnings
 
-from astropy import wcs
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.units import Quantity
 from astropy.visualization import (SqrtStretch, LogStretch, AsinhStretch, SinhStretch, LinearStretch,
                                    MinMaxInterval, ManualInterval, AsymmetricPercentileInterval)
-from astropy.nddata import Cutout2D
 import numpy as np
 from PIL import Image
 from s3path import S3Path

--- a/astrocut/ImageCutout.py
+++ b/astrocut/ImageCutout.py
@@ -1,0 +1,389 @@
+from abc import abstractmethod, ABC
+from pathlib import Path
+from time import monotonic
+from typing import List, Optional, Union, Tuple
+import warnings
+
+from astropy import wcs
+from astropy.coordinates import SkyCoord
+from astropy.io import fits
+from astropy.units import Quantity
+from astropy.visualization import (SqrtStretch, LogStretch, AsinhStretch, SinhStretch, LinearStretch,
+                                   MinMaxInterval, ManualInterval, AsymmetricPercentileInterval)
+from astropy.nddata import Cutout2D
+import numpy as np
+from PIL import Image
+from s3path import S3Path
+
+from . import log
+from .exceptions import DataWarning, InputWarning, InvalidInputError, InvalidQueryError
+from .Cutout import Cutout
+
+
+class ImageCutout(Cutout, ABC):
+    """
+    Abstract class for creating cutouts from images. This class defines attributes and methods that are common to all
+    image cutout classes.
+
+    Attributes
+    ----------
+    input_files : list
+        List of input image files.
+    coordinates : str | `~astropy.coordinates.SkyCoord`
+        Coordinates of the center of the cutout.
+    cutout_size : int | array | list | tuple | `~astropy.units.Quantity`
+        Size of the cutout array.
+    fill_value : int | float
+        Value to fill the cutout with if the cutout is outside the image.
+    memory_only : bool
+        If True, the cutout is written to memory instead of disk.
+    output_dir : str | Path
+        Directory to write the cutout file(s) to.
+    limit_rounding_method : str
+        Method to use for rounding the cutout limits. Options are 'round', 'ceil', and 'floor'.
+    stretch : str
+        Optional, default 'asinh'. The stretch to apply to the image array.
+        Valid values are: asinh, sinh, sqrt, log, linear.
+    minmax_percent : list
+        Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric) 
+        when scaling the image. The format is [lower percentile, upper percentile], where pixel
+        values below the lower percentile and above the upper percentile are clipped.
+        Only one of minmax_percent and minmax_value should be specified.
+    minmax_value : list
+        Optional. Interval based on user-specified pixel values when scaling the image.
+        The format is [min value, max value], where pixel values below the min value and above
+        the max value are clipped.
+        Only one of minmax_percent and minmax_value should be specified.
+    invert : bool
+        Optional, default False.  If True the image is inverted (light pixels become dark and vice versa).
+    colorize : bool
+        Optional, default False.  If True a single color image is produced as output, and it is expected
+        that three files are given as input.
+    output_format : str
+        Optional, default '.jpg'. The format of the output image file.
+    cutout_prefix : str
+        Optional, default 'cutout'. The prefix to use for the output file name.
+    verbose : bool
+        If True, log messages are printed to the console.
+
+    Methods
+    -------
+    _get_cutout_data()
+        Get the cutout data from the input image.
+    _cutout_file()
+        Cutout an image file.
+    _write_to_memory()
+        Write the cutouts to memory.
+    _write_as_fits()
+        Write the cutouts to a file in FITS format.
+    _write_as_asdf()
+        Write the cutouts to a file in ASDF format.
+    _write_as_img()
+        Write the cutouts to a file in an image format.
+    _write_cutouts()
+        Write the cutouts according to the specified location and output format.
+    cutout()
+        Generate the cutouts.
+    normalize_img()
+        Apply given stretch and scaling to an image array.
+    """
+
+    def __init__(self, input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
+                 cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
+                 fill_value: Union[int, float] = np.nan, memory_only: bool = False,
+                 output_dir: Union[str, Path] = '.', limit_rounding_method: str = 'round', stretch: str = 'asinh', 
+                 minmax_percent: Optional[List[int]] = None, minmax_value: Optional[List[int]] = None, 
+                 invert: bool = False, colorize: bool = False, output_format: str = 'jpg', 
+                 cutout_prefix: str = 'cutout', verbose: bool = True):
+        super().__init__(input_files, coordinates, cutout_size, fill_value, memory_only, output_dir, 
+                         limit_rounding_method, verbose)
+
+        # Attributes for normalizing image cutouts
+        valid_stretches = ['asinh', 'sinh', 'sqrt', 'log', 'linear']
+        if not isinstance(stretch, str) or stretch.lower() not in valid_stretches:
+            raise InvalidInputError(f"Stretch {stretch} is not recognized. Valid options are {valid_stretches}.")
+        self._stretch = stretch.lower()
+        self._minmax_percent = minmax_percent
+        self._minmax_value = minmax_value
+        self._invert = invert
+        self._colorize = colorize
+        self._output_format = output_format.lower()
+        self._cutout_prefix = cutout_prefix
+
+        # Initialize cutout dictionary
+        self._cutout_dict = {}
+
+        # Handle if output format is passed in without a dot
+        if not self._output_format.startswith('.'):
+            self._output_format = f'.{self._output_format}'
+
+        # Apply default scaling for image outputs
+        if (self._minmax_percent is None) and (self._minmax_value is None):
+            self._minmax_percent = [0.5, 99.5]
+
+    def _get_cutout_data(self, data: np.ndarray, wcs_obj: wcs.WCS) -> Cutout2D:
+        """
+        Get the cutout data from the input image.
+
+        Parameters
+        ----------
+        data : array
+            The input image data.
+        wcs : `~astropy.wcs.WCS`
+            The WCS of the input image.
+
+        Returns
+        -------
+        img_cutout : `~astropy.nddata.Cutout2D`
+            The cutout data.
+        """
+        # Using `~astropy.nddata.Cutout2D` to get the cutout data and handle WCS
+        log.debug("Original image shape: %s", data.shape)
+        img_cutout = Cutout2D(data,
+                              position=self._coordinates,
+                              wcs=wcs_obj,
+                              size=(self._cutout_size[1], self._cutout_size[0]),
+                              mode='partial',
+                              fill_value=self._fill_value)
+        log.debug("Image cutout shape: %s", img_cutout.shape)
+
+        return img_cutout
+
+    @abstractmethod
+    def _cutout_file(self, file: Union[str, Path, S3Path]):
+        """
+        Cutout an image file.
+
+        This method is abstract and should be defined in subclasses.
+        """
+        pass
+
+    @abstractmethod
+    def _write_to_memory(self):
+        """
+        Write the cutouts to memory.
+
+        This method is abstract and should be defined in the subclass.
+        """
+        pass
+
+    @abstractmethod
+    def _write_as_fits(self):
+        """
+        Write the cutouts to a file in FITS format.
+
+        This method is abstract and should be defined in the subclass.
+        """
+        pass
+
+    @abstractmethod
+    def _write_as_asdf(self):
+        """
+        Write the cutouts to a file in ASDF format.
+
+        This method is abstract and should be defined in the subclass.
+        """
+        pass
+
+    def _write_as_img(self) -> Union[str, List[str]]:
+        """
+        Write the cutout to a file in an image format. If colorize is set, the first 3 cutouts will be combined 
+        into a single RGB image. Otherwise, each cutout will be written to a separate file.
+
+        Returns
+        -------
+        cutout_path : List[Path]
+            Path(s) to the written cutout files.
+
+        Raises
+        ------
+        InvalidInputError
+            If less than three inputs were provided for a colorized cutout.
+        """
+        # Set up output files and write them
+        if self._colorize:  # Combine first three cutouts into a single RGB image
+            cutouts = [x for fle in self._input_files for x in self._cutout_dict.get(fle, [])]
+
+            # Check for the correct number of cutouts
+            if len(cutouts) < 3:
+                raise InvalidInputError(("Color cutouts require 3 input images (RGB)."
+                                         "If you supplied 3 images one of the cutouts may have been empty."))
+            if len(cutouts) > 3:
+                warnings.warn("Too many inputs for a color cutout, only the first three will be used.", InputWarning)
+                cutouts = cutouts[:3]
+
+            # Write the colorized cutout to disk
+            cutout_path = "{}_{:.7f}_{:.7f}_{}-x-{}_astrocut{}".format(
+                self._cutout_prefix,
+                self._coordinates.ra.value,
+                self._coordinates.dec.value,
+                str(self._cutout_size[0]).replace(' ', ''), 
+                str(self._cutout_size[1]).replace(' ', ''),
+                self._output_format
+            )
+            cutout_path = Path(self._output_dir, cutout_path).as_posix()
+            Image.fromarray(np.dstack([cutouts[0], cutouts[1], cutouts[2]]).astype(np.uint8)).save(cutout_path)
+
+        else:  # Write each cutout to a separate image file
+            cutout_path = []  # Store the paths of the written cutout files
+            for file, cutout_list in self._cutout_dict.items():
+                if not cutout_list:
+                    warnings.warn("Cutout of {} contains no data and will not be written.".format(file), DataWarning)
+                    continue
+                for i, cutout in enumerate(cutout_list):
+                    # Write individual cutouts to disk
+                    file_path = "{}_{:.7f}_{:.7f}_{}-x-{}_astrocut_{}{}".format(
+                        Path(file).stem,
+                        self._coordinates.ra.value,
+                        self._coordinates.dec.value,
+                        str(self._cutout_size[0]).replace(' ', ''), 
+                        str(self._cutout_size[1]).replace(' ', ''),
+                        i,
+                        self._output_format)
+                    file_path = Path(self._output_dir, file_path).as_posix()
+                    cutout_path.append(file_path)
+                    Image.fromarray(cutout).save(file_path)
+
+        return cutout_path
+
+    def _write_cutouts(self) -> Union[str, List]:
+        """
+        Write the cutout to a file according to the specified output format.
+
+        Returns
+        -------
+        cutout_path : Path | list
+            Cutouts as memory objects or path(s) to the written cutout files.
+
+        Raises
+        ------
+        InvalidInputError
+            If the output format is not supported.
+        """
+        if self._memory_only:
+            # Write only to memory if specified
+            return self._write_to_memory()
+        else:
+            # If writing to disk, ensure that output directory exists
+            Path(self._output_dir).mkdir(parents=True, exist_ok=True)
+
+        if self._output_format == '.fits':
+            return self._write_as_fits()
+        elif self._output_format == '.asdf':
+            return self._write_as_asdf()
+        elif self._output_format in Image.registered_extensions().keys():
+            return self._write_as_img()
+        else:
+            raise InvalidInputError(f"Output format {self._output_format} is not supported.")
+        
+    def cutout(self) -> Union[str, List[str], List[fits.HDUList]]:
+        """
+        Generate cutouts from a list of input images.
+
+        Returns
+        -------
+        cutout_path : Path | list
+            Cutouts as memory objects or path(s) to the written cutout files.
+
+        Raises
+        ------
+        InvalidQueryError
+            If no cutouts contain data.
+        """
+        # Track start time
+        start_time = monotonic()
+
+        # Cutout each input file
+        for file in self._input_files:
+            self._cutout_file(file)
+
+        # If no cutouts contain data, raise exception
+        if all(len(value) == 0 for value in self._cutout_dict.values()):
+            raise InvalidQueryError("Cutout contains no data! (Check image footprint.)")
+
+        # Write cutout(s)
+        cutout_path = self._write_cutouts()
+
+        # Log cutout path and total time elapsed
+        log.debug("Cutout fits file(s): %s", cutout_path)
+        log.debug("Total time: %.2f sec", monotonic() - start_time)
+
+        return cutout_path
+    
+    @staticmethod
+    def normalize_img(img_arr: np.ndarray, stretch: str = 'asinh', minmax_percent: Optional[List[int]] = None, 
+                      minmax_value: Optional[List[int]] = None, invert: bool = False) -> np.ndarray:
+        """
+        Apply given stretch and scaling to an image array.
+
+        Parameters
+        ----------
+        img_arr : array
+            The input image array.
+        stretch : str
+            Optional, default 'asinh'. The stretch to apply to the image array.
+            Valid values are: asinh, sinh, sqrt, log, linear
+        minmax_percent : array
+            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric) 
+            when scaling the image. The format is [lower percentile, upper percentile], where pixel
+            values below the lower percentile and above the upper percentile are clipped.
+            Only one of minmax_percent and minmax_value shoul be specified.
+        minmax_value : array
+            Optional. Interval based on user-specified pixel values when scaling the image.
+            The format is [min value, max value], where pixel values below the min value and above
+            the max value are clipped.
+            Only one of minmax_percent and minmax_value should be specified.
+        invert : bool
+            Optional, default False.  If True the image is inverted (light pixels become dark and vice versa).
+
+        Returns
+        -------
+        response : array
+            The normalized image array, in the form in an integer arrays with values in the range 0-255.
+
+        Raises
+        ------
+        InvalidInputError
+            If the stretch is not supported.
+        """
+
+        # Check if the input image array is empty
+        if img_arr.size == 0:
+            raise InvalidInputError("Input image array is empty.")
+
+        # Setting up the transform with the stretch
+        if stretch == 'asinh':
+            transform = AsinhStretch()
+        elif stretch == 'sinh':
+            transform = SinhStretch()
+        elif stretch == 'sqrt':
+            transform = SqrtStretch()
+        elif stretch == 'log':
+            transform = LogStretch()
+        elif stretch == 'linear':
+            transform = LinearStretch()
+        else:
+            raise InvalidInputError(f"Stretch '{stretch}' is not supported!"
+                                    "Valid options are: asinh, sinh, sqrt, log, linear.")
+
+        # Adding the scaling to the transform
+        if minmax_percent is not None:
+            transform += AsymmetricPercentileInterval(*minmax_percent)
+            
+            if minmax_value is not None:
+                warnings.warn("Both minmax_percent and minmax_value are set, minmax_value will be ignored.",
+                              InputWarning)
+        elif minmax_value is not None:
+            transform += ManualInterval(*minmax_value)
+        else:  # Default, scale the entire image range to [0,1]
+            transform += MinMaxInterval()
+
+        # Performing the transform and then putting it into the integer range 0-255
+        norm_img = transform(img_arr)
+        np.multiply(255, norm_img, out=norm_img)
+        norm_img = norm_img.astype(np.uint8)
+
+        # Applying invert if requested
+        np.subtract(255, norm_img, out=norm_img, where=invert)
+
+        return norm_img

--- a/astrocut/ImageCutout.py
+++ b/astrocut/ImageCutout.py
@@ -110,8 +110,10 @@ class ImageCutout(Cutout, ABC):
         self._output_format = output_format.lower()
         self._cutout_prefix = cutout_prefix
 
-        # Initialize cutout dictionary
+        # Initialize cutout dictionary and counters
         self._cutout_dict = {}
+        self._num_empty = 0
+        self._num_cutouts = 0
 
         # Handle if output format is passed in without a dot
         if not self._output_format.startswith('.'):
@@ -298,7 +300,7 @@ class ImageCutout(Cutout, ABC):
             self._cutout_file(file)
 
         # If no cutouts contain data, raise exception
-        if all(len(value) == 0 for value in self._cutout_dict.values()):
+        if self._num_cutouts == self._num_empty:
             raise InvalidQueryError("Cutout contains no data! (Check image footprint.)")
 
         # Write cutout(s)

--- a/astrocut/ImageCutout.py
+++ b/astrocut/ImageCutout.py
@@ -129,34 +129,6 @@ class ImageCutout(Cutout, ABC):
         if (self._minmax_percent is None) and (self._minmax_value is None):
             self._minmax_percent = [0.5, 99.5]
 
-    def _get_cutout_data(self, data: np.ndarray, wcs_obj: wcs.WCS) -> Cutout2D:
-        """
-        Get the cutout data from the input image.
-
-        Parameters
-        ----------
-        data : array
-            The input image data.
-        wcs : `~astropy.wcs.WCS`
-            The WCS of the input image.
-
-        Returns
-        -------
-        img_cutout : `~astropy.nddata.Cutout2D`
-            The cutout data.
-        """
-        # Using `~astropy.nddata.Cutout2D` to get the cutout data and handle WCS
-        log.debug('Original image shape: %s', data.shape)
-        img_cutout = Cutout2D(data,
-                              position=self._coordinates,
-                              wcs=wcs_obj,
-                              size=(self._cutout_size[1], self._cutout_size[0]),
-                              mode='partial',
-                              fill_value=self._fill_value)
-        log.debug('Image cutout shape: %s', img_cutout.shape)
-
-        return img_cutout
-
     @abstractmethod
     def _cutout_file(self, file: Union[str, Path, S3Path]):
         """

--- a/astrocut/ImageCutout.py
+++ b/astrocut/ImageCutout.py
@@ -111,7 +111,7 @@ class ImageCutout(Cutout, ABC):
         # Assign attributes with defaults if not provided
         stretch = stretch or 'asinh'
         valid_stretches = ['asinh', 'sinh', 'sqrt', 'log', 'linear']
-        if stretch and not isinstance(stretch, str) or stretch.lower() not in valid_stretches:
+        if not isinstance(stretch, str) or stretch.lower() not in valid_stretches:
             raise InvalidInputError(f'Stretch {stretch} is not recognized. Valid options are {valid_stretches}.')
         self._stretch = stretch.lower()
         self._invert = invert or False

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -71,9 +71,9 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
     Returns
     -------
     response : str or list
-        If single_outfile is True returns the single output filepath. Otherwise returns a list of all 
+        If single_outfile is True, returns the single output filepath. Otherwise, returns a list of all 
         the output filepaths.
-        If memory_only is True a list of `~astropy.io.fit.HDUList` objects is returned instead of
+        If memory_only is True, a list of `~astropy.io.fit.HDUList` objects is returned instead of
         file name(s).
     """
     return FITSCutout(input_files,
@@ -191,7 +191,7 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
     Returns
     -------
     response : str or list
-        If colorize is True returns the single output filepath. Otherwise returns a list of all 
+        If colorize is True, returns the single output filepath. Otherwise, returns a list of all 
         the output filepaths.
     """
 

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -2,187 +2,26 @@
 
 """This module implements cutout functionality similar to fitscut."""
 
-import os
-import warnings
-import numpy as np
-from time import monotonic
+from pathlib import Path
+from typing import List, Literal, Optional, Union, Tuple
 
-from astropy import log as astropy_log
-from astropy.io import fits
 from astropy.coordinates import SkyCoord
-from astropy import wcs
-from astropy.visualization import (SqrtStretch, LogStretch, AsinhStretch, SinhStretch, LinearStretch,
-                                   MinMaxInterval, ManualInterval, AsymmetricPercentileInterval)
-
-from PIL import Image
-
-from . import log
-from .utils.utils import _handle_verbose, parse_size_input, get_cutout_limits, get_cutout_wcs, get_fits
-from .exceptions import InputWarning, DataWarning, InvalidQueryError, InvalidInputError
+from astropy.io.fits import HDUList
+from astropy.units import Quantity
+from astropy.utils.decorators import deprecated_renamed_argument
+import numpy as np
+from s3path import S3Path
+from .FITSCutout import FITSCutout
+from .ImageCutout import ImageCutout
 
 
-def _hducut(img_hdu, center_coord, cutout_size, correct_wcs=False, verbose=False):
-    """
-    Takes an ImageHDU (image and associated metatdata in the fits format), as well as a center 
-    coordinate and size and make a cutout of that image, which is returned as another ImageHDU,
-    including updated  WCS information.
-
-
-    Parameters
-    ----------
-    img_hdu : `~astropy.io.fits.hdu.image.ImageHDU`
-        The image and assciated metadata that is being cut out.
-    center_coord : `~astropy.coordinates.sky_coordinate.SkyCoord`
-        The coordinate to cut out around.
-    cutout_size : array
-        The size of the cutout as [nx,ny], where nx/ny can be integers (assumed to be pixels)
-        or `~astropy.Quantity` values, either pixels or angular quantities.
-    correct_wcs : bool
-        Default False. If true a new WCS will be created for the cutout that is tangent projected
-        and does not include distortions.  
-    verbose : bool
-        Default False. If true intermediate information is printed.
-
-    Returns
-    -------
-    response : `~astropy.io.fits.hdu.image.ImageHDU` 
-        The cutout image and associated metadata.
-    """
-    # Log messages based on verbosity
-    _handle_verbose(verbose)
-    hdu_header = fits.Header(img_hdu.header, copy=True)
-
-    # We are going to reroute the logging to a string stream temporarily so we can
-    # intercept any message from astropy, chiefly the "Inconsistent SIP distortion information"
-    # INFO message which will indicate that we need to remove existing SIP keywords
-    # from a WCS whose CTYPE does not include SIP. In this we are taking the CTYPE to be
-    # correct and adjusting the header keywords to match.
-    hdlrs = astropy_log.handlers
-    astropy_log.handlers = []
-    with astropy_log.log_to_list() as log_list:        
-        img_wcs = wcs.WCS(hdu_header, relax=True)
-
-    for hd in hdlrs:
-        astropy_log.addHandler(hd)
-
-    no_sip = False
-    if (len(log_list) > 0):
-        if ("Inconsistent SIP distortion information" in log_list[0].msg):
-
-            # Remove sip coefficients
-            img_wcs.sip = None
-            no_sip = True
-            
-        else:  # Message(s) we didn't prepare for we want to go ahead and display
-            for log_rec in log_list:
-                astropy_log.log(log_rec.levelno, log_rec.msg, extra={"origin": log_rec.name})
-
-    img_data = img_hdu.section
-
-    log.debug("Original image shape: %s", img_data.shape)
-
-    # Get cutout limits
-    cutout_lims = get_cutout_limits(img_wcs, center_coord, cutout_size)
-
-    log.debug("xmin,xmax: %s", cutout_lims[0])
-    log.debug("ymin,ymax: %s", cutout_lims[1])
-
-    # These limits are not guarenteed to be within the image footprint
-    xmin, xmax = cutout_lims[0]
-    ymin, ymax = cutout_lims[1]
-
-    ymax_img, xmax_img = img_data.shape
-
-    # Check the cutout is on the image
-    if (xmax <= 0) or (xmin >= xmax_img) or (ymax <= 0) or (ymin >= ymax_img):
-        raise InvalidQueryError("Cutout location is not in image footprint!")
-
-    # Adjust limits and figuring out the` padding
-    padding = np.zeros((2, 2), dtype=int)
-    if xmin < 0:
-        padding[1, 0] = -xmin
-        xmin = 0
-    if ymin < 0:
-        padding[0, 0] = -ymin
-        ymin = 0
-    if xmax > xmax_img:
-        padding[1, 1] = xmax - xmax_img
-        xmax = xmax_img
-    if ymax > ymax_img:
-        padding[0, 1] = ymax - ymax_img
-        ymax = ymax_img  
-        
-    img_cutout = img_hdu.section[ymin:ymax, xmin:xmax]
-
-    # Adding padding to the cutout so that it's the expected size
-    if padding.any():  # only do if we need to pad
-        img_cutout = np.pad(img_cutout, padding, 'constant', constant_values=np.nan)
-
-    log.debug("Image cutout shape: %s", img_cutout.shape)
-
-    # Getting the cutout wcs
-    cutout_wcs = get_cutout_wcs(img_wcs, cutout_lims)
-
-    # Updating the header with the new wcs info
-    if no_sip:
-        hdu_header.update(cutout_wcs.to_header(relax=False))
-    else:
-        hdu_header.update(cutout_wcs.to_header(relax=True))  # relax arg is for sip distortions if they exist
-
-    # Naming the extension and preserving the original name
-    hdu_header["O_EXT_NM"] = (hdu_header.get("EXTNAME"), "Original extension name.")
-    hdu_header["EXTNAME"] = "CUTOUT"
-
-    # Moving the filename, if present, into the ORIG_FLE keyword
-    hdu_header["ORIG_FLE"] = (hdu_header.get("FILENAME"), "Original image filename.")
-    hdu_header.remove("FILENAME", ignore_missing=True)
-
-    hdu = fits.ImageHDU(header=hdu_header, data=img_cutout)
-
-    return hdu
-
-
-def _parse_extensions(infile_exts, infile_name, user_exts):
-    """
-    Given a list of image extensions available in the file with infile_name, cross-match with
-    user input extensions to figure out which extensions to use for cutout.
-
-    Parameters
-    ----------
-    infile_exts : array
-    infile_name : str
-    user_exts : int, list of ints, None, or 'all'
-        Optional, default None. Default is to cutout the first extension that has image data.
-        The user can also supply one or more extensions to cutout from (integers), or "all".
-
-    Returns
-    -------
-    response : array
-        List of extensions to be cutout.
-    """
- 
-    if len(infile_exts) == 0:
-        warnings.warn(f"No image extensions with data found in {infile_name}, skipping...",
-                      DataWarning)
-        return []
-            
-    if user_exts is None:
-        cutout_exts = infile_exts[:1]  # Take the first image extension
-    elif user_exts == 'all':
-        cutout_exts = infile_exts  # Take all the extensions
-    else:  # User input extentions
-        cutout_exts = [x for x in infile_exts if x in user_exts]
-        if len(cutout_exts) < len(user_exts):
-            warnings.warn((f"Not all requested extensions in {infile_name} are image extensions or have data, "
-                           f"extension(s) {','.join([x for x in user_exts if x not in cutout_exts])} will be skipped."),
-                          DataWarning)
-
-    return cutout_exts
-
-                    
-def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, extension=None, 
-             single_outfile=True, cutout_prefix="cutout", output_dir='.',
-             memory_only=False, verbose=False):
+@deprecated_renamed_argument('correct_wcs', None, '1.0.0', warning_type=DeprecationWarning,
+                             message='`correct_wcs` is non-operational and will be removed in a future version.')
+def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
+             cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
+             correct_wcs: bool = False, extension: Optional[Union[int, List[int], Literal['all']]] = None,
+             single_outfile: bool = True, cutout_prefix: str = "cutout", output_dir: Union[str, Path] = '.', 
+             memory_only: bool = False, verbose=False) -> Union[str, List[str], List[HDUList]]:
     """
     Takes one or more fits files with the same WCS/pointing, makes the same cutout in each file,
     and returns the result either in a single FITS file with one cutout per extension or in 
@@ -205,9 +44,6 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, extension
         If ``cutout_size`` has two elements, they should be in ``(ny, nx)`` order.  Scalar numbers 
         in ``cutout_size`` are assumed to be in units of pixels. `~astropy.units.Quantity` objects 
         must be in pixel or angular units.
-    correct_wcs : bool
-        Default False. If true a new WCS will be created for the cutout that is tangent projected
-        and does not include distortions.
     extension : int, list of ints, None, or 'all'
        Optional, default None. Default is to cutout the first extension that has image data.
        The user can also supply one or more extensions to cutout from (integers), or 'all'.
@@ -240,147 +76,20 @@ def fits_cut(input_files, coordinates, cutout_size, correct_wcs=False, extension
         If memory_only is True a list of `~astropy.io.fit.HDUList` objects is returned instead of
         file name(s).
     """
-    # Log messages based on verbosity
-    _handle_verbose(verbose)
-    start_time = monotonic()
-            
-    # Making sure we have an array of images
-    if isinstance(input_files, str):
-        input_files = [input_files]
-
-    # If a single extension is given, make it a list
-    if isinstance(extension, int):
-        extension = [extension]
-
-    if not isinstance(coordinates, SkyCoord):
-        coordinates = SkyCoord(coordinates, unit='deg')
-
-    # Turning the cutout size into a 2 member array
-    cutout_size = parse_size_input(cutout_size)
-
-    log.debug("Number of input files: %d", len(input_files))
-    if extension:
-        log.debug("Cutting out %s extension(s)", extension)
-    log.debug("Center coordinate: %s deg", coordinates)
-    log.debug("Cutout size: %s", cutout_size)
-
-    # Making the cutouts
-    cutout_hdu_dict = {}
-    num_empty = 0
-    num_cutouts = 0
-    fsspec_kwargs = None
-    for in_fle in input_files:
-        log.debug("\nCutting out %s", in_fle)
-
-        if "s3://" in in_fle:
-            fsspec_kwargs = {"anon": True}
-
-        warnings.filterwarnings("ignore", category=wcs.FITSFixedWarning)
-        with fits.open(in_fle, mode='denywrite', memmap=True, fsspec_kwargs=fsspec_kwargs) as hdulist:
-
-            # Sorting out which extension(s) to cutout
-            all_inds = np.where([hdu.is_image and hdu.size > 0 for hdu in hdulist])[0]
-            cutout_inds = _parse_extensions(all_inds, in_fle, extension)
-
-            num_cutouts += len(cutout_inds)
-            for ind in cutout_inds:            
-                try:
-                    cutout = _hducut(hdulist[ind], coordinates, cutout_size,
-                                     correct_wcs=correct_wcs, verbose=verbose)
-
-                    # Check that there is data in the cutout image
-                    if (cutout.data == 0).all() or (np.isnan(cutout.data)).all():
-                        cutout.header["EMPTY"] = (True, "Indicates no data in cutout image.")
-                        num_empty += 1
-
-                    # Adding a few more keywords
-                    cutout.header["ORIG_EXT"] = (ind, "Extension in original file.")
-                    if not cutout.header.get("ORIG_FLE") and hdulist[0].header.get("FILENAME"):
-                        cutout.header["ORIG_FLE"] = hdulist[0].header.get("FILENAME")
-                    
-                    cutout_hdu_dict[in_fle] = cutout_hdu_dict.get(in_fle, []) + [cutout]
-                    
-                except OSError as err:
-                    warnings.warn((f"Error {err} encountered when performing cutout on {in_fle}, "
-                                   f"extension {ind}, skipping..."),
-                                  DataWarning)
-                    num_empty += 1
-
-    # If no cutouts contain data, raise exception
-    if num_empty == num_cutouts:
-        raise InvalidQueryError("Cutout contains no data! (Check image footprint.)")
-
-    # Make sure the output directory exists
-    if not memory_only and not os.path.exists(output_dir):
-        os.makedirs(output_dir)
-        
-    # Setting up the output file(s) and writing them
-    cutout_path = None
-    if single_outfile:
-
-        log.debug("Returning cutout as single FITS")
-
-        if not memory_only:
-            cutout_path = "{}_{:7f}_{:7f}_{}-x-{}_astrocut.fits".format(cutout_prefix,
-                                                                        coordinates.ra.value,
-                                                                        coordinates.dec.value,
-                                                                        str(cutout_size[0]).replace(' ', ''), 
-                                                                        str(cutout_size[1]).replace(' ', ''))
-            cutout_path = os.path.join(output_dir, cutout_path)
-            log.debug("Cutout fits file: %s", cutout_path)
-            
-        cutout_hdus = [x for fle in cutout_hdu_dict for x in cutout_hdu_dict[fle]]    
-        cutout_fits = get_fits(cutout_hdus, coordinates, cutout_path)
-        
-        if memory_only:
-            all_hdus = [cutout_fits]
-        else:
-            all_paths = cutout_path
-
-    else:  # one output file per input file
-
-        log.debug("Returning cutouts as individual FITS")
-            
-        if memory_only:
-            all_hdus = []
-        else:
-            all_paths = []
-            log.debug("Cutout fits files:")
-            
-        for fle in input_files:
-            cutout_list = cutout_hdu_dict[fle]
-            if np.array([x.header.get("EMPTY") for x in cutout_list]).all():
-                warnings.warn(f"Cutout of {fle} contains no data and will not be written.",
-                              DataWarning)
-                continue
-
-            if memory_only:
-                cutout_path = None
-            else:
-                filename = "{}_{:7f}_{:7f}_{}-x-{}_astrocut.fits".format(os.path.basename(fle).rstrip('.fits'),
-                                                                         coordinates.ra.value,
-                                                                         coordinates.dec.value,
-                                                                         str(cutout_size[0]).replace(' ', ''), 
-                                                                         str(cutout_size[1]).replace(' ', ''))
-                cutout_path = os.path.join(output_dir, filename)
-
-            cutout_fits = get_fits(cutout_list, coordinates, cutout_path)
-
-            if memory_only:
-                all_hdus.append(cutout_fits)
-            else:
-                all_paths.append(cutout_path)
-                log.debug(cutout_path)
-        
-    log.debug("Total time: %.2f sec", monotonic() - start_time)
-
-    if memory_only:
-        return all_hdus
-    else:
-        return all_paths
+    return FITSCutout(input_files,
+                      coordinates=coordinates,
+                      cutout_size=cutout_size,
+                      memory_only=memory_only,
+                      output_dir=output_dir,
+                      output_format='.fits',
+                      extension=extension,
+                      single_outfile=single_outfile,
+                      cutout_prefix=cutout_prefix,
+                      verbose=verbose).cutout()
 
 
-def normalize_img(img_arr, stretch='asinh', minmax_percent=None, minmax_value=None, invert=False):
+def normalize_img(img_arr: np.ndarray, stretch: str = 'asinh', minmax_percent: Optional[List[int]] = None, 
+                  minmax_value: Optional[List[int]] = None, invert: bool = False) -> np.ndarray:
     """
     Apply given stretch and scaling to an image array.
 
@@ -409,49 +118,20 @@ def normalize_img(img_arr, stretch='asinh', minmax_percent=None, minmax_value=No
     response : array
         The normalized image array, in the form in an integer arrays with values in the range 0-255.
     """
+    return ImageCutout.normalize_img(img_arr=img_arr,
+                                     stretch=stretch,
+                                     minmax_percent=minmax_percent,
+                                     minmax_value=minmax_value,
+                                     invert=invert)
 
 
-    # Setting up the transform with the stretch
-    if stretch == 'asinh':
-        transform = AsinhStretch()
-    elif stretch == 'sinh':
-        transform = SinhStretch()
-    elif stretch == 'sqrt':
-        transform = SqrtStretch()
-    elif stretch == 'log':
-        transform = LogStretch()
-    elif stretch == 'linear':
-        transform = LinearStretch()
-    else:
-        raise InvalidInputError("Stretch {} is not supported!".format(stretch))
-
-    # Adding the scaling to the transform
-    if minmax_percent is not None:
-        transform += AsymmetricPercentileInterval(*minmax_percent)
-        
-        if minmax_value is not None:
-            warnings.warn("Both minmax_percent and minmax_value are set, minmax_value will be ignored.",
-                          InputWarning)
-    elif minmax_value is not None:
-        transform += ManualInterval(*minmax_value)
-    else:  # Default, scale the entire image range to [0,1]
-        transform += MinMaxInterval()
-   
-    # Performing the transform and then putting it into the integer range 0-255
-    norm_img = transform(img_arr)
-    norm_img = np.multiply(255, norm_img, out=norm_img)
-    norm_img = norm_img.astype(np.uint8)
-
-    # Applying invert if requested
-    if invert:
-        norm_img = 255 - norm_img
-
-    return norm_img
-
-
-def img_cut(input_files, coordinates, cutout_size, stretch='asinh', minmax_percent=None,
-            minmax_value=None, invert=False, img_format='jpg', colorize=False,
-            cutout_prefix="cutout", output_dir='.', extension=None, verbose=False):
+def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
+            cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25, stretch: str = 'asinh', 
+            minmax_percent: Optional[List[int]] = None, minmax_value: Optional[List[int]] = None, 
+            invert: bool = False, img_format: str = '.jpg', colorize: bool = False,
+            cutout_prefix: str = "cutout", output_dir: Union[str, Path] = '.', 
+            extension: Optional[Union[int, List[int], Literal['all']]] = None, fill_value: Union[int, float] = np.nan,
+            limit_rounding_method: str = 'round', verbose=False) -> Union[str, List[str]]:
     """
     Takes one or more fits files with the same WCS/pointing, makes the same cutout in each file,
     and returns the result either as a single color image or in individual image files.
@@ -472,6 +152,8 @@ def img_cut(input_files, coordinates, cutout_size, stretch='asinh', minmax_perce
         If ``cutout_size`` has two elements, they should be in ``(ny, nx)`` order.  Scalar numbers 
         in ``cutout_size`` are assumed to be in units of pixels. `~astropy.units.Quantity` objects 
         must be in pixel or angular units.
+    fill_value : int | float
+        Value to fill the cutout with if the cutout is outside the image.
     stretch : str
         Optional, default 'asinh'. The stretch to apply to the image array.
         Valid values are: asinh, sinh, sqrt, log, linear
@@ -497,6 +179,8 @@ def img_cut(input_files, coordinates, cutout_size, stretch='asinh', minmax_perce
         cutout filename. 
     output_dir : str
         Defaul value '.'. The directory to save the cutout file(s) to.
+    limit_rounding_method : str
+        Method to use for rounding the cutout limits. Options are 'round', 'ceil', and 'floor'.
     extension : int, list of ints, None, or 'all'
         Optional, default None. Default is to cutout the first extension that has image data.
         The user can also supply one or more extensions to cutout from (integers), or "all".
@@ -509,113 +193,19 @@ def img_cut(input_files, coordinates, cutout_size, stretch='asinh', minmax_perce
         If colorize is True returns the single output filepath. Otherwise returns a list of all 
         the output filepaths.
     """
-    # Log messages based on verbosity
-    _handle_verbose(verbose)
-    start_time = monotonic()
-            
-    # Making sure we have an array of images
-    if isinstance(input_files, str):
-        input_files = [input_files]
-            
-    if not isinstance(coordinates, SkyCoord):
-        coordinates = SkyCoord(coordinates, unit='deg')
 
-    # Turning the cutout size into a 2 member array
-    cutout_size = parse_size_input(cutout_size)
-
-    # Applying the default scaling
-    if (minmax_percent is None) and (minmax_value is None):
-        minmax_percent = [0.5, 99.5]
-        
-    # Making the cutouts
-    cutout_hdu_dict = {}
-    for in_fle in input_files:
-        log.debug("\n%s", in_fle)
-
-
-        warnings.filterwarnings("ignore", category=wcs.FITSFixedWarning)
-        with fits.open(in_fle, mode='denywrite', memmap=True) as hdulist:
-
-            # Sorting out which extension(s) to cutout
-            all_inds = np.where([hdu.is_image and hdu.size > 0 for hdu in hdulist])[0]
-            cutout_inds = _parse_extensions(all_inds, in_fle, extension)
-
-            for ind in cutout_inds:   
-                try:
-                    cutout = _hducut(hdulist[ind], coordinates, cutout_size, correct_wcs=False, verbose=verbose)
-
-                    # We just want the data array
-                    cutout = cutout.data
-        
-                    # Applying the appropriate normalization parameters
-                    normalized_cutout = normalize_img(cutout, stretch, minmax_percent, minmax_value, invert)
-        
-                    # Check that there is data in the cutout image
-                    if not (cutout == 0).all():
-                        cutout_hdu_dict[in_fle] = cutout_hdu_dict.get(in_fle, []) + [normalized_cutout]
-                    
-                except OSError as err:
-                    warnings.warn("Error {} encountered when performing cutout on {}, skipping...".format(err, in_fle),
-                                  DataWarning)
-
-    # If no cutouts contain data, raise exception
-    if not cutout_hdu_dict:
-        raise InvalidQueryError("Cutout contains no data! (Check image footprint.)")
-
-    # Make sure the output directory exists
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
-        
-    # Setting up the output file(s) and writing them
-    if colorize:
-        cutouts = [x for fle in input_files for x in cutout_hdu_dict.get(fle, [])]
-        
-        # Doing checks correct number of cutouts
-        if len(cutouts) < 3:
-            raise InvalidInputError(("Color cutouts require 3 input images (RGB)."
-                                     "If you supplied 3 images one of the cutouts may have been empty."))
-        if len(cutouts) > 3:
-            warnings.warn("Too many inputs for a color cutout, only the first three will be used.",
-                          InputWarning)
-            cutouts = cutouts[:3]
-
-            
-        cutout_path = "{}_{:7f}_{:7f}_{}-x-{}_astrocut.{}".format(cutout_prefix,
-                                                                  coordinates.ra.value,
-                                                                  coordinates.dec.value,
-                                                                  str(cutout_size[0]).replace(' ', ''), 
-                                                                  str(cutout_size[1]).replace(' ', ''),
-                                                                  img_format.lower()) 
-        cutout_path = os.path.join(output_dir, cutout_path)
-
-        Image.fromarray(np.dstack([cutouts[0], cutouts[1], cutouts[2]]).astype(np.uint8)).save(cutout_path)
-          
-    else:
- 
-        cutout_path = []
-        for fle in input_files:
-
-            if cutout_hdu_dict.get(fle) is None:
-                warnings.warn("Cutout of {} contains no data and will not be written.".format(fle),
-                              DataWarning)
-                continue
-
-            for i, cutout in enumerate(cutout_hdu_dict.get(fle)):
-
-
-                file_path = "{}_{:7f}_{:7f}_{}-x-{}_astrocut_{}.{}".format(os.path.basename(fle).rstrip('.fits'),
-                                                                           coordinates.ra.value,
-                                                                           coordinates.dec.value,
-                                                                           str(cutout_size[0]).replace(' ', ''), 
-                                                                           str(cutout_size[1]).replace(' ', ''),
-                                                                           i,
-                                                                           img_format.lower())
-                file_path = os.path.join(output_dir, file_path)
-                cutout_path.append(file_path)
-            
-                Image.fromarray(cutout).save(file_path)
-        
-    log.debug("Cutout fits file(s): %s", cutout_path)
-    log.debug("Total time: %.2f sec", monotonic() - start_time)
-
-    return cutout_path
+    return FITSCutout(input_files=input_files,
+                      coordinates=coordinates,
+                      cutout_size=cutout_size,
+                      fill_value=fill_value,
+                      output_dir=output_dir,
+                      limit_rounding_method=limit_rounding_method,
+                      stretch=stretch,
+                      minmax_percent=minmax_percent,
+                      minmax_value=minmax_value,
+                      invert=invert,
+                      colorize=colorize,
+                      output_format=img_format,
+                      cutout_prefix=cutout_prefix,
+                      extension=extension,
+                      verbose=verbose).cutout()

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -20,10 +20,11 @@ from .ImageCutout import ImageCutout
 def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
              cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
              correct_wcs: bool = False, extension: Optional[Union[int, List[int], Literal['all']]] = None,
-             single_outfile: bool = True, cutout_prefix: str = "cutout", output_dir: Union[str, Path] = '.', 
-             memory_only: bool = False, verbose=False) -> Union[str, List[str], List[HDUList]]:
+             single_outfile: bool = True, cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.', 
+             memory_only: bool = False, limit_rounding_method: str = 'round', 
+             verbose=False) -> Union[str, List[str], List[HDUList]]:
     """
-    Takes one or more fits files with the same WCS/pointing, makes the same cutout in each file,
+    Takes one or more FITS files with the same WCS/pointing, makes the same cutout in each file,
     and returns the result either in a single FITS file with one cutout per extension or in 
     individual fits files. The memory_only flag allows the cutouts to be returned as 
     `~astropy.io.fits.HDUList` objects rather than saving to disk.
@@ -62,11 +63,10 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
         the cutout(s) are returned as a list of `~astropy.io.fit.HDUList` objects. If set to
         True cutout_prefix and output_dir are ignored, however single_outfile can still be used to
         set the number of returned `~astropy.io.fits.HDUList` objects.
+    limit_rounding_method : str
+        Method to use for rounding the cutout limits. Options are 'round', 'ceil', and 'floor'.
     verbose : bool
         Default False. If true intermediate information is printed.
-    fsspec_kwargs : any
-        Default value {"anon": True}. This parameter should be used to provide cloud credentials to
-        access private data buckets (e.g. {"key": "YOUR-SECRET-KEY-ID", "secret": "YOUR-SECRET-KEY"}).
 
     Returns
     -------
@@ -81,6 +81,7 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
                       cutout_size=cutout_size,
                       memory_only=memory_only,
                       output_dir=output_dir,
+                      limit_rounding_method=limit_rounding_method,
                       output_format='.fits',
                       extension=extension,
                       single_outfile=single_outfile,
@@ -129,7 +130,7 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
             cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25, stretch: str = 'asinh', 
             minmax_percent: Optional[List[int]] = None, minmax_value: Optional[List[int]] = None, 
             invert: bool = False, img_format: str = '.jpg', colorize: bool = False,
-            cutout_prefix: str = "cutout", output_dir: Union[str, Path] = '.', 
+            cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.', 
             extension: Optional[Union[int, List[int], Literal['all']]] = None, fill_value: Union[int, float] = np.nan,
             limit_rounding_method: str = 'round', verbose=False) -> Union[str, List[str]]:
     """

--- a/astrocut/cutouts.py
+++ b/astrocut/cutouts.py
@@ -32,6 +32,9 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
     Note: No checking is done on either the WCS pointing or pixel scale. If images don't line up
     the cutouts will also not line up.
 
+    This function is maintained for backwards compatibility. For maximum flexibility, we recommend using
+    ``FITSCutout`` directly.
+
     Parameters
     ----------
     input_files : list
@@ -139,6 +142,9 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
 
     Note: No checking is done on either the WCS pointing or pixel scale. If images don't line up
     the cutouts will also not line up.
+
+    This function is maintained for backwards compatibility. For maximum flexibility, we recommend using
+    ``FITSCutout`` directly.
 
     Parameters
     ----------

--- a/astrocut/tests/test_FITSCutout.py
+++ b/astrocut/tests/test_FITSCutout.py
@@ -22,21 +22,13 @@ from ..exceptions import DataWarning, InputWarning, InvalidInputError, InvalidQu
 
 @pytest.fixture(params=['SPOC', 'TICA'])
 def test_images(request, tmpdir):
-    if request.param == 'SPOC':
-        return create_test_imgs('SPOC', 50, 6, dir_name=tmpdir)
-    else:
-        return create_test_imgs('TICA', 50, 6, dir_name=tmpdir)
-
+    create_test_imgs(request.param, 50, 6, dir_name=tmpdir)
 
 # Fixture to create a test image with bad SIP keywords
 @pytest.fixture(params=['SPOC', 'TICA'])
 def test_image_bad_sip(request, tmpdir):
-    if request.param == 'SPOC':
-        return create_test_imgs('SPOC', 50, 1, dir_name=tmpdir,
-                                basename="img_badsip_{:04d}.fits", bad_sip_keywords=True)[0]
-    else:
-        return create_test_imgs('TICA', 50, 1, dir_name=tmpdir,
-                                basename="img_badsip_{:04d}.fits", bad_sip_keywords=True)[0]
+    return create_test_imgs(request.param, 50, 1, dir_name=tmpdir,
+                            basename="img_badsip_{:04d}.fits", bad_sip_keywords=True)[0]
     
 
 # Fixture to return a center coordinate
@@ -111,6 +103,8 @@ def test_fits_cutout_multiple_files(tmpdir, test_images, center_coord, cutout_si
         assert round(float(sra), 4) == round(center_coord.ra.deg, 4)
         assert round(float(sdec), 4) == round(center_coord.dec.deg, 4)
 
+        cutout_hdulist.close()
+
     # Test case where output directory does not exist
     new_dir = path.join(tmpdir, 'cutout_files')  # non-existing directory to write files to
     cutout_files = FITSCutout(test_images, center_coord, cutout_size,
@@ -120,8 +114,6 @@ def test_fits_cutout_multiple_files(tmpdir, test_images, center_coord, cutout_si
     assert len(cutout_files) == len(test_images)
     assert new_dir in cutout_files[0]
     assert path.exists(new_dir)  # new directory should now exist
-
-    cutout_hdulist.close()
 
 
 def test_fits_cutout_memory_only(test_images, center_coord, cutout_size):

--- a/astrocut/tests/test_FITSCutout.py
+++ b/astrocut/tests/test_FITSCutout.py
@@ -1,0 +1,524 @@
+# Fixture to create test images for both SPOC and TICA
+import pytest
+
+import numpy as np
+from os import path
+from re import findall
+
+from astropy.io import fits
+from astropy import wcs
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+
+from PIL import Image
+
+from astrocut.FITSCutout import FITSCutout
+from astrocut.ImageCutout import ImageCutout
+
+from .utils_for_test import create_test_imgs
+from ..exceptions import DataWarning, InputWarning, InvalidInputError, InvalidQueryError
+
+
+@pytest.fixture(params=['SPOC', 'TICA'])
+def test_images(request, tmpdir):
+    if request.param == 'SPOC':
+        return create_test_imgs('SPOC', 50, 6, dir_name=tmpdir)
+    else:
+        return create_test_imgs('TICA', 50, 6, dir_name=tmpdir)
+
+
+# Fixture to create a test image with bad SIP keywords
+@pytest.fixture(params=['SPOC', 'TICA'])
+def test_image_bad_sip(request, tmpdir):
+    if request.param == 'SPOC':
+        return create_test_imgs('SPOC', 50, 1, dir_name=tmpdir,
+                                basename="img_badsip_{:04d}.fits", bad_sip_keywords=True)[0]
+    else:
+        return create_test_imgs('TICA', 50, 1, dir_name=tmpdir,
+                                basename="img_badsip_{:04d}.fits", bad_sip_keywords=True)[0]
+    
+
+# Fixture to return a center coordinate
+@pytest.fixture
+def center_coord():
+    return SkyCoord('150.1163213 2.200973097', unit='deg')
+
+
+# Fixture to return a cutout size
+@pytest.fixture
+def cutout_size():
+    return 10
+
+
+def test_fits_cutout_single_outfile(test_images, center_coord, cutout_size, tmpdir):
+    # Create cutout with single output file
+    cutout = FITSCutout(test_images, center_coord, cutout_size, single_outfile=True, output_dir=tmpdir).cutout()
+
+    # Should output a single string
+    assert isinstance(cutout, str)
+
+    # Open output file
+    cutout_hdulist = fits.open(cutout)
+    assert len(cutout_hdulist) == len(test_images) + 1  # num imgs + primary header
+
+    # Check shape of data
+    cut1 = cutout_hdulist[1].data
+    assert cut1.shape == (cutout_size, cutout_size)
+    assert cutout_hdulist[1].data.shape == cutout_hdulist[2].data.shape
+    assert cutout_hdulist[2].data.shape == cutout_hdulist[3].data.shape
+    assert cutout_hdulist[3].data.shape == cutout_hdulist[4].data.shape
+    assert cutout_hdulist[4].data.shape == cutout_hdulist[5].data.shape
+    assert cutout_hdulist[5].data.shape == cutout_hdulist[6].data.shape
+
+    # Check that data is equal between cutout and original image
+    for i, img in enumerate(test_images):
+        with fits.open(img) as test_hdu:
+            assert np.all(cutout_hdulist[i + 1].data == test_hdu[0].data[19:29, 19:29])
+    
+    # Check WCS and position of center
+    cut_wcs = wcs.WCS(cutout_hdulist[1].header)
+    sra, sdec = cut_wcs.all_pix2world(cutout_size/2, cutout_size/2, 0)
+    assert round(float(sra), 4) == round(center_coord.ra.deg, 4)
+    assert round(float(sdec), 4) == round(center_coord.dec.deg, 4)
+
+    cutout_hdulist.close()
+
+
+def test_fits_cutout_multiple_files(tmpdir, test_images, center_coord, cutout_size):
+    # Output is multiple files
+    cutout_files = FITSCutout(test_images, center_coord, cutout_size, single_outfile=False, output_dir=tmpdir).cutout()
+
+    # Output is a list with paths to each file
+    assert isinstance(cutout_files, list)
+    assert len(cutout_files) == len(test_images)
+    
+    for i, cutout in enumerate(cutout_files):
+        cutout_hdulist = fits.open(cutout)
+        cut1 = cutout_hdulist[1].data
+
+        # Check shape of data
+        assert len(cutout_hdulist) == 2  # primary header + 1 image
+        assert cut1.shape == (cutout_size, cutout_size)
+        
+        # Check that data is equal between cutout and original image
+        with fits.open(test_images[i]) as test_hdu:
+            assert np.all(cut1 == test_hdu[0].data[19:29, 19:29])
+    
+        # Check WCS and position of center
+        cut_wcs = wcs.WCS(cutout_hdulist[1].header)
+        sra, sdec = cut_wcs.all_pix2world(cutout_size/2, cutout_size/2, 0)
+        assert round(float(sra), 4) == round(center_coord.ra.deg, 4)
+        assert round(float(sdec), 4) == round(center_coord.dec.deg, 4)
+
+    # Test case where output directory does not exist
+    new_dir = path.join(tmpdir, 'cutout_files')  # non-existing directory to write files to
+    cutout_files = FITSCutout(test_images, center_coord, cutout_size,
+                              output_dir=new_dir, single_outfile=False).cutout()
+
+    assert isinstance(cutout_files, list)
+    assert len(cutout_files) == len(test_images)
+    assert new_dir in cutout_files[0]
+    assert path.exists(new_dir)  # new directory should now exist
+
+    cutout_hdulist.close()
+
+
+def test_fits_cutout_memory_only(test_images, center_coord, cutout_size):
+    # Memory only, single file
+    nonexisting_dir = 'nonexisting'  # non-existing directory to check that no files are written
+    cutout_list = FITSCutout(test_images, center_coord, cutout_size, output_dir=nonexisting_dir,
+                             single_outfile=True, memory_only=True).cutout()
+    cutout_hdu = cutout_list[0]
+    assert isinstance(cutout_list, list)
+    assert len(cutout_list) == 1
+    assert isinstance(cutout_hdu, fits.HDUList)
+    assert not path.exists(nonexisting_dir)  # no files should be written
+
+    # Memory only, multiple files
+    cutout_list = FITSCutout(test_images, center_coord, cutout_size, output_dir=nonexisting_dir, 
+                             single_outfile=False, memory_only=True).cutout()
+    assert isinstance(cutout_list, list)
+    assert len(cutout_list) == len(test_images)
+    assert isinstance(cutout_list[0], fits.HDUList)
+    assert not path.exists(nonexisting_dir)  # no files should be written
+
+
+def test_fits_cutout_off_edge(tmpdir, test_images, cutout_size):
+    #  Off the top
+    center_coord = SkyCoord("150.1163213 2.2005731", unit='deg')
+    cutout_file = FITSCutout(test_images, center_coord, cutout_size, single_outfile=True, output_dir=tmpdir).cutout()
+    assert isinstance(cutout_file, str)
+    
+    cutout_hdulist = fits.open(cutout_file)
+    assert len(cutout_hdulist) == len(test_images) + 1  # num imgs + primary header
+
+    cut1 = cutout_hdulist[1].data
+    assert cut1.shape == (cutout_size, cutout_size)
+    assert np.isnan(cut1[:cutout_size//2, :]).all()
+
+    cutout_hdulist.close()
+
+    # Off the bottom
+    center_coord = SkyCoord("150.1163213 2.2014", unit='deg')
+    cutout = FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True).cutout()
+    assert np.isnan(cutout[0][1].data[cutout_size//2:, :]).all()
+
+    # Off the left, with integer fill value
+    center_coord = SkyCoord('150.11672 2.200973097', unit='deg')
+    cutout = FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True, fill_value=1).cutout()
+    assert np.all(cutout[0][1].data[:, :cutout_size//2] == 1)
+
+    # Off the right, with float fill value
+    center_coord = SkyCoord('150.11588 2.200973097', unit='deg')
+    cutout = FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True, fill_value=1.5).cutout()
+    assert np.all(cutout[0][1].data[:, cutout_size//2:] == 1.5)
+
+    # Error if unexpected fill value
+    with pytest.raises(InvalidInputError, match='Fill value must be an integer or a float.'):
+        FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True, fill_value='invalid').cutout()
+
+
+def test_fits_cutout_cloud(tmpdir):
+    # Test single cloud image
+    test_s3_uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
+    center_coord = SkyCoord("150.4275416667 2.42155", unit='deg')
+    cutout_size = [10, 15]
+    cutout_file = FITSCutout(test_s3_uri, center_coord, cutout_size, output_dir=tmpdir).cutout()
+    assert isinstance(cutout_file, str)
+    assert "10-x-15" in cutout_file
+    
+    with fits.open(cutout_file) as cutout_hdulist:
+        assert cutout_hdulist[1].data.shape == (15, 10)
+
+
+def test_fits_cutout_rounding(test_images, cutout_size):
+    # Rounding normally
+    center_coord = SkyCoord("150.1163117 2.200973097", unit='deg')
+    cutout_list = FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True).cutout()
+    test_hdu = fits.open(test_images[0])
+    assert np.all(cutout_list[0][1].data == test_hdu[0].data[19:29, 20:30])
+
+    # Rounding to ceiling
+    cutout_list = FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True, 
+                             limit_rounding_method='ceil').cutout()
+    assert np.all(cutout_list[0][1].data == test_hdu[0].data[20:30, 20:30])
+
+    # Rounding to floor
+    cutout_list = FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True, 
+                             limit_rounding_method='floor').cutout()
+    assert np.all(cutout_list[0][1].data == test_hdu[0].data[19:29, 19:29])
+
+    # Case that the cutout rounds to zero
+    cutout_size = 0.57557495
+    cutout_list = FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True, 
+                             limit_rounding_method='round').cutout()
+    assert np.all(cutout_list[0][1].data == test_hdu[0].data[24:25, 24:25])
+
+    test_hdu.close()
+
+
+def test_fits_cutout_extension(test_images, center_coord, cutout_size):
+    # Add additional extensions to one of the input files
+    with fits.open(test_images[0], mode='update') as hdul:
+        # Create a copy of first extension
+        source_hdu = hdul[0]
+        new_hdu = source_hdu.copy()
+        hdul.append(new_hdu)
+        hdul.append(new_hdu)  # add two copies
+        hdul.flush()  # save changes
+
+    # Cutout all extensions
+    cutout_list = FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True, extension='all').cutout()
+    assert len(cutout_list[0]) == 4  # primary header + 3 images
+
+    # Specify a single extension
+    cutout_list = FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True, extension=2).cutout()
+    assert len(cutout_list[0]) == 2  # primary header + 1 image
+
+    # Specify a list of extensions
+    cutout_list = FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True, extension=[0, 1]).cutout()
+    assert len(cutout_list[0]) == 3  # primary header + 2 images
+
+    # Warning if a non-existing extension is specified
+    with pytest.warns(DataWarning, match=r'extension\(s\) 3 will be skipped.'):
+        cutout_list = FITSCutout(test_images[0], center_coord, cutout_size, memory_only=True, extension=[1, 3]).cutout()
+        assert len(cutout_list[0]) == 2  # primary header + 1 image
+
+
+def test_fits_cutout_not_in_footprint(test_images, cutout_size):
+    # Test when the requested cutout is not on the image
+    center_coord = SkyCoord("140.1163213 2.2005731", unit='deg')
+    with pytest.raises(InvalidQueryError, match='Cutout location is not in image footprint!'):
+        FITSCutout(test_images, center_coord, cutout_size, single_outfile=True).cutout()
+
+    center_coord = SkyCoord("15.1163213 2.2005731", unit='deg')
+    with pytest.raises(InvalidQueryError, match='Cutout location is not in image footprint!'):
+        FITSCutout(test_images, center_coord, cutout_size, single_outfile=True).cutout()
+
+
+def test_fits_cutout_no_data(tmpdir, test_images, cutout_size):
+    # Test behavior when some input files contain zeros in cutout footprint
+    # Putting zeros into 2 images
+    for img in test_images[:2]:
+        hdu = fits.open(img, mode="update")
+        hdu[0].data[:20, :] = 0
+        hdu.flush()
+        hdu.close()
+        
+    # Single outfile should include empty files as extensions
+    center_coord = SkyCoord("150.1163213 2.2007", unit='deg')
+    cutout_file = FITSCutout(test_images, center_coord, cutout_size, single_outfile=True, output_dir=tmpdir).cutout()
+    cutout_hdulist = fits.open(cutout_file)
+    assert len(cutout_hdulist) == len(test_images) + 1  # num imgs + primary header
+    assert (cutout_hdulist[1].data == 0).all()
+    assert (cutout_hdulist[2].data == 0).all()
+    assert ~(cutout_hdulist[3].data == 0).any()
+    assert ~(cutout_hdulist[4].data == 0).any()
+    assert ~(cutout_hdulist[5].data == 0).any()
+    assert ~(cutout_hdulist[6].data == 0).any()
+    
+    # Empty files should not be written to their own file
+    cutout_files = FITSCutout(test_images, center_coord, cutout_size, single_outfile=False, output_dir=tmpdir).cutout()
+    assert isinstance(cutout_files, list)
+    assert len(cutout_files) == len(test_images) - 2
+
+    # Test when all input files contain only zeros in cutout footprint
+    # Putting zeros into the rest of the images
+    for img in test_images[2:]:
+        hdu = fits.open(img, mode="update")
+        hdu[0].data[:20, :] = 0
+        hdu.flush()
+        hdu.close()
+
+    with pytest.raises(InvalidQueryError) as e:
+        cutout_file = FITSCutout(test_images, center_coord, cutout_size, single_outfile=True, 
+                                 output_dir=tmpdir).cutout()
+        assert 'Cutout contains no data! (Check image footprint.)' in e
+
+
+def test_fits_cutout_bad_sip(tmpdir, caplog, test_image_bad_sip):
+    # Test single image and also conflicting sip keywords
+    center_coord = SkyCoord("150.1163213 2.2007", unit='deg')
+    cutout_size = [10, 15]
+    cutout_file = FITSCutout(test_image_bad_sip, center_coord, cutout_size, output_dir=tmpdir).cutout()
+    assert isinstance(cutout_file, str)
+    assert "10-x-15" in cutout_file
+    cutout_hdulist = fits.open(cutout_file)
+    assert cutout_hdulist[1].data.shape == (15, 10)
+
+    center_coord = SkyCoord("150.1159 2.2006", unit='deg')
+    cutout_size = [10, 15]*u.pixel
+    cutout_file = FITSCutout(test_image_bad_sip, center_coord, cutout_size, output_dir=tmpdir).cutout()
+    assert isinstance(cutout_file, str)
+    assert "10.0pix-x-15.0pix" in cutout_file
+    cutout_hdulist = fits.open(cutout_file)
+    assert cutout_hdulist[1].data.shape == (15, 10)
+
+    cutout_size = [1, 2]*u.arcsec
+    cutout_file = FITSCutout(test_image_bad_sip, center_coord, cutout_size, output_dir=tmpdir, verbose=True).cutout()
+    assert isinstance(cutout_file, str)
+    assert "1.0arcsec-x-2.0arcsec" in cutout_file
+    cutout_hdulist = fits.open(cutout_file)
+    assert cutout_hdulist[1].data.shape == (33, 17)
+    captured = caplog.text
+    assert "Original image shape: (50, 50)" in captured
+    assert "Image cutout shape: (33, 17)" in captured
+    assert "Total time:" in captured
+
+    center_coord = "150.1159 2.2006"
+    cutout_size = [10, 15, 20]
+    with pytest.warns(InputWarning, match='Too many dimensions in cutout size, only the first two will be used.'):
+        cutout_file = FITSCutout(test_image_bad_sip, center_coord, cutout_size, output_dir=tmpdir).cutout()
+    assert isinstance(cutout_file, str)
+    assert "10-x-15" in cutout_file
+    assert "x-20" not in cutout_file
+
+
+def test_fits_cutout_invalid_params(test_images, center_coord, cutout_size):
+    # Warning when image options are given
+    with pytest.warns(InputWarning, match='are not supported for FITS output and will be ignored.'):
+        FITSCutout(test_images, center_coord, cutout_size, stretch='asinh').cutout()
+
+    # Invalid limit rounding method
+    with pytest.raises(InvalidInputError, match='Limit rounding method invalid is not recognized.'):
+        FITSCutout(test_images, center_coord, cutout_size, limit_rounding_method='invalid').cutout()
+
+    # Invalid units for cutout size
+    cutout_size = 1 * u.m  # meters are not valid
+    with pytest.raises(InvalidInputError, match='Cutout size unit meter is not supported.'):
+        FITSCutout(test_images, center_coord, cutout_size).cutout()
+
+
+def test_fits_cutout_img_output(tmpdir, test_images, caplog, center_coord, cutout_size):
+    # Basic jpg image
+    jpg_files = FITSCutout(test_images, center_coord, cutout_size, output_dir=tmpdir, output_format='jpg').cutout()
+    
+    assert len(jpg_files) == len(test_images)
+    with open(jpg_files[0], 'rb') as IMGFLE:
+        assert IMGFLE.read(3) == b'\xFF\xD8\xFF'  # JPG
+
+    # Png (single input file, not as list)
+    img_files = FITSCutout(test_images[0], center_coord, cutout_size, output_format='png', output_dir=tmpdir).cutout()
+    with open(img_files[0], 'rb') as IMGFLE:
+        assert IMGFLE.read(8) == b'\x89\x50\x4E\x47\x0D\x0A\x1A\x0A'  # PNG
+    assert len(img_files) == 1
+
+    # string coordinates and verbose
+    center_coord = "150.1163213 2.200973097"
+    jpg_files = FITSCutout(test_images, center_coord, cutout_size, output_format='jpg',
+                           output_dir=path.join(tmpdir, 'image_path'), verbose=True).cutout()
+    captured = caplog.text
+    assert len(findall('Original image shape', captured)) == 6
+    assert 'Cutout fits file(s)' in captured
+    assert 'Total time' in captured
+
+
+def test_fits_cutout_img_color(tmpdir, test_images, center_coord, cutout_size):
+    # Color image
+    color_jpg = FITSCutout(test_images[:3], center_coord, cutout_size, output_format='jpg', colorize=True, 
+                           output_dir=tmpdir).cutout()
+    img = Image.open(color_jpg)
+    assert img.mode == 'RGB'
+
+
+def test_fits_cutout_img_memory_only(test_images, center_coord, cutout_size):
+    # Save black and white image to memory
+    imgs = FITSCutout(test_images[0], center_coord, cutout_size, output_format='png', memory_only=True).cutout()
+    assert isinstance(imgs, list)
+    assert len(imgs) == 1
+    assert isinstance(imgs[0], Image.Image)
+
+    # Save color image to memory
+    color_imgs = FITSCutout(test_images[:3], center_coord, cutout_size, output_format='jpg', colorize=True, 
+                            memory_only=True).cutout()
+    assert isinstance(color_imgs, list)
+    assert len(color_imgs) == 1
+    assert isinstance(color_imgs[0], Image.Image)
+    assert color_imgs[0].mode == 'RGB'
+
+
+def test_fits_cutout_img_errors(tmpdir, test_images, center_coord, cutout_size):
+    # Error when too few input images
+    with pytest.raises(InvalidInputError):
+        FITSCutout(test_images[0], center_coord, cutout_size, output_format='jpg', colorize=True, 
+                   output_dir=tmpdir).cutout()
+
+    # Warning when too many input images
+    with pytest.warns(InputWarning, match='Too many inputs for a color cutout, only the first three will be used.'):
+        color_jpg = FITSCutout(test_images, center_coord, cutout_size, output_format='jpg', colorize=True, 
+                               output_dir=tmpdir).cutout()
+    img = Image.open(color_jpg)
+    assert img.mode == 'RGB'
+
+    # Warning when saving image to unsupported image formats
+    with pytest.warns(DataWarning, match='Cutout could not be saved in .blp format'):
+        FITSCutout(test_images[0], center_coord, cutout_size, output_format='blp', output_dir=tmpdir).cutout()
+
+    with pytest.warns(DataWarning, match='Cutout could not be saved in .mpg format'):
+        FITSCutout(test_images, center_coord, cutout_size, output_format='mpg', colorize=True, 
+                   output_dir=tmpdir).cutout()
+        
+    # Invalid stretch error
+    with pytest.raises(InvalidInputError, match='Stretch invalid is not recognized.'):
+        FITSCutout(test_images[0], center_coord, cutout_size, stretch='invalid', output_format='png', 
+                   output_dir=tmpdir).cutout()
+
+    # Invalid output format
+    with pytest.raises(InvalidInputError, match='Output format .invalid is not supported'):
+        FITSCutout(test_images[0], center_coord, cutout_size, output_format='invalid', output_dir=tmpdir).cutout()
+
+    # Change first input file to be all zeros
+    hdu = fits.open(test_images[0], mode='update')
+    hdu[0].data[:, :] = 0
+    hdu.flush()
+    hdu.close()
+
+    # Warning when outputting non-color images
+    with pytest.warns(DataWarning, match='contains no data and will not be written.'):
+        FITSCutout(test_images[0], center_coord, cutout_size, output_format='png', output_dir=tmpdir).cutout()
+
+    # Error when outputting color image
+    with pytest.raises(InvalidInputError):
+        FITSCutout(test_images[:3], center_coord, cutout_size,
+                   colorize=True, output_format='png', output_dir=tmpdir).cutout()
+        
+
+def test_fits_cutout_asdf_output(test_images, center_coord, cutout_size):
+    # Should warn if output format is ASDF (not yet implemented)
+    with pytest.warns(InputWarning, match='ASDF output is not yet implemented for FITS files.'):
+        FITSCutout(test_images[0], center_coord, cutout_size, output_format='asdf').cutout()
+
+
+def test_normalize_img():
+    # basic linear stretch
+    img_arr = np.array([[1, 0], [.25, .75]])
+    assert ((img_arr*255).astype(int) == ImageCutout.normalize_img(img_arr, stretch='linear')).all()
+
+    # invert
+    assert (255-(img_arr*255).astype(int) == ImageCutout.normalize_img(img_arr, stretch='linear', invert=True)).all()
+
+    # linear stretch where input image must be scaled 
+    img_arr = np.array([[10, 5], [2.5, 7.5]])
+    norm_img = ((img_arr - img_arr.min())/(img_arr.max()-img_arr.min())*255).astype(int)
+    assert (norm_img == ImageCutout.normalize_img(img_arr, stretch='linear')).all()
+
+    # min_max val
+    minval, maxval = 0, 1
+    img_arr = np.array([[1, 0], [-1, 2]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_value=[minval, maxval])
+    img_arr[img_arr < minval] = minval
+    img_arr[img_arr > maxval] = maxval
+    assert ((img_arr*255).astype(int) == norm_img).all()
+
+    minval, maxval = 0, 1
+    img_arr = np.array([[1, 0], [.1, .2]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_value=[minval, maxval])
+    img_arr[img_arr < minval] = minval
+    img_arr[img_arr > maxval] = maxval
+    ((img_arr*255).astype(int) == norm_img).all()
+
+    # min_max percent
+    img_arr = np.array([[1, 0], [0.1, 0.9], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_percent=[25, 75])
+    assert (norm_img == [[255, 0], [0, 255], [39, 215]]).all()
+
+    # asinh
+    img_arr = np.array([[1, 0], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr)
+    assert ((np.arcsinh(img_arr*10)/np.arcsinh(10)*255).astype(int) == norm_img).all()
+
+    # sinh
+    img_arr = np.array([[1, 0], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='sinh')
+    assert ((np.sinh(img_arr*3)/np.sinh(3)*255).astype(int) == norm_img).all()
+
+    # sqrt
+    img_arr = np.array([[1, 0], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='sqrt')
+    assert ((np.sqrt(img_arr)*255).astype(int) == norm_img).all()
+
+    # log
+    img_arr = np.array([[1, 0], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='log')
+    assert ((np.log(img_arr*1000+1)/np.log(1000)*255).astype(int) == norm_img).all()
+
+
+def test_normalize_img_errors():
+    # Bad stretch
+    with pytest.raises(InvalidInputError):
+        img_arr = np.array([[1, 0], [.25, .75]])
+        ImageCutout.normalize_img(img_arr, stretch='lin')
+
+    # Giving both minmax percent and cut
+    img_arr = np.array([[1, 0], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='asinh', minmax_percent=[0.7, 99.3])
+    with pytest.warns(InputWarning, 
+                      match='Both minmax_percent and minmax_value are set, minmax_value will be ignored.'):
+        test_img = ImageCutout.normalize_img(img_arr, stretch='asinh', minmax_value=[5, 2000], 
+                                             minmax_percent=[0.7, 99.3])
+    assert (test_img == norm_img).all()
+
+    # Raise error if image array is empty
+    img_arr = np.array([])
+    with pytest.raises(InvalidInputError):
+        ImageCutout.normalize_img(img_arr)

--- a/astrocut/tests/test_FITSCutout.py
+++ b/astrocut/tests/test_FITSCutout.py
@@ -1,4 +1,3 @@
-# Fixture to create test images for both SPOC and TICA
 import pytest
 
 import numpy as np
@@ -20,6 +19,7 @@ from .utils_for_test import create_test_imgs
 from ..exceptions import DataWarning, InputWarning, InvalidInputError, InvalidQueryError
 
 
+# Fixture to create test images for both SPOC and TICA
 @pytest.fixture(params=['SPOC', 'TICA'])
 def test_images(request, tmpdir):
     return create_test_imgs(request.param, 50, 6, dir_name=tmpdir)

--- a/astrocut/tests/test_FITSCutout.py
+++ b/astrocut/tests/test_FITSCutout.py
@@ -13,7 +13,6 @@ from astropy.table import Table
 from PIL import Image
 
 from astrocut.FITSCutout import FITSCutout
-from astrocut.ImageCutout import ImageCutout
 
 from .utils_for_test import create_test_imgs
 from ..exceptions import DataWarning, InputWarning, InvalidInputError, InvalidQueryError
@@ -453,78 +452,3 @@ def test_fits_cutout_asdf_output(test_images, center_coord, cutout_size):
     # Should warn if output format is ASDF (not yet implemented)
     with pytest.warns(InputWarning, match='ASDF output is not yet implemented for FITS files.'):
         FITSCutout(test_images[0], center_coord, cutout_size, output_format='asdf').cutout()
-
-
-def test_normalize_img():
-    # basic linear stretch
-    img_arr = np.array([[1, 0], [.25, .75]])
-    assert ((img_arr*255).astype(int) == ImageCutout.normalize_img(img_arr, stretch='linear')).all()
-
-    # invert
-    assert (255-(img_arr*255).astype(int) == ImageCutout.normalize_img(img_arr, stretch='linear', invert=True)).all()
-
-    # linear stretch where input image must be scaled 
-    img_arr = np.array([[10, 5], [2.5, 7.5]])
-    norm_img = ((img_arr - img_arr.min())/(img_arr.max()-img_arr.min())*255).astype(int)
-    assert (norm_img == ImageCutout.normalize_img(img_arr, stretch='linear')).all()
-
-    # min_max val
-    minval, maxval = 0, 1
-    img_arr = np.array([[1, 0], [-1, 2]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_value=[minval, maxval])
-    img_arr[img_arr < minval] = minval
-    img_arr[img_arr > maxval] = maxval
-    assert ((img_arr*255).astype(int) == norm_img).all()
-
-    minval, maxval = 0, 1
-    img_arr = np.array([[1, 0], [.1, .2]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_value=[minval, maxval])
-    img_arr[img_arr < minval] = minval
-    img_arr[img_arr > maxval] = maxval
-    ((img_arr*255).astype(int) == norm_img).all()
-
-    # min_max percent
-    img_arr = np.array([[1, 0], [0.1, 0.9], [.25, .75]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_percent=[25, 75])
-    assert (norm_img == [[255, 0], [0, 255], [39, 215]]).all()
-
-    # asinh
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = ImageCutout.normalize_img(img_arr)
-    assert ((np.arcsinh(img_arr*10)/np.arcsinh(10)*255).astype(int) == norm_img).all()
-
-    # sinh
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='sinh')
-    assert ((np.sinh(img_arr*3)/np.sinh(3)*255).astype(int) == norm_img).all()
-
-    # sqrt
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='sqrt')
-    assert ((np.sqrt(img_arr)*255).astype(int) == norm_img).all()
-
-    # log
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='log')
-    assert ((np.log(img_arr*1000+1)/np.log(1000)*255).astype(int) == norm_img).all()
-
-
-def test_normalize_img_errors():
-    # Bad stretch
-    with pytest.raises(InvalidInputError):
-        img_arr = np.array([[1, 0], [.25, .75]])
-        ImageCutout.normalize_img(img_arr, stretch='lin')
-
-    # Giving both minmax percent and cut
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='asinh', minmax_percent=[0.7, 99.3])
-    with pytest.warns(InputWarning, 
-                      match='Both minmax_percent and minmax_value are set, minmax_value will be ignored.'):
-        test_img = ImageCutout.normalize_img(img_arr, stretch='asinh', minmax_value=[5, 2000], 
-                                             minmax_percent=[0.7, 99.3])
-    assert (test_img == norm_img).all()
-
-    # Raise error if image array is empty
-    img_arr = np.array([])
-    with pytest.raises(InvalidInputError):
-        ImageCutout.normalize_img(img_arr)

--- a/astrocut/tests/test_FITSCutout.py
+++ b/astrocut/tests/test_FITSCutout.py
@@ -22,7 +22,8 @@ from ..exceptions import DataWarning, InputWarning, InvalidInputError, InvalidQu
 
 @pytest.fixture(params=['SPOC', 'TICA'])
 def test_images(request, tmpdir):
-    create_test_imgs(request.param, 50, 6, dir_name=tmpdir)
+    return create_test_imgs(request.param, 50, 6, dir_name=tmpdir)
+
 
 # Fixture to create a test image with bad SIP keywords
 @pytest.fixture(params=['SPOC', 'TICA'])

--- a/astrocut/tests/test_ImageCutout.py
+++ b/astrocut/tests/test_ImageCutout.py
@@ -1,0 +1,82 @@
+import pytest
+
+import numpy as np
+
+from astrocut.ImageCutout import ImageCutout
+
+from ..exceptions import InputWarning, InvalidInputError
+
+
+def test_normalize_img():
+    # basic linear stretch
+    img_arr = np.array([[1, 0], [.25, .75]])
+    assert ((img_arr*255).astype(int) == ImageCutout.normalize_img(img_arr, stretch='linear')).all()
+
+    # invert
+    assert (255-(img_arr*255).astype(int) == ImageCutout.normalize_img(img_arr, stretch='linear', invert=True)).all()
+
+    # linear stretch where input image must be scaled 
+    img_arr = np.array([[10, 5], [2.5, 7.5]])
+    norm_img = ((img_arr - img_arr.min())/(img_arr.max()-img_arr.min())*255).astype(int)
+    assert (norm_img == ImageCutout.normalize_img(img_arr, stretch='linear')).all()
+
+    # min_max val
+    minval, maxval = 0, 1
+    img_arr = np.array([[1, 0], [-1, 2]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_value=[minval, maxval])
+    img_arr[img_arr < minval] = minval
+    img_arr[img_arr > maxval] = maxval
+    assert ((img_arr*255).astype(int) == norm_img).all()
+
+    minval, maxval = 0, 1
+    img_arr = np.array([[1, 0], [.1, .2]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_value=[minval, maxval])
+    img_arr[img_arr < minval] = minval
+    img_arr[img_arr > maxval] = maxval
+    ((img_arr*255).astype(int) == norm_img).all()
+
+    # min_max percent
+    img_arr = np.array([[1, 0], [0.1, 0.9], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_percent=[25, 75])
+    assert (norm_img == [[255, 0], [0, 255], [39, 215]]).all()
+
+    # asinh
+    img_arr = np.array([[1, 0], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr)
+    assert ((np.arcsinh(img_arr*10)/np.arcsinh(10)*255).astype(int) == norm_img).all()
+
+    # sinh
+    img_arr = np.array([[1, 0], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='sinh')
+    assert ((np.sinh(img_arr*3)/np.sinh(3)*255).astype(int) == norm_img).all()
+
+    # sqrt
+    img_arr = np.array([[1, 0], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='sqrt')
+    assert ((np.sqrt(img_arr)*255).astype(int) == norm_img).all()
+
+    # log
+    img_arr = np.array([[1, 0], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='log')
+    assert ((np.log(img_arr*1000+1)/np.log(1000)*255).astype(int) == norm_img).all()
+
+
+def test_normalize_img_errors():
+    # Bad stretch
+    with pytest.raises(InvalidInputError):
+        img_arr = np.array([[1, 0], [.25, .75]])
+        ImageCutout.normalize_img(img_arr, stretch='lin')
+
+    # Giving both minmax percent and cut
+    img_arr = np.array([[1, 0], [.25, .75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch='asinh', minmax_percent=[0.7, 99.3])
+    with pytest.warns(InputWarning, 
+                      match='Both minmax_percent and minmax_value are set, minmax_value will be ignored.'):
+        test_img = ImageCutout.normalize_img(img_arr, stretch='asinh', minmax_value=[5, 2000], 
+                                             minmax_percent=[0.7, 99.3])
+    assert (test_img == norm_img).all()
+
+    # Raise error if image array is empty
+    img_arr = np.array([])
+    with pytest.raises(InvalidInputError):
+        ImageCutout.normalize_img(img_arr)

--- a/astrocut/tests/test_cutouts.py
+++ b/astrocut/tests/test_cutouts.py
@@ -13,43 +13,17 @@ from PIL import Image
 
 from .utils_for_test import create_test_imgs
 from .. import cutouts
-from ..exceptions import InputWarning, InvalidInputError, InvalidQueryError
+from ..exceptions import InputWarning, InvalidInputError, InvalidQueryError 
 
 
-# Fixture to create test images for both SPOC and TICA
-@pytest.fixture(params=['SPOC', 'TICA'])
-def test_images(request, tmpdir):
-    if request.param == 'SPOC':
-        return create_test_imgs('SPOC', 50, 6, dir_name=tmpdir)
-    else:
-        return create_test_imgs('TICA', 50, 6, dir_name=tmpdir)
+@pytest.mark.parametrize('ffi_type', ['SPOC', 'TICA'])
+def test_fits_cut(tmpdir, caplog, ffi_type):
 
+    test_images = create_test_imgs(ffi_type, 50, 6, dir_name=tmpdir)
 
-# Fixture to create a test image with bad SIP keywords
-@pytest.fixture(params=['SPOC', 'TICA'])
-def test_image_bad_sip(request, tmpdir):
-    if request.param == 'SPOC':
-        return create_test_imgs('SPOC', 50, 1, dir_name=tmpdir,
-                                basename="img_badsip_{:04d}.fits", bad_sip_keywords=True)[0]
-    else:
-        return create_test_imgs('TICA', 50, 1, dir_name=tmpdir,
-                                basename="img_badsip_{:04d}.fits", bad_sip_keywords=True)[0]
-    
-
-# Fixture to return a center coordinate
-@pytest.fixture
-def center_coord():
-    return SkyCoord("150.1163213 2.200973097", unit='deg')
-
-
-# Fixture to return a cutout size
-@pytest.fixture
-def cutout_size():
-    return 10
-
-
-def test_fits_cut_single_file(tmpdir, test_images, center_coord, cutout_size):
     # Single file
+    center_coord = SkyCoord("150.1163213 2.200973097", unit='deg')
+    cutout_size = 10
     cutout_file = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=True, output_dir=tmpdir)
     assert isinstance(cutout_file, str)
     
@@ -71,8 +45,6 @@ def test_fits_cut_single_file(tmpdir, test_images, center_coord, cutout_size):
 
     cutout_hdulist.close()
 
-
-def test_fits_cut_multiple_files(tmpdir, test_images, center_coord, cutout_size):
     # Multiple files
     cutout_files = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=False, output_dir=tmpdir)
 
@@ -90,20 +62,8 @@ def test_fits_cut_multiple_files(tmpdir, test_images, center_coord, cutout_size)
     assert round(float(sra), 4) == round(center_coord.ra.deg, 4)
     assert round(float(sdec), 4) == round(center_coord.dec.deg, 4)
 
-    # Output directory that has to be created
-    new_dir = path.join(tmpdir, "cutout_files")  # non-existing directory to write files to
-    cutout_files = cutouts.fits_cut(test_images, center_coord, cutout_size,
-                                    output_dir=new_dir, single_outfile=False)
-
-    assert isinstance(cutout_files, list)
-    assert len(cutout_files) == len(test_images)
-    assert new_dir in cutout_files[0]
-    assert path.exists(new_dir)  # new directory should now exist
-
     cutout_hdulist.close()
 
-
-def test_fits_cut_memory_only(test_images, center_coord, cutout_size):
     # Memory only, single file
     nonexisting_dir = "nonexisting"  # non-existing directory to check that no files are written
     cutout_list = cutouts.fits_cut(test_images, center_coord, cutout_size, 
@@ -121,8 +81,16 @@ def test_fits_cut_memory_only(test_images, center_coord, cutout_size):
     assert isinstance(cutout_list[0], fits.HDUList)
     assert not path.exists(nonexisting_dir)  # no files should be written
 
+    # Output directory that has to be created
+    new_dir = path.join(tmpdir, "cutout_files")  # non-existing directory to write files to
+    cutout_files = cutouts.fits_cut(test_images, center_coord, cutout_size,
+                                    output_dir=new_dir, single_outfile=False)
 
-def test_fits_cut_off_edge(tmpdir, test_images, cutout_size):
+    assert isinstance(cutout_files, list)
+    assert len(cutout_files) == len(test_images)
+    assert new_dir in cutout_files[0]
+    assert path.exists(new_dir)  # new directory should now exist
+    
     # Do an off the edge test
     center_coord = SkyCoord("150.1163213 2.2005731", unit='deg')
     cutout_file = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=True, output_dir=tmpdir)
@@ -137,21 +105,20 @@ def test_fits_cut_off_edge(tmpdir, test_images, cutout_size):
 
     cutout_hdulist.close()
 
-
-def test_fits_cutout_not_in_footprint(test_images, cutout_size):
-
     # Test when the requested cutout is not on the image
     center_coord = SkyCoord("140.1163213 2.2005731", unit='deg')
-    with pytest.raises(InvalidQueryError, match='Cutout location is not in image footprint!'):
-        cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=True)
+    with pytest.raises(Exception, match='Cutout location is not in image footprint!') as e:
+        cutout_file = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=True)
+        assert e.type is InvalidQueryError
 
     center_coord = SkyCoord("15.1163213 2.2005731", unit='deg')
-    with pytest.raises(InvalidQueryError, match='Cutout location is not in image footprint!'):
-        cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=True)
+    with pytest.raises(Exception, match='Cutout location is not in image footprint!') as e:
+        cutout_file = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=True)
+        assert e.type is InvalidQueryError
     
 
-def test_fits_cutout_no_data(tmpdir, test_images, cutout_size):
-    # Test behavior when some input files contain zeros in cutout footprint
+    # Test when cutout is in some images not others
+
     # Putting zeros into 2 images
     for img in test_images[:2]:
         hdu = fits.open(img, mode="update")
@@ -159,9 +126,10 @@ def test_fits_cutout_no_data(tmpdir, test_images, cutout_size):
         hdu.flush()
         hdu.close()
         
-    # Single outfile should include empty files as extensions
+        
     center_coord = SkyCoord("150.1163213 2.2007", unit='deg')
     cutout_file = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=True, output_dir=tmpdir)
+    
     cutout_hdulist = fits.open(cutout_file)
     assert len(cutout_hdulist) == len(test_images) + 1  # num imgs + primary header
     assert (cutout_hdulist[1].data == 0).all()
@@ -170,30 +138,31 @@ def test_fits_cutout_no_data(tmpdir, test_images, cutout_size):
     assert ~(cutout_hdulist[4].data == 0).any()
     assert ~(cutout_hdulist[5].data == 0).any()
     assert ~(cutout_hdulist[6].data == 0).any()
+
     
-    # Empty files should not be written to their own file
     cutout_files = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=False, output_dir=tmpdir)
     assert isinstance(cutout_files, list)
     assert len(cutout_files) == len(test_images) - 2
 
-    # Test when all input files contain only zeros in cutout footprint
-    # Putting zeros into the rest of the images
+    # Test when cutout is in no images
     for img in test_images[2:]:
         hdu = fits.open(img, mode="update")
         hdu[0].data[:20, :] = 0
         hdu.flush()
         hdu.close()
 
-    with pytest.raises(InvalidQueryError) as e:
+    with pytest.raises(Exception) as e:
         cutout_file = cutouts.fits_cut(test_images, center_coord, cutout_size, single_outfile=True, output_dir=tmpdir)
-        assert 'Cutout contains no data! (Check image footprint.)' in e
+        assert e.type is InvalidQueryError
+        assert "Cutout contains no data! (Check image footprint.)" in str(e.value)
 
+    # test single image and also conflicting sip keywords
+    test_image = create_test_imgs(ffi_type, 50, 1, dir_name=tmpdir,
+                                  basename="img_badsip_{:04d}.fits", bad_sip_keywords=True)[0]
 
-def test_fits_cutout_bad_sip(tmpdir, caplog, test_image_bad_sip):
-    # Test single image and also conflicting sip keywords
     center_coord = SkyCoord("150.1163213 2.2007", unit='deg')
     cutout_size = [10, 15]
-    cutout_file = cutouts.fits_cut(test_image_bad_sip, center_coord, cutout_size, output_dir=tmpdir)
+    cutout_file = cutouts.fits_cut(test_image, center_coord, cutout_size, output_dir=tmpdir)
     assert isinstance(cutout_file, str)
     assert "10-x-15" in cutout_file
     cutout_hdulist = fits.open(cutout_file)
@@ -201,14 +170,14 @@ def test_fits_cutout_bad_sip(tmpdir, caplog, test_image_bad_sip):
 
     center_coord = SkyCoord("150.1159 2.2006", unit='deg')
     cutout_size = [10, 15]*u.pixel
-    cutout_file = cutouts.fits_cut(test_image_bad_sip, center_coord, cutout_size, output_dir=tmpdir)
+    cutout_file = cutouts.fits_cut(test_image, center_coord, cutout_size, output_dir=tmpdir)
     assert isinstance(cutout_file, str)
     assert "10.0pix-x-15.0pix" in cutout_file
     cutout_hdulist = fits.open(cutout_file)
     assert cutout_hdulist[1].data.shape == (15, 10)
 
     cutout_size = [1, 2]*u.arcsec
-    cutout_file = cutouts.fits_cut(test_image_bad_sip, center_coord, cutout_size, output_dir=tmpdir, verbose=True)
+    cutout_file = cutouts.fits_cut(test_image, center_coord, cutout_size, output_dir=tmpdir, verbose=True)
     assert isinstance(cutout_file, str)
     assert "1.0arcsec-x-2.0arcsec" in cutout_file
     cutout_hdulist = fits.open(cutout_file)
@@ -221,13 +190,11 @@ def test_fits_cutout_bad_sip(tmpdir, caplog, test_image_bad_sip):
     center_coord = "150.1159 2.2006"
     cutout_size = [10, 15, 20]
     with pytest.warns(InputWarning):
-        cutout_file = cutouts.fits_cut(test_image_bad_sip, center_coord, cutout_size, output_dir=tmpdir)
+        cutout_file = cutouts.fits_cut(test_image, center_coord, cutout_size, output_dir=tmpdir)
     assert isinstance(cutout_file, str)
     assert "10-x-15" in cutout_file
     assert "x-20" not in cutout_file
 
-
-def test_fits_cloud(tmpdir):
     # Test single cloud image
     test_s3_uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
     center_coord = SkyCoord("150.4275416667 2.42155", unit='deg')
@@ -241,6 +208,7 @@ def test_fits_cloud(tmpdir):
 
 
 def test_normalize_img():
+
     # basic linear stretch
     img_arr = np.array([[1, 0], [.25, .75]])
     assert ((img_arr*255).astype(int) == cutouts.normalize_img(img_arr, stretch='linear')).all()
@@ -306,7 +274,13 @@ def test_normalize_img():
     assert (test_img == norm_img).all()
 
 
-def test_img_cut(tmpdir, test_images, caplog, center_coord, cutout_size):
+@pytest.mark.parametrize('ffi_type', ['SPOC', 'TICA'])
+def test_img_cut(tmpdir, caplog, ffi_type):
+
+    test_images = create_test_imgs(ffi_type, 50, 6, dir_name=tmpdir)
+    center_coord = SkyCoord("150.1163213 2.200973097", unit='deg')
+    cutout_size = 10
+
     # Basic jpg image
     jpg_files = cutouts.img_cut(test_images, center_coord, cutout_size, output_dir=tmpdir)
     
@@ -320,24 +294,11 @@ def test_img_cut(tmpdir, test_images, caplog, center_coord, cutout_size):
         assert IMGFLE.read(8) == b'\x89\x50\x4E\x47\x0D\x0A\x1A\x0A'  # PNG
     assert len(img_files) == 1
 
-    # string coordinates and verbose
-    center_coord = "150.1163213 2.200973097"
-    jpg_files = cutouts.img_cut(test_images, center_coord, cutout_size,
-                                output_dir=path.join(tmpdir, "image_path"), verbose=True)
-    captured = caplog.text
-    assert len(findall("Original image shape", captured)) == 6
-    assert "Cutout fits file(s)" in captured
-    assert "Total time" in captured
-
-
-def test_img_cut_color(tmpdir, caplog, test_images, center_coord, cutout_size):
     # Color image
     color_jpg = cutouts.img_cut(test_images[:3], center_coord, cutout_size, colorize=True, output_dir=tmpdir)
     img = Image.open(color_jpg)
     assert img.mode == 'RGB'
 
-
-def test_img_cut_errors(tmpdir, test_images, center_coord, cutout_size):
     # Too few input images
     with pytest.raises(InvalidInputError):
         cutouts.img_cut(test_images[0], center_coord, cutout_size, colorize=True, output_dir=tmpdir)
@@ -348,7 +309,16 @@ def test_img_cut_errors(tmpdir, test_images, center_coord, cutout_size):
     img = Image.open(color_jpg)
     assert img.mode == 'RGB'
 
-    # Test color image where one of the images is all zeros
+    # string coordinates and verbose
+    center_coord = "150.1163213 2.200973097"
+    jpg_files = cutouts.img_cut(test_images, center_coord, cutout_size,
+                                output_dir=path.join(tmpdir, "image_path"), verbose=True)
+    captured = caplog.text
+    assert len(findall("Original image shape", captured)) == 6
+    assert "Cutout fits file(s)" in captured
+    assert "Total time" in captured
+
+    # test color image where one of the images is all zeros
     hdu = fits.open(test_images[0], mode='update')
     hdu[0].data[:, :] = 0
     hdu.flush()


### PR DESCRIPTION
This PR implements the generalized architecture for creating cutouts from FITS files. It implements `Cutout`, `ImageCutout`, and `FITSCutout`. It also changes the functions in `cutouts.py` to call the aforementioned classes and updates the test suite with a new file, `test_FITSCutout.py`.

Here is a class diagram of the new generalized architecture, though it may not be fully updated: https://innerspace.stsci.edu/display/MASTC/Class+Diagram

Considerations:

- While implementing this new generalized architecture, I'm focusing on restructuring the code rather than adding features or making significant changes. The existing API should have no breaking changes, for now.
- Ideally, `FITSCutout` will eventually use the `_get_cutout_data` method defined in `ImageCutout` that uses `astropy.nddata.Cutout2D`. Unfortunately, there is an issue with using the `section` attribute of an `ImageHDU` object that I've put in a [PR to Astropy](https://github.com/astropy/astropy/pull/17611) to fix. We could choose to use `data` instead of `section`, but this significantly worsens performance. I'm not sure when Astropy's next release will be, so for now, I think we will have to leave in the code that cuts out the data array and modifies the WCS for the cutout.
- The new test class looks VERY similar to `test_cutouts.py`. The main difference is that `test_FITSCutout.py` uses the `FITSCutout` class directly while `test_cutouts.py` uses the `fits_cut` and `img_cut` functions. I've essentially copy-pasted the old code and added some assertions and cases to increase coverage.