### PR TITLE
Allow user to pass in fsspec_kwargs to FITSCutout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,24 +1,26 @@
 Unreleased
 -----------
 
+- Added ``fsspec_kwargs`` parameter to ``FITSCutout`` to pass through to ``s3fs`` for cloud-hosted files. [#177]
+
 
 1.2.0 (2026-02-04)
 -------------------
 
 - Added support in ``ra_dec_crossmatch`` for a cutout size of zero, enabling single-point matching to FFIs that contain
   the specified coordinates. [#166]
-- Added ``write_as_zip`` method to ``ASDFCutout``, ``FITSCutout``, ``TessCubeCutout``, and ``TessFootprintCutout`` classes to facilitate 
+- Added ``write_as_zip`` method to ``ASDFCutout``, ``FITSCutout``, ``TessCubeCutout``, and ``TessFootprintCutout`` classes to facilitate
   writing multiple cutouts into a single ZIP archive. [#167]
-- Added ``get_tess_sectors`` function to return TESS sector information for sectors whose footprints overlap with 
+- Added ``get_tess_sectors`` function to return TESS sector information for sectors whose footprints overlap with
   the given sky coordinates and cutout size. [#168]
-- Cutouts of ASDF data in FITS format now include embedded ASDF metadata in an "ASDF" extension within the FITS file for 
+- Cutouts of ASDF data in FITS format now include embedded ASDF metadata in an "ASDF" extension within the FITS file for
   Python versions greater than or equal to 3.11. [#170]
 - Bugfix for getting the pixel location of given coordinates in ``ASDFCutout``. [#175]
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
-- Cube cutout filenames now use a hyphen between dimensions (e.g., ``10-x-10`` instead of ``10x10``). They also include unit suffixes when 
+- Cube cutout filenames now use a hyphen between dimensions (e.g., ``10-x-10`` instead of ``10x10``). They also include unit suffixes when
   users request sizes as an ``astropy.units.Quantity`` object (e.g., ``5arcmin-x-4arcmin`` or ``30arcsec-x-20arcsec``). RA/Dec formatting within
   filenames now uses 7 decimal places (``{:.7f}``) for consistency across classes. These changes may break code that parses filenames or relies on
   old glob patterns. [#167]
@@ -37,7 +39,7 @@ Breaking Changes
     - New (no unit - pixels assumed): ``..._83.4063100_-62.4897710_64-x-64_astrocut.fits``
     - New (with units): ``..._83.4063100_-62.4897710_5arcmin-x-4arcmin_astrocut.fits``
 
-  - ASDF cutouts in FITS format now include cutout data in an ``ImageHDU`` extension called "CUTOUT". Code that reads ASDF cutouts from FITS files 
+  - ASDF cutouts in FITS format now include cutout data in an ``ImageHDU`` extension called "CUTOUT". Code that reads ASDF cutouts from FITS files
     should be updated to access the "CUTOUT" extension for cutout data rather than the "PRIMARY" extension. [#170]
 
 
@@ -150,7 +152,7 @@ Breaking Changes
 ----------------
 
 - Add moving target cutout functionality [#40]
-  
+
 
 0.7 (2020-08-19)
 ----------------

--- a/astrocut/fits_cutout.py
+++ b/astrocut/fits_cutout.py
@@ -698,7 +698,8 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
             invert: bool = False, img_format: str = '.jpg', colorize: bool = False,
             cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.',
             extension: Optional[Union[int, List[int], Literal['all']]] = None, fill_value: Union[int, float] = np.nan,
-            limit_rounding_method: str = 'round', verbose=False, fsspec_kwargs: Optional[dict] = None) -> Union[str, List[str]]:
+            limit_rounding_method: str = 'round', verbose=False, fsspec_kwargs: Optional[dict] = None
+            ) -> Union[str, List[str]]:
     """
     Takes one or more fits files with the same WCS/pointing, makes the same cutout in each file,
     and returns the result either as a single color image or in individual image files.

--- a/astrocut/fits_cutout.py
+++ b/astrocut/fits_cutout.py
@@ -42,6 +42,8 @@ class FITSCutout(ImageCutout):
         Optional, default True. If True, all cutouts are written to a single file or HDUList.
     verbose : bool
         If True, log messages are printed to the console.
+    fsspec_kwargs : dict
+        Optional, default None. Keyword arguments to pass through to `s3fs` for cloud-hosted files.
 
     Attributes
     ----------
@@ -619,7 +621,7 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
              correct_wcs: bool = False, extension: Optional[Union[int, List[int], Literal['all']]] = None,
              single_outfile: bool = True, cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.',
              memory_only: bool = False, fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round',
-             verbose=False) -> Union[str, List[str], List[HDUList]]:
+             verbose=False, fsspec_kwargs: Optional[dict] = None) -> Union[str, List[str], List[HDUList]]:
     """
     Takes one or more FITS files with the same WCS/pointing, makes the same cutout in each file,
     and returns the result either in a single FITS file with one cutout per extension or in
@@ -669,6 +671,8 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
         Method to use for rounding the cutout limits. Options are 'round', 'ceil', and 'floor'.
     verbose : bool
         Default False. If true intermediate information is printed.
+    fsspec_kwargs : dict
+        Optional, default None. Keyword arguments to pass through to `s3fs` for cloud-hosted files.
 
     Returns
     -------
@@ -679,7 +683,7 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
         file name(s).
     """
     fits_cutout = FITSCutout(input_files, coordinates, cutout_size, fill_value, limit_rounding_method,
-                             extension, single_outfile, verbose)
+                             extension, single_outfile, verbose, fsspec_kwargs)
 
     if memory_only:
         return fits_cutout.fits_cutouts

--- a/astrocut/fits_cutout.py
+++ b/astrocut/fits_cutout.py
@@ -698,7 +698,7 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
             invert: bool = False, img_format: str = '.jpg', colorize: bool = False,
             cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.',
             extension: Optional[Union[int, List[int], Literal['all']]] = None, fill_value: Union[int, float] = np.nan,
-            limit_rounding_method: str = 'round', verbose=False) -> Union[str, List[str]]:
+            limit_rounding_method: str = 'round', verbose=False, fsspec_kwargs: Optional[dict] = None) -> Union[str, List[str]]:
     """
     Takes one or more fits files with the same WCS/pointing, makes the same cutout in each file,
     and returns the result either as a single color image or in individual image files.
@@ -756,6 +756,8 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
         The user can also supply one or more extensions to cutout from (integers), or "all".
     verbose : bool
         Default False. If true intermediate information is printed.
+    fsspec_kwargs : dict
+        Optional, default None. Keyword arguments to pass through to `s3fs` for cloud-hosted files.
 
     Returns
     -------
@@ -765,7 +767,7 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
     """
 
     fits_cutout = FITSCutout(input_files, coordinates, cutout_size, fill_value, limit_rounding_method,
-                             extension, verbose=verbose)
+                             extension, verbose=verbose, fsspec_kwargs=fsspec_kwargs)
 
     cutout_paths = fits_cutout.write_as_img(stretch, minmax_percent, minmax_value, invert, colorize, img_format,
                                             output_dir, cutout_prefix)

--- a/astrocut/fits_cutout.py
+++ b/astrocut/fits_cutout.py
@@ -59,15 +59,15 @@ class FITSCutout(ImageCutout):
     write_as_fits(output_dir, cutout_prefix)
         Write the cutouts to files in FITS format.
     """
-        
-    def __init__(self, input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
+
+    def __init__(self, input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str],
                  cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
                  fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round',
-                 extension: Optional[Union[int, List[int], Literal['all']]] = None, 
-                 single_outfile: bool = True, verbose: bool = False):
-        # Superclass constructor 
+                 extension: Optional[Union[int, List[int], Literal['all']]] = None,
+                 single_outfile: bool = True, verbose: bool = False, fsspec_kwargs: Optional[dict] = None):
+        # Superclass constructor
         super().__init__(input_files, coordinates, cutout_size, fill_value, limit_rounding_method, verbose)
-               
+
         # If a single extension is given, make it a list
         if isinstance(extension, int):
             extension = [extension]
@@ -77,6 +77,7 @@ class FITSCutout(ImageCutout):
         self._single_outfile = single_outfile
         self._fits_cutouts = None
         self.hdu_cutouts_by_file = {}
+        self._fsspec_kwargs = fsspec_kwargs
 
         # Make the cutouts upon initialization
         self.cutout()
@@ -94,7 +95,7 @@ class FITSCutout(ImageCutout):
         -------
         response : `~astropy.io.fits.HDUList`
             The HDUList object.
-        """        
+        """
         # Setting up the Primary HDU
         keywords = dict()
         if self._coordinates:
@@ -148,7 +149,7 @@ class FITSCutout(ImageCutout):
         if len(infile_exts) == 0:
             warnings.warn(f'No image extensions with data found in {input_file}, skipping...', DataWarning)
             return []
-                
+
         if self._extension is None:
             cutout_exts = infile_exts[:1]  # Take the first image extension
         elif self._extension == 'all':
@@ -179,7 +180,11 @@ class FITSCutout(ImageCutout):
             The indices of the extension(s) to cutout from.
         """
         # Account for cloud-hosted files
-        fsspec_kwargs = {'anon': True} if 's3://' in input_file else None
+        fsspec_kwargs = None
+        if 's3://' in input_file:
+            fsspec_kwargs = {'anon': True}
+            if self._fsspec_kwargs:
+                fsspec_kwargs.update(self._fsspec_kwargs)
 
         # Open the file
         hdulist = fits.open(input_file, mode='denywrite', memmap=True, fsspec_kwargs=fsspec_kwargs)
@@ -189,7 +194,7 @@ class FITSCutout(ImageCutout):
         cutout_inds = self._parse_extensions(input_file, infile_exts)
 
         return (hdulist, cutout_inds)
-    
+
     def _get_img_wcs(self, hdu_header: fits.Header) -> Tuple[WCS, bool]:
         """
         Get the WCS for an image.
@@ -198,7 +203,7 @@ class FITSCutout(ImageCutout):
         ----------
         hdu_header : `~astropy.io.fits.Header`
             The header for the image HDU.
-        
+
         Returns
         --------
         img_wcs : `~astropy.wcs.WCS`
@@ -213,7 +218,7 @@ class FITSCutout(ImageCutout):
         # correct and adjusting the header keywords to match.
         hdlrs = astropy_log.handlers
         astropy_log.handlers = []
-        with astropy_log.log_to_list() as log_list:        
+        with astropy_log.log_to_list() as log_list:
             img_wcs = WCS(hdu_header, relax=True)
 
         for hd in hdlrs:
@@ -244,7 +249,7 @@ class FITSCutout(ImageCutout):
             The WCS for the image.
         hdu_header : `~astropy.io.fits.Header`
             The header for the image HDU.
-        no_sip : bool   
+        no_sip : bool
             Whether the image WCS has no SIP information.
         ind : int
             The index of the extension in the original file.
@@ -309,7 +314,7 @@ class FITSCutout(ImageCutout):
         for ind in cutout_inds:
             try:
                 # Get HDU, header, and WCS
-                img_hdu = hdulist[ind] 
+                img_hdu = hdulist[ind]
                 hdu_header = fits.Header(img_hdu.header, copy=True)
                 img_wcs, no_sip = self._get_img_wcs(hdu_header)
                 primary_filename = hdulist[0].header.get('FILENAME')
@@ -327,7 +332,7 @@ class FITSCutout(ImageCutout):
                     cutouts.append(cutout)
 
                 # Also save the cutouts as ImageHDU objects for FITS output
-                fits_cutouts.append(self._hducut(cutout.data, cutout.wcs, hdu_header, no_sip, ind, 
+                fits_cutouts.append(self._hducut(cutout.data, cutout.wcs, hdu_header, no_sip, ind,
                                                  primary_filename, is_empty))
 
             except OSError as err:
@@ -349,7 +354,7 @@ class FITSCutout(ImageCutout):
                     num_empty += 1
                 else:
                     raise
-        
+
         # Close HDUList
         hdulist.close()
 
@@ -381,7 +386,7 @@ class FITSCutout(ImageCutout):
         for file in self._input_files:
             self._cutout_file(file)
 
-        # If no cutouts contain data, raise exception        
+        # If no cutouts contain data, raise exception
         if not self.cutouts_by_file:
             raise InvalidQueryError('Cutout contains no data! (Check image footprint.)')
 
@@ -408,11 +413,11 @@ class FITSCutout(ImageCutout):
             filename = self._make_cutout_filename(cutout_prefix)
             cutout_path = Path(output_dir, filename)
             with warnings.catch_warnings():
-                warnings.simplefilter('ignore') 
+                warnings.simplefilter('ignore')
                 cutout_fits.writeto(cutout_path, overwrite=True, checksum=True)
             # Return file path or memory object
             return [cutout_path.as_posix()]
-    
+
         else:  # one output file per input file
             log.debug('Returning cutouts as individual FITS files.')
 
@@ -462,7 +467,7 @@ class FITSCutout(ImageCutout):
                     yield arcname, hdu
 
         return self._write_cutouts_to_zip(output_dir=output_dir, filename=filename, build_entries=build_entries)
-        
+
     class CutoutInstance:
         """
         Represents an individual cutout with its own data and WCS. Eventually, this will be replaced
@@ -509,8 +514,8 @@ class FITSCutout(ImageCutout):
             self.shape_input = img_data.shape
 
             self.wcs = self._get_cutout_wcs(img_wcs, cutout_lims)
-        
-        def _get_cutout_data(self, data: fits.Section, cutout_lims: np.ndarray, 
+
+        def _get_cutout_data(self, data: fits.Section, cutout_lims: np.ndarray,
                              parent: 'FITSCutout') -> np.ndarray:
             """
             Extract the cutout data from an image.
@@ -549,7 +554,7 @@ class FITSCutout(ImageCutout):
                 (max(0, -ymin), max(0, ymax - ymax_img)),  # (top, bottom)
                 (max(0, -xmin), max(0, xmax - xmax_img))   # (left, right)
             ])
-            
+
             # Extract the cutout
             img_cutout = data[ymin_clipped:ymax_clipped, xmin_clipped:xmax_clipped]
 
@@ -584,7 +589,7 @@ class FITSCutout(ImageCutout):
                 The cutout WCS object including SIP distortions if present.
             """
             # relax = True is important when the WCS has sip distortions, otherwise it has no effect
-            wcs_header = img_wcs.to_header(relax=True) 
+            wcs_header = img_wcs.to_header(relax=True)
 
             # Adjusting the CRPIX values
             wcs_header['CRPIX1'] -= cutout_lims[0, 0]
@@ -603,22 +608,22 @@ class FITSCutout(ImageCutout):
             wcs_header.set('CRPIX2P', 1, 'reference CCD row')
             wcs_header.set('CRVAL2P', cutout_lims[1, 0] + 1, 'value at reference CCD row')
             wcs_header.set('CDELT2P', 1.0, 'physical WCS axis 2 step')
-            
+
             return WCS(wcs_header)
-        
+
 
 @deprecated_renamed_argument('correct_wcs', None, '1.0.0', warning_type=DeprecationWarning,
                              message='`correct_wcs` is non-operational and will be removed in a future version.')
-def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
+def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str],
              cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
              correct_wcs: bool = False, extension: Optional[Union[int, List[int], Literal['all']]] = None,
-             single_outfile: bool = True, cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.', 
+             single_outfile: bool = True, cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.',
              memory_only: bool = False, fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round',
              verbose=False) -> Union[str, List[str], List[HDUList]]:
     """
     Takes one or more FITS files with the same WCS/pointing, makes the same cutout in each file,
-    and returns the result either in a single FITS file with one cutout per extension or in 
-    individual fits files. The memory_only flag allows the cutouts to be returned as 
+    and returns the result either in a single FITS file with one cutout per extension or in
+    individual fits files. The memory_only flag allows the cutouts to be returned as
     `~astropy.io.fits.HDUList` objects rather than saving to disk.
 
     Note: No checking is done on either the WCS pointing or pixel scale. If images don't line up
@@ -632,25 +637,25 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
     input_files : list
         List of fits image files to cutout from. The image is assumed to be in the first extension.
     coordinates : str or `~astropy.coordinates.SkyCoord` object
-        The position around which to cutout. It may be specified as a string ("ra dec" in degrees) 
+        The position around which to cutout. It may be specified as a string ("ra dec" in degrees)
         or as the appropriate `~astropy.coordinates.SkyCoord` object.
     cutout_size : int, array-like, `~astropy.units.Quantity`
-        The size of the cutout array. If ``cutout_size`` is a scalar number or a scalar 
-        `~astropy.units.Quantity`, then a square cutout of ``cutout_size`` will be created.  
-        If ``cutout_size`` has two elements, they should be in ``(ny, nx)`` order.  Scalar numbers 
-        in ``cutout_size`` are assumed to be in units of pixels. `~astropy.units.Quantity` objects 
+        The size of the cutout array. If ``cutout_size`` is a scalar number or a scalar
+        `~astropy.units.Quantity`, then a square cutout of ``cutout_size`` will be created.
+        If ``cutout_size`` has two elements, they should be in ``(ny, nx)`` order.  Scalar numbers
+        in ``cutout_size`` are assumed to be in units of pixels. `~astropy.units.Quantity` objects
         must be in pixel or angular units.
     extension : int, list of ints, None, or 'all'
        Optional, default None. Default is to cutout the first extension that has image data.
        The user can also supply one or more extensions to cutout from (integers), or 'all'.
-    single_outfile : bool 
+    single_outfile : bool
         Default True. If true return all cutouts in a single fits file with one cutout per extension,
-        if False return cutouts in individual fits files. If returing a single file the filename will 
+        if False return cutouts in individual fits files. If returing a single file the filename will
         have the form: <cutout_prefix>_<ra>_<dec>_<size x>_<size y>.fits. If returning multiple files
         each will be named: <original filemame base>_<ra>_<dec>_<size x>_<size y>.fits.
-    cutout_prefix : str 
-        Default value "cutout". Only used if single_outfile is True. A prefix to prepend to the cutout 
-        filename. 
+    cutout_prefix : str
+        Default value "cutout". Only used if single_outfile is True. A prefix to prepend to the cutout
+        filename.
     output_dir : str
         Default value '.'. The directory to save the cutout file(s) to.
     memory_only : bool
@@ -668,26 +673,26 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
     Returns
     -------
     response : str or list
-        If single_outfile is True, returns the single output filepath. Otherwise, returns a list of all 
+        If single_outfile is True, returns the single output filepath. Otherwise, returns a list of all
         the output filepaths.
         If memory_only is True, a list of `~astropy.io.fit.HDUList` objects is returned instead of
         file name(s).
     """
-    fits_cutout = FITSCutout(input_files, coordinates, cutout_size, fill_value, limit_rounding_method, 
+    fits_cutout = FITSCutout(input_files, coordinates, cutout_size, fill_value, limit_rounding_method,
                              extension, single_outfile, verbose)
-    
+
     if memory_only:
         return fits_cutout.fits_cutouts
-    
+
     cutout_paths = fits_cutout.write_as_fits(output_dir, cutout_prefix)
     return cutout_paths[0] if len(cutout_paths) == 1 else cutout_paths
 
 
-def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
-            cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25, stretch: str = 'asinh', 
-            minmax_percent: Optional[List[int]] = None, minmax_value: Optional[List[int]] = None, 
+def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str],
+            cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25, stretch: str = 'asinh',
+            minmax_percent: Optional[List[int]] = None, minmax_value: Optional[List[int]] = None,
             invert: bool = False, img_format: str = '.jpg', colorize: bool = False,
-            cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.', 
+            cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.',
             extension: Optional[Union[int, List[int], Literal['all']]] = None, fill_value: Union[int, float] = np.nan,
             limit_rounding_method: str = 'round', verbose=False) -> Union[str, List[str]]:
     """
@@ -705,20 +710,20 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
     input_files : list
         List of fits image files to cutout from. The image is assumed to be in the first extension.
     coordinates : str or `~astropy.coordinates.SkyCoord` object
-        The position around which to cutout. It may be specified as a string ("ra dec" in degrees) 
+        The position around which to cutout. It may be specified as a string ("ra dec" in degrees)
         or as the appropriate `~astropy.coordinates.SkyCoord` object.
     cutout_size : int, array-like, `~astropy.units.Quantity`
-        The size of the cutout array. If ``cutout_size`` is a scalar number or a scalar 
-        `~astropy.units.Quantity`, then a square cutout of ``cutout_size`` will be created.  
-        If ``cutout_size`` has two elements, they should be in ``(ny, nx)`` order.  Scalar numbers 
-        in ``cutout_size`` are assumed to be in units of pixels. `~astropy.units.Quantity` objects 
+        The size of the cutout array. If ``cutout_size`` is a scalar number or a scalar
+        `~astropy.units.Quantity`, then a square cutout of ``cutout_size`` will be created.
+        If ``cutout_size`` has two elements, they should be in ``(ny, nx)`` order.  Scalar numbers
+        in ``cutout_size`` are assumed to be in units of pixels. `~astropy.units.Quantity` objects
         must be in pixel or angular units.
     stretch : str
         Optional, default 'asinh'. The stretch to apply to the image array.
         Valid values are: asinh, sinh, sqrt, log, linear
     minmax_percent : array
-        Optional, default [0.5,99.5]. Interval based on a keeping a specified fraction of pixels 
-        (can be asymmetric) when scaling the image. The format is [lower percentile, upper percentile], 
+        Optional, default [0.5,99.5]. Interval based on a keeping a specified fraction of pixels
+        (can be asymmetric) when scaling the image. The format is [lower percentile, upper percentile],
         where pixel values below the lower percentile and above the upper percentile are clipped.
         Only one of minmax_percent and minmax_value should be specified.
     minmax_value : array
@@ -733,9 +738,9 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
     colorize : bool
         Optional, default False.  If True a single color image is produced as output, and it is expected
         that three files are given as input.
-    cutout_prefix : str 
-        Default value "cutout". Only used when producing a color image. A prefix to prepend to the 
-        cutout filename. 
+    cutout_prefix : str
+        Default value "cutout". Only used when producing a color image. A prefix to prepend to the
+        cutout filename.
     output_dir : str
         Defaul value '.'. The directory to save the cutout file(s) to.
     fill_value : int | float
@@ -751,13 +756,13 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
     Returns
     -------
     response : str or list
-        If colorize is True, returns the single output filepath. Otherwise, returns a list of all 
+        If colorize is True, returns the single output filepath. Otherwise, returns a list of all
         the output filepaths.
     """
 
-    fits_cutout = FITSCutout(input_files, coordinates, cutout_size, fill_value, limit_rounding_method, 
+    fits_cutout = FITSCutout(input_files, coordinates, cutout_size, fill_value, limit_rounding_method,
                              extension, verbose=verbose)
-    
+
     cutout_paths = fits_cutout.write_as_img(stretch, minmax_percent, minmax_value, invert, colorize, img_format,
                                             output_dir, cutout_prefix)
     return cutout_paths

--- a/astrocut/fits_cutout.py
+++ b/astrocut/fits_cutout.py
@@ -66,7 +66,7 @@ class FITSCutout(ImageCutout):
                  cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
                  fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round',
                  extension: Optional[Union[int, List[int], Literal['all']]] = None,
-                 single_outfile: bool = True, verbose: bool = False, fsspec_kwargs: Optional[dict] = None):
+                 single_outfile: bool = True, verbose: bool = False, *, fsspec_kwargs: Optional[dict] = None):
         # Superclass constructor
         super().__init__(input_files, coordinates, cutout_size, fill_value, limit_rounding_method, verbose)
 
@@ -621,7 +621,7 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
              correct_wcs: bool = False, extension: Optional[Union[int, List[int], Literal['all']]] = None,
              single_outfile: bool = True, cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.',
              memory_only: bool = False, fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round',
-             verbose=False, fsspec_kwargs: Optional[dict] = None) -> Union[str, List[str], List[HDUList]]:
+             verbose=False, *, fsspec_kwargs: Optional[dict] = None) -> Union[str, List[str], List[HDUList]]:
     """
     Takes one or more FITS files with the same WCS/pointing, makes the same cutout in each file,
     and returns the result either in a single FITS file with one cutout per extension or in
@@ -683,7 +683,7 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
         file name(s).
     """
     fits_cutout = FITSCutout(input_files, coordinates, cutout_size, fill_value, limit_rounding_method,
-                             extension, single_outfile, verbose, fsspec_kwargs)
+                             extension, single_outfile, verbose=verbose, fsspec_kwargs=fsspec_kwargs)
 
     if memory_only:
         return fits_cutout.fits_cutouts
@@ -698,7 +698,7 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
             invert: bool = False, img_format: str = '.jpg', colorize: bool = False,
             cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.',
             extension: Optional[Union[int, List[int], Literal['all']]] = None, fill_value: Union[int, float] = np.nan,
-            limit_rounding_method: str = 'round', verbose=False, fsspec_kwargs: Optional[dict] = None
+            limit_rounding_method: str = 'round', verbose=False, *, fsspec_kwargs: Optional[dict] = None
             ) -> Union[str, List[str]]:
     """
     Takes one or more fits files with the same WCS/pointing, makes the same cutout in each file,

--- a/astrocut/tests/test_fits_cutout.py
+++ b/astrocut/tests/test_fits_cutout.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import patch
 import pytest
 import zipfile
 import io
@@ -32,7 +33,7 @@ def test_images(request, tmpdir):
 def test_image_bad_sip(request, tmpdir):
     return create_test_imgs(request.param, 50, 1, dir_name=tmpdir,
                             basename="img_badsip_{:04d}.fits", bad_sip_keywords=True)[0]
-    
+
 
 # Fixture to return a center coordinate
 @pytest.fixture
@@ -69,7 +70,7 @@ def test_fits_cutout_single_outfile(test_images, center_coord, cutout_size, tmpd
     for i, img in enumerate(test_images):
         with fits.open(img) as test_hdu:
             assert np.all(cutout[i + 1].data == test_hdu[0].data[19:29, 19:29])
-    
+
     # Check WCS and position of center
     cut_wcs = wcs.WCS(cutout[1].header)
     sra, sdec = cut_wcs.all_pix2world(cutout_size/2, cutout_size/2, 0)
@@ -85,18 +86,18 @@ def test_fits_cutout_multiple_files(tmpdir, test_images, center_coord, cutout_si
     assert isinstance(cutouts, list)
     assert isinstance(cutouts[0], fits.HDUList)
     assert len(cutouts) == len(test_images)
-    
+
     for i, cutout in enumerate(cutouts):
         cut1 = cutout[1].data
 
         # Check shape of data
         assert len(cutout) == 2  # primary header + 1 image
         assert cut1.shape == (cutout_size, cutout_size)
-        
+
         # Check that data is equal between cutout and original image
         with fits.open(test_images[i]) as test_hdu:
             assert np.all(cut1 == test_hdu[0].data[19:29, 19:29])
-    
+
         # Check WCS and position of center
         cut_wcs = wcs.WCS(cutout[1].header)
         sra, sdec = cut_wcs.all_pix2world(cutout_size/2, cutout_size/2, 0)
@@ -133,7 +134,7 @@ def test_fits_cutout_memory_only(test_images, center_coord, cutout_size):
 
 def test_fits_cutout_return_paths(test_images, center_coord, cutout_size, tmpdir):
     # Return filepath for single output file
-    cutout_file = FITSCutout(test_images, center_coord, cutout_size).write_as_fits(output_dir=tmpdir, 
+    cutout_file = FITSCutout(test_images, center_coord, cutout_size).write_as_fits(output_dir=tmpdir,
                                                                                    cutout_prefix='prefix')[0]
     assert isinstance(cutout_file, str)
     assert path.exists(cutout_file)
@@ -144,7 +145,7 @@ def test_fits_cutout_return_paths(test_images, center_coord, cutout_size, tmpdir
     assert '10-x-10' in cutout_file
 
     # Return list of filepaths for multiple output files
-    cutout_files = FITSCutout(test_images, center_coord, cutout_size, 
+    cutout_files = FITSCutout(test_images, center_coord, cutout_size,
                               single_outfile=False).write_as_fits(output_dir=tmpdir)
     assert isinstance(cutout_files, list)
     assert len(cutout_files) == len(test_images)
@@ -203,7 +204,7 @@ def test_fits_cutout_off_edge(test_images, cutout_size):
     center_coord = SkyCoord("150.1163213 2.2005731", unit='deg')
     cutout = FITSCutout(test_images, center_coord, cutout_size, single_outfile=True).fits_cutouts[0]
     assert isinstance(cutout, fits.HDUList)
-    
+
     assert len(cutout) == len(test_images) + 1  # num imgs + primary header
 
     cut1 = cutout[1].data
@@ -237,6 +238,20 @@ def test_fits_cutout_cloud():
     cutout_size = [10, 15]
     cutout = FITSCutout(test_s3_uri, center_coord, cutout_size).fits_cutouts[0]
     assert cutout[1].data.shape == (15, 10)
+
+
+def test_fits_cutout_cloud_fsspec_kwargs():
+    # Test single cloud image with fsspec_kwargs passed through to fits.open
+    test_s3_uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
+    center_coord = SkyCoord("150.4275416667 2.42155", unit='deg')
+    cutout_size = [10, 15]
+    fsspec_kwargs = {'default_block_size': 1 * 1024 * 1024}
+    with patch('astrocut.fits_cutout.fits.open', wraps=fits.open) as mock_open:
+        FITSCutout(test_s3_uri, center_coord, cutout_size, fsspec_kwargs=fsspec_kwargs).fits_cutouts[0]
+        # Verify fsspec_kwargs was passed with user's kwargs merged in
+        call_fsspec_kwargs = mock_open.call_args.kwargs['fsspec_kwargs']
+        assert call_fsspec_kwargs['anon'] is True
+        assert call_fsspec_kwargs['default_block_size'] == 1 * 1024 * 1024
 
 
 def test_fits_cutout_rounding(test_images, cutout_size):
@@ -323,7 +338,7 @@ def test_fits_cutout_no_data(tmpdir, test_images, cutout_size):
         with fits.open(img, mode="update") as hdu:
             hdu[0].data[:20, :] = 0
             hdu.flush()
-        
+
     # Single outfile should include empty files as extensions
     center_coord = SkyCoord("150.1163213 2.2007", unit='deg')
     with pytest.warns(DataWarning, match='contains no data, skipping...'):
@@ -333,10 +348,10 @@ def test_fits_cutout_no_data(tmpdir, test_images, cutout_size):
     assert ~(cutout[2].data == 0).any()
     assert ~(cutout[3].data == 0).any()
     assert ~(cutout[4].data == 0).any()
-    
+
     # Empty files should not be written to their own file
     with pytest.warns(DataWarning, match='contains no data, skipping...'):
-        cutout_files = FITSCutout(test_images, center_coord, cutout_size, 
+        cutout_files = FITSCutout(test_images, center_coord, cutout_size,
                                   single_outfile=False).write_as_fits(output_dir=tmpdir)
     assert isinstance(cutout_files, list)
     assert len(cutout_files) == len(test_images) - 2
@@ -372,7 +387,7 @@ def test_fits_cutout_bad_sip(tmpdir, caplog, test_image_bad_sip):
         assert cutout_hdulist[1].data.shape == (15, 10)
 
     cutout_size = [1, 2]*u.arcsec
-    cutout_file = FITSCutout(test_image_bad_sip, center_coord, cutout_size, 
+    cutout_file = FITSCutout(test_image_bad_sip, center_coord, cutout_size,
                              verbose=True).write_as_fits(output_dir=tmpdir)[0]
     assert isinstance(cutout_file, str)
     assert "1.0arcsec-x-2.0arcsec" in cutout_file
@@ -411,7 +426,7 @@ def test_fits_cutout_img_output(tmpdir, test_images, caplog, center_coord, cutou
         assert IMGFLE.read(3) == b'\xFF\xD8\xFF'  # JPG
 
     # Png (single input file, not as list)
-    img_files = FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(output_format='png', 
+    img_files = FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(output_format='png',
                                                                                    output_dir=tmpdir)
     with open(img_files[0], 'rb') as IMGFLE:
         assert IMGFLE.read(8) == b'\x89\x50\x4E\x47\x0D\x0A\x1A\x0A'  # PNG
@@ -419,7 +434,7 @@ def test_fits_cutout_img_output(tmpdir, test_images, caplog, center_coord, cutou
 
     # String coordinates and verbose
     center_coord = "150.1163213 2.200973097"
-    jpg_files = FITSCutout(test_images, center_coord, cutout_size, verbose=True).write_as_img(output_format='jpg', 
+    jpg_files = FITSCutout(test_images, center_coord, cutout_size, verbose=True).write_as_img(output_format='jpg',
                                                                                               output_dir=tmpdir)
     captured = caplog.text
     assert len(findall('Original image shape', captured)) == 6
@@ -465,9 +480,9 @@ def test_fits_cutout_img_errors(tmpdir, test_images, center_coord, cutout_size):
         FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(output_format='blp', output_dir=tmpdir)
 
     with pytest.warns(DataWarning, match='Cutout could not be saved in .mpg format'):
-        FITSCutout(test_images[:3], center_coord, cutout_size).write_as_img(output_format='mpg', output_dir=tmpdir, 
+        FITSCutout(test_images[:3], center_coord, cutout_size).write_as_img(output_format='mpg', output_dir=tmpdir,
                                                                             colorize=True)
-        
+
     # Invalid stretch error
     with pytest.raises(InvalidInputError, match='Stretch invalid is not recognized.'):
         FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(stretch='invalid', output_format='png',
@@ -490,5 +505,5 @@ def test_fits_cutout_img_errors(tmpdir, test_images, center_coord, cutout_size):
     # Error when outputting color image
     with pytest.warns(DataWarning, match='contains no data, skipping...'):
         with pytest.raises(InvalidInputError):
-            FITSCutout(test_images[:3], center_coord, cutout_size).write_as_img(colorize=True, output_format='png', 
+            FITSCutout(test_images[:3], center_coord, cutout_size).write_as_img(colorize=True, output_format='png',
                                                                                 output_dir=tmpdir)

--- a/astrocut/tests/test_fits_cutout.py
+++ b/astrocut/tests/test_fits_cutout.py
@@ -236,8 +236,12 @@ def test_fits_cutout_cloud():
     test_s3_uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
     center_coord = SkyCoord("150.4275416667 2.42155", unit='deg')
     cutout_size = [10, 15]
-    cutout = FITSCutout(test_s3_uri, center_coord, cutout_size).fits_cutouts[0]
-    assert cutout[1].data.shape == (15, 10)
+    with patch('astrocut.fits_cutout.fits.open', wraps=fits.open) as mock_open:
+        cutout = FITSCutout(test_s3_uri, center_coord, cutout_size).fits_cutouts[0]
+        assert cutout[1].data.shape == (15, 10)
+        # Verify fsspec_kwargs was passed with anonymous access
+        call_fsspec_kwargs = mock_open.call_args.kwargs['fsspec_kwargs']
+        assert call_fsspec_kwargs['anon'] is True
 
 
 def test_fits_cutout_cloud_fsspec_kwargs():
@@ -245,13 +249,14 @@ def test_fits_cutout_cloud_fsspec_kwargs():
     test_s3_uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
     center_coord = SkyCoord("150.4275416667 2.42155", unit='deg')
     cutout_size = [10, 15]
-    fsspec_kwargs = {'default_block_size': 1 * 1024 * 1024}
+    new_default_block_size = 1 * 1024 * 1024
+    fsspec_kwargs = {'default_block_size': new_default_block_size}
     with patch('astrocut.fits_cutout.fits.open', wraps=fits.open) as mock_open:
         FITSCutout(test_s3_uri, center_coord, cutout_size, fsspec_kwargs=fsspec_kwargs).fits_cutouts[0]
         # Verify fsspec_kwargs was passed with user's kwargs merged in
         call_fsspec_kwargs = mock_open.call_args.kwargs['fsspec_kwargs']
         assert call_fsspec_kwargs['anon'] is True
-        assert call_fsspec_kwargs['default_block_size'] == 1 * 1024 * 1024
+        assert call_fsspec_kwargs['default_block_size'] == new_default_block_size
 
 
 def test_fits_cutout_rounding(test_images, cutout_size):


### PR DESCRIPTION
Add the `fsspec_kwargs` argument to `FITSCutout` constructor. This will allow the user to pass in custom fsspec settings during the opening of a FITS file.

On the cloud we saw dramatic improvement when setting this to `1MB` as there is less data to load for a 256x256 PS1 cutout compared to the package default of `50MB`.

It reduced our cutout time on AWS ECS from 2s to about 650ms.