### PR TITLE
Update CI workflow to use codecov token

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -83,6 +83,8 @@ jobs:
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
         with:
           file: ./coverage.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   allowed_failures:
     name: ${{ matrix.name }}


### PR DESCRIPTION
Update our CI workflow to use a codecov upload token.

Successful run is here: https://github.com/spacetelescope/astrocut/actions/runs/14980614049/job/42134176448?pr=156