### PR TITLE
Run dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: ".github/workflows" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
PR to only run the GH Dependabot once a month.