### PR TITLE
Bugfix for converting sky coordinates into pixel location in ASDFCutout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
   the given sky coordinates and cutout size. [#168]
 - Cutouts of ASDF data in FITS format now include embedded ASDF metadata in an "ASDF" extension within the FITS file for 
   Python versions greater than or equal to 3.11. [#170]
+- Bugfix for getting the pixel location of given coordinates in ``ASDFCutout``. [#175]
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -665,13 +665,10 @@ def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> Tuple[Tupl
         warnings.simplefilter('ignore')
         wcs_updated = WCS(header)
 
-    # Turn input RA, Dec into a SkyCoord object
-    coordinates = SkyCoord(ra, dec, unit='deg')
-
-    # Map the coordinates to a pixel's location on the Roman 2d array (row, col)
-    row, col = gwcsobj.invert(coordinates.ra.deg, coordinates.dec.deg, with_bounding_box=False)
-
-    return (row, col), wcs_updated
+    # Map the coordinates to a pixel's location on the 2d image
+    row, col = gwcsobj.invert(np.atleast_1d(ra), np.atleast_1d(dec), with_bounding_box=False)
+    pixel_coords = (float(row[0]), float(col[0]))
+    return pixel_coords, wcs_updated
 
 
 @deprecated_renamed_argument('output_file', None, '1.0.0', warning_type=DeprecationWarning,


### PR DESCRIPTION
Fix a bug in `ASDFCutout.get_center_pixel` so that a `SkyCoord` object is not passed to `gwcs.invert`