### PR TITLE
Coordinate footprint crossmatch with a cutout size of 0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Added support in `ra_dec_crossmatch` for a cutout size of zero, enabling single-point matching to FFIs that contain
+  the specified coordinates. [#166]
+
 
 1.1.0 (2025-09-15)
 ------------------

--- a/astrocut/cutout.py
+++ b/astrocut/cutout.py
@@ -150,7 +150,7 @@ class Cutout(ABC):
         raise NotImplementedError('Subclasses must implement this method.')
 
     @staticmethod
-    def _parse_size_input(cutout_size):
+    def _parse_size_input(cutout_size, *, allow_zero: bool = False) -> np.ndarray:
         """
         Makes the given cutout size into a length 2 array.
 
@@ -162,6 +162,8 @@ class Cutout(ABC):
             If ``cutout_size`` has two elements, they should be in ``(ny, nx)`` order.  Scalar numbers 
             in ``cutout_size`` are assumed to be in units of pixels. `~astropy.units.Quantity` objects 
             must be in pixel or angular units.
+        allow_zero : bool, optional
+            If True, allows cutout dimensions to be zero. Default is False.
 
         Returns
         -------
@@ -186,7 +188,7 @@ class Cutout(ABC):
         
         for dim in cutout_size:
             # Raise error if either dimension is not a positive number
-            if dim <= 0:
+            if dim < 0 or (not allow_zero and dim == 0):
                 raise InvalidInputError('Cutout size dimensions must be greater than zero. '
                                         f'Provided size: ({cutout_size[0]}, {cutout_size[1]})')
             

--- a/astrocut/cutout.py
+++ b/astrocut/cutout.py
@@ -61,7 +61,7 @@ class Cutout(ABC):
         log.debug('Coordinates: %s', self._coordinates)
 
         # Turning the cutout size into an array of two values
-        self._cutout_size = self._parse_size_input(cutout_size)
+        self._cutout_size = self.parse_size_input(cutout_size)
         log.debug('Cutout size: %s', self._cutout_size)
 
         # Assigning other attributes
@@ -150,7 +150,7 @@ class Cutout(ABC):
         raise NotImplementedError('Subclasses must implement this method.')
 
     @staticmethod
-    def _parse_size_input(cutout_size, *, allow_zero: bool = False) -> np.ndarray:
+    def parse_size_input(cutout_size, *, allow_zero: bool = False) -> np.ndarray:
         """
         Makes the given cutout size into a length 2 array.
 

--- a/astrocut/footprint_cutout.py
+++ b/astrocut/footprint_cutout.py
@@ -194,6 +194,89 @@ def get_ffis(s3_footprint_cache: str) -> Table:
     return ffis
 
 
+def _crossmatch_point(ra: SkyCoord, dec: SkyCoord, all_ffis: Table) -> List[int]:
+    """
+    Returns the indices of the Full Frame Images (FFIs) that contain the given RA and
+    Dec coordinates by checking which FFI polygons contain the point.
+    
+    Parameters
+    ----------
+    ra : SkyCoord
+        Right Ascension in degrees.
+    dec : SkyCoord
+        Declination in degrees.
+    all_ffis : `~astropy.table.Table`
+        Table of FFIs to crossmatch with the point.
+        
+    Returns
+    -------
+    ffi_inds : `~numpy.ndarray`
+        Indices of FFIs that contain the given RA and Dec coordinates.
+    """
+    ffi_inds = []
+    vector_coord = radec_to_vector(ra, dec)
+    for sector in np.unique(all_ffis['sequence_number']):
+        # Returns a 2-long array where the first element is indexes and the 2nd element is empty
+        sector_ffi_inds = np.where(all_ffis['sequence_number'] == sector)[0]
+
+        for ind in sector_ffi_inds:
+            if all_ffis[ind]["polygon"].contains_point(vector_coord):
+                ffi_inds.append(ind)
+                break  # the ra/dec will only be on one ccd per sector
+    return np.array(ffi_inds, dtype=int)
+
+
+def _crossmatch_polygon(ra: SkyCoord, dec: SkyCoord, all_ffis: Table, px_size: np.ndarray,
+                        arcsec_per_px: int = 21) -> np.ndarray:
+    """
+    Returns the indices of the Full Frame Images (FFIs) that intersect with the given cutout footprint
+    by checking which FFI polygons intersect with the cutout polygon.
+
+    Parameters
+    ----------
+    ra : SkyCoord
+        Right Ascension in degrees.
+    dec : SkyCoord
+        Declination in degrees.
+    all_ffis : `~astropy.table.Table`
+        Table of FFIs to crossmatch with the point.
+    px_size : array-like
+        Size of the cutout in pixels, in the form [ny, nx].
+    arcsec_per_px : int, optional
+        Default 21. The number of arcseconds per pixel in an image. Used to determine
+        the footprint of the cutout. Default is the number of arcseconds per pixel in
+        a TESS image.
+
+    Returns
+    -------
+    ffi_inds : `~numpy.ndarray`
+        Boolean array indicating whether each FFI intersects with the cutout.
+    """
+    # Create polygon for intersection
+    # Convert dimensions from pixels to arcseconds and divide by 2 to get offset from center
+    # If one of the dimensions is 0, use a very small value to avoid issues with SphericalPolygon
+    min_offset = 0.1  # pixels
+    ra_offset = ((max(px_size[0], min_offset) * arcsec_per_px) / 2) * u.arcsec
+    dec_offset = ((max(px_size[1], min_offset) * arcsec_per_px) / 2) * u.arcsec
+
+    # Calculate RA and Dec boundaries
+    ra_bounds = [ra - ra_offset, ra + ra_offset]
+    dec_bounds = [dec - dec_offset, dec + dec_offset]
+
+    # Get RA and Dec for four corners of rectangle
+    ras = [ra_bounds[0].value, ra_bounds[1].value, ra_bounds[1].value, ra_bounds[0].value]
+    decs = [dec_bounds[0].value, dec_bounds[0].value, dec_bounds[1].value, dec_bounds[1].value]
+
+    # Create SphericalPolygon for comparison
+    cutout_fp = SphericalPolygon.from_radec(ras, decs, center=(ra, dec))
+
+    # Find indices of FFIs that intersect with the cutout
+    ffi_inds = np.vectorize(lambda ffi: ffi.intersects_poly(cutout_fp))(all_ffis['polygon'])
+    ffi_inds = FootprintCutout._ffi_intersect(all_ffis, cutout_fp)
+
+    return ffi_inds
+
+
 def ra_dec_crossmatch(all_ffis: Table, coordinates: Union[SkyCoord, str], cutout_size, 
                       arcsec_per_px: int = 21) -> Table:
     """
@@ -235,7 +318,7 @@ def ra_dec_crossmatch(all_ffis: Table, coordinates: Union[SkyCoord, str], cutout
     ra, dec = coordinates.ra, coordinates.dec
 
     px_size = np.zeros(2, dtype=object)
-    for axis, size in enumerate(Cutout._parse_size_input(cutout_size, allow_zero=True)):
+    for axis, size in enumerate(Cutout.parse_size_input(cutout_size, allow_zero=True)):
         if isinstance(size, u.Quantity):  # If Quantity, convert to pixels
             if size.unit == u.pixel:
                 px_size[axis] = size.value
@@ -246,38 +329,10 @@ def ra_dec_crossmatch(all_ffis: Table, coordinates: Union[SkyCoord, str], cutout
             px_size[axis] = size
 
     if np.all(px_size == 0):
-        # A single point
-        ffi_inds = []
-        vector_coord = radec_to_vector(ra, dec)
-        for sector in np.unique(all_ffis['sequence_number']):
-            # Returns a 2-long array where the first element is indexes and the 2nd element is empty
-            sector_ffi_inds = np.where(all_ffis['sequence_number'] == sector)[0]
-
-            for ind in sector_ffi_inds:
-                if all_ffis[ind]["polygon"].contains_point(vector_coord):
-                    ffi_inds.append(ind)
-                    break  # the ra/dec will only be on one ccd per sector
+        # Cross match with point
+        ffi_inds = _crossmatch_point(ra, dec, all_ffis)
     else:
-        # Create polygon for intersection
-        # Convert dimensions from pixels to arcseconds and divide by 2 to get offset from center
-        # If one of the dimensions is 0, use a very small value to avoid issues with SphericalPolygon
-        min_offset = 0.1  # pixels
-        ra_offset = ((max(px_size[0], min_offset) * arcsec_per_px) / 2) * u.arcsec
-        dec_offset = ((max(px_size[1], min_offset) * arcsec_per_px) / 2) * u.arcsec
-
-        # Calculate RA and Dec boundaries
-        ra_bounds = [ra - ra_offset, ra + ra_offset]
-        dec_bounds = [dec - dec_offset, dec + dec_offset]
-
-        # Get RA and Dec for four corners of rectangle
-        ras = [ra_bounds[0].value, ra_bounds[1].value, ra_bounds[1].value, ra_bounds[0].value]
-        decs = [dec_bounds[0].value, dec_bounds[0].value, dec_bounds[1].value, dec_bounds[1].value]
-
-        # Create SphericalPolygon for comparison
-        cutout_fp = SphericalPolygon.from_radec(ras, decs, center=(ra, dec))
-
-        # Find indices of FFIs that intersect with the cutout
-        ffi_inds = np.vectorize(lambda ffi: ffi.intersects_poly(cutout_fp))(all_ffis['polygon'])
-        ffi_inds = FootprintCutout._ffi_intersect(all_ffis, cutout_fp)
+        # Cross match with polygon
+        ffi_inds = _crossmatch_polygon(ra, dec, all_ffis, px_size, arcsec_per_px)
 
     return all_ffis[ffi_inds]

--- a/astrocut/footprint_cutout.py
+++ b/astrocut/footprint_cutout.py
@@ -194,7 +194,8 @@ def get_ffis(s3_footprint_cache: str) -> Table:
     return ffis
 
 
-def ra_dec_crossmatch(all_ffis: Table, coordinates: Union[SkyCoord, str], cutout_size, arcsec_per_px: int = 21) -> Table:
+def ra_dec_crossmatch(all_ffis: Table, coordinates: Union[SkyCoord, str], cutout_size, 
+                      arcsec_per_px: int = 21) -> Table:
     """
     Returns the Full Frame Images (FFIs) whose footprints overlap with a cutout of a given position and size.
 
@@ -214,6 +215,10 @@ def ra_dec_crossmatch(all_ffis: Table, coordinates: Union[SkyCoord, str], cutout
         order.  Scalar numbers in ``cutout_size`` are assumed to be in
         units of pixels. `~astropy.units.Quantity` objects must be in pixel or
         angular units.
+
+        If a cutout size of zero is provided, the function will return FFIs that contain 
+        the exact RA and Dec position. If a non-zero cutout size is provided, the function 
+        will return FFIs whose footprints overlap with the cutout area.
     arcsec_per_px : int, optional
         Default 21. The number of arcseconds per pixel in an image. Used to determine
         the footprint of the cutout. Default is the number of arcseconds per pixel in

--- a/astrocut/footprint_cutout.py
+++ b/astrocut/footprint_cutout.py
@@ -194,7 +194,7 @@ def get_ffis(s3_footprint_cache: str) -> Table:
     return ffis
 
 
-def _crossmatch_point(ra: SkyCoord, dec: SkyCoord, all_ffis: Table) -> List[int]:
+def _crossmatch_point(ra: SkyCoord, dec: SkyCoord, all_ffis: Table) -> np.ndarray:
     """
     Returns the indices of the Full Frame Images (FFIs) that contain the given RA and
     Dec coordinates by checking which FFI polygons contain the point.

--- a/astrocut/tests/test_tess_footprint_cutout.py
+++ b/astrocut/tests/test_tess_footprint_cutout.py
@@ -2,6 +2,8 @@ from pathlib import Path
 import pytest
 import re
 
+import astropy.units as u
+import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Table
@@ -75,6 +77,35 @@ def test_ffi_intersect(lon, lat, center, expected):
 
     # Assert the intersection result matches the expected value
     assert intersection.value[0] == expected
+
+
+def test_ra_dec_crossmatch(coordinates, cutout_size):
+    all_ffis = get_ffis('s3://stpubdata/tess/public/footprints/tess_ffi_footprint_cache.json')
+
+    # Cutout size of 0 should do a point match
+    point_results = ra_dec_crossmatch(all_ffis, coordinates, 0, 21)
+    len_point_results = len(point_results)
+    assert isinstance(point_results, Table)
+
+    # Try cutout size of 0 in different forms
+    zero_sizes = [0 * u.arcmin, [0, 0], (0, 0), (0*u.pix, 0*u.pix), [0*u.arcsec, 0*u.arcsec], np.array([0, 0])]
+    for size in zero_sizes:
+        results = ra_dec_crossmatch(all_ffis, coordinates, size)
+        assert len(results) == len_point_results
+
+    # Coordinates as string
+    str_results = ra_dec_crossmatch(all_ffis, '350 -80', 0)
+    assert len(str_results) == len_point_results
+
+    # Cutout size > 0 should do an intersection match
+    # Should intersect with more sectors than point match
+    intersect_results = ra_dec_crossmatch(all_ffis, coordinates, 100)
+    assert len(intersect_results) > len_point_results
+
+    # Cutout size with one zero axis should check along a rectangle with a small width in that axis
+    # Should intersect with more sectors than point match
+    line_results = ra_dec_crossmatch(all_ffis, coordinates, (0, 100))
+    assert len(line_results) > len_point_results
 
 
 def test_tess_footprint_cutout(cutout_size, caplog):


### PR DESCRIPTION
Added support in `ra_dec_crossmatch` for a cutout size of zero, enabling single-point matching to FFIs that contain the specified coordinates. This single-point matching is significantly faster than computing an intersection between polygons.

If only one axis of the cutout size is equal to zero, I add a negligible amount in that dimension and treat the cutout as a very thin rectangle.