### PR TITLE
add 3.11 3.12 and 3.13 to CI

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -45,6 +45,21 @@ jobs:
             python: "3.10"
             toxenv: py310-test-alldeps-numpy2
 
+          - name: Python 3.11 with minimal dependencies
+            os: ubuntu-latest
+            python: 3.11
+            toxenv: py311-test
+
+          - name: Python 3.12 with minimal dependencies
+            os: ubuntu-latest
+            python: 3.12
+            toxenv: py312-test
+
+          - name: Python 3.13 with minimal dependencies
+            os: ubuntu-latest
+            python: 3.13
+            toxenv: py313-test
+
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{38,39,310,311}-test{,-alldeps,-devdeps}{,-cov}
-    py{38,39,310,311}-test-numpy{120,123}
-    py{38,39,310,311}-test-astropy{52}
+    py{38,39,310,311,312,313}-test{,-alldeps,-devdeps}{,-cov}
+    py{38,39,310,311,312,313}-test-numpy{120,123}
+    py{38,39,310,311,312,313}-test-astropy{52}
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
This PR updates the tox and github workflow configuration files to run tests with 3.11 3.12 and 3.13.