### PR TITLE
Bugfix for flipped axes in GWCS bounding box

### DIFF
--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -208,14 +208,10 @@ class ASDFCutout(ImageCutout):
                               wcs=wcs,
                               size=(self._cutout_size[1], self._cutout_size[0]),
                               mode='partial',
+                              copy=True,
                               fill_value=self._fill_value)
         
         log.debug('Image cutout shape: %s', img_cutout.shape)
-
-        # Data in the Cutout2D object is a view into the original data. We need to deep copy the 
-        # data in the cutout object to ensure that it is fully independent of the original data 
-        # and that it does not take up the same amount of storage.
-        img_cutout.data = np.array(img_cutout.data, copy=True)
 
         return img_cutout
 
@@ -249,14 +245,14 @@ class ASDFCutout(ImageCutout):
         slices = cutout.slices_original
         xmin, xmax = slices[1].start, slices[1].stop
         ymin, ymax = slices[0].start, slices[0].stop
-        shape = (ymax - ymin, xmax - xmin)
+        shape = (xmax - xmin, ymax - ymin)
         offsets = models.Shift(xmin, name='cutout_offset1') & models.Shift(ymin, name='cutout_offset2')
         tmp.insert_transform('detector', offsets, after=True)
 
         # Modify the gwcs bounding box to the cutout shape
         tmp.bounding_box = ((0, shape[0] - 1), (0, shape[1] - 1))
-        tmp.pixel_shape = shape[::-1]
-        tmp.array_shape = shape
+        tmp.pixel_shape = shape
+        tmp.array_shape = shape[::-1]
         return tmp
     
     def _cutout_file(self, file: Union[str, Path, S3Path]):

--- a/astrocut/tests/test_asdf_cutout.py
+++ b/astrocut/tests/test_asdf_cutout.py
@@ -294,6 +294,20 @@ def test_asdf_cutout_img_output(test_images, center_coord, cutout_size, tmpdir):
     assert img.mode == 'RGB'
 
 
+def test_asdf_cutout_gwcs(test_images, center_coord):
+    """ Test creating a rectangular cutout to make sure cutout gwcs is correct """
+    cutout = ASDFCutout(test_images[0], center_coord, cutout_size=[20, 40])
+    asdf_cutouts = cutout.asdf_cutouts
+    gwcs = asdf_cutouts[0]['roman']['meta']['wcs']
+    assert isinstance(gwcs, wcs.WCS)
+    assert gwcs.pixel_shape == (20, 40)
+    assert gwcs.array_shape == (40, 20)
+    assert gwcs.bounding_box.intervals[0].lower == 0
+    assert gwcs.bounding_box.intervals[0].upper == 19
+    assert gwcs.bounding_box.intervals[1].lower == 0
+    assert gwcs.bounding_box.intervals[1].upper == 39
+
+
 def test_get_center_pixel(fakedata):
     """ Test get_center_pixel function """
     # Get the fake data


### PR DESCRIPTION
Addresses #159 

I also noticed that `array_shape` and `pixel_shape` for the GWCS object were incorrect, so I fixed those as well and added a test case.