### PR TITLE
Switch to ruff for linting

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -75,7 +75,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install language-pack-de tzdata
       - name: Install Python dependencies
-        run: python -m pip install --upgrade tox codecov
+        run: python -m pip install --upgrade tox
       - name: Run tests
         run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
       - name: Upload coverage to codecov

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Unreleased
 
 - Added ``fsspec_kwargs`` parameter to ``FITSCutout`` to pass through to ``s3fs`` for cloud-hosted files. [#177]
 - New ``RomanSpectralSubset`` class for creating spectral subsets from Roman Space Telescope ASDF data. [#179]
+- Added support for Python 3.14. [#181]
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
+
+- Removed support for Python 3.8. [#181]
 
 
 1.2.0 (2026-02-04)

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,27 @@ For active development install in develop mode
 .. code-block:: bash
 
     $ pip install -e .
-    
+
+Linting
+=======
+Astrocut uses `ruff <https://github.com/charliermarsh/ruff>`_ for linting.
+
+To run ruff, install it with ``pip install ruff`` and then run the following commands from the root of the repository:
+
+.. code-block:: bash
+
+    $ ruff check .
+    $ ruff format --check .
+
+To automatically fix linting issues, run:
+
+.. code-block:: bash
+
+    $ ruff check . --fix
+    $ ruff format .
+
+Be careful with the above commands, as they will make changes to your code. You should review the changes before committing them.
+
 Testing
 =======
 Testing is now run with `tox <https://tox.readthedocs.io>`_ (``pip install tox``).

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ For active development install in develop mode
 
 Linting
 =======
-Astrocut uses `ruff <https://github.com/charliermarsh/ruff>`_ for linting.
+Astrocut uses `ruff <https://github.com/astral-sh/ruff>`_ for linting.
 
 To run ruff, install it with ``pip install ruff`` and then run the following commands from the root of the repository:
 

--- a/astrocut/__init__.py
+++ b/astrocut/__init__.py
@@ -4,7 +4,11 @@
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
 from ._astropy_init import *  # noqa
-# ----------------------------------------------------------------------------
+
+import sys
+
+from .exceptions import UnsupportedPythonError
+from .utils.logger import setup_logger
 
 """
 This module initializes the astrocut package and performs essential setup tasks, including:
@@ -12,11 +16,6 @@ This module initializes the astrocut package and performs essential setup tasks,
 - Setting up package-wide logging.
 - Importing key modules.
 """
-
-import sys
-
-from .exceptions import UnsupportedPythonError
-from .utils.logger import setup_logger
 
 # Enforce Python version check during package import.
 __minimum_python_version__ = "3.9"  # minimum supported Python version

--- a/astrocut/_astropy_init.py
+++ b/astrocut/_astropy_init.py
@@ -1,15 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ['__version__']
+__all__ = ["__version__"]
 
 # this indicates whether or not we are in the package's setup.py
 try:
     _ASTROPY_SETUP_
 except NameError:
     import builtins
+
     builtins._ASTROPY_SETUP_ = False
 
 try:
     from .version import version as __version__
 except ImportError:
-    __version__ = ''
+    __version__ = ""

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -145,7 +145,7 @@ class ASDFCutout(ImageCutout):
                     self._can_embed_asdf_in_fits = False
             else:
                 warnings.warn(
-                    "ASDF-in-FITS embedding requires Python 3.11 or higher. " "Skipping embedding for these cutouts.",
+                    "ASDF-in-FITS embedding requires Python 3.11 or higher. Skipping embedding for these cutouts.",
                     ModuleWarning,
                 )
                 self._can_embed_asdf_in_fits = False
@@ -794,5 +794,5 @@ def asdf_cut(
     else:
         # Error if output format not recognized
         raise InvalidInputError(
-            f"Output format {output_format} is not recognized. " 'Valid options are ".asdf" and ".fits".'
+            f'Output format {output_format} is not recognized. Valid options are ".asdf" and ".fits".'
         )

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -1,10 +1,10 @@
 import sys
 import warnings
 from copy import deepcopy
+from datetime import date
 from pathlib import Path
 from time import monotonic
-from typing import List, Tuple, Union, Optional
-from datetime import date
+from typing import List, Optional, Tuple, Union
 
 import asdf
 import gwcs
@@ -20,9 +20,9 @@ from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.wcs import WCS
 from s3path import S3Path
 
-from . import log, __version__
+from . import __version__, log
+from .exceptions import DataWarning, InvalidInputError, InvalidQueryError, ModuleWarning
 from .image_cutout import ImageCutout
-from .exceptions import DataWarning, ModuleWarning, InvalidQueryError, InvalidInputError
 
 
 class ASDFCutout(ImageCutout):
@@ -47,7 +47,7 @@ class ASDFCutout(ImageCutout):
         Optional, default None. Security token for S3 file system.
     lite : bool
         Optional, default False. By default, the class creates cutouts of all arrays in the input
-        file (e.g., data, error, uncertainty, variance, etc.) where the last two dimensions match the 
+        file (e.g., data, error, uncertainty, variance, etc.) where the last two dimensions match the
         shape of the science data array. It also preserves all of the metadata from the input file.
 
         If this parameter is True, the cutout will be created in "lite" mode,
@@ -77,12 +77,20 @@ class ASDFCutout(ImageCutout):
     write_as_asdf(output_dir)
         Write the cutouts to disk or memory in ASDF format.
     """
-        
-    def __init__(self, input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
-                 cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
-                 fill_value: Union[int, float] = np.nan, key: Optional[str] = None, secret: Optional[str] = None,
-                 token: Optional[str] = None, lite: Optional[bool] = False, verbose: bool = False):
-        # Superclass constructor 
+
+    def __init__(
+        self,
+        input_files: List[Union[str, Path, S3Path]],
+        coordinates: Union[SkyCoord, str],
+        cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
+        fill_value: Union[int, float] = np.nan,
+        key: Optional[str] = None,
+        secret: Optional[str] = None,
+        token: Optional[str] = None,
+        lite: Optional[bool] = False,
+        verbose: bool = False,
+    ):
+        # Superclass constructor
         super().__init__(input_files, coordinates, cutout_size, fill_value, verbose=verbose)
 
         # Must be using Python 3.11 or higher to support stdatamodels and ASDF-in-FITS embedding
@@ -92,7 +100,7 @@ class ASDFCutout(ImageCutout):
         self._key = key
         self._secret = secret
         self._token = token
-        self._mission_kwd = 'roman'
+        self._mission_kwd = "roman"
 
         self.cutouts = []  # Public attribute to hold `Cutout2D` objects
         self._asdf_cutouts = None  # Store ASDF objects
@@ -114,58 +122,65 @@ class ASDFCutout(ImageCutout):
             if self._py311_or_higher:
                 try:
                     # Check version of stdatamodels
-                    from stdatamodels import __version__ as stdata_version, asdf_in_fits
-                    if stdata_version < '4.1.0':
+                    from stdatamodels import __version__ as stdata_version
+                    from stdatamodels import asdf_in_fits
+
+                    if stdata_version < "4.1.0":
                         warnings.warn(
-                            'The `stdatamodels` package is not available in the correct version (>=4.1.0); '
-                            'ASDF-in-FITS embedding will be skipped for these cutouts. Install the optional '
+                            "The `stdatamodels` package is not available in the correct version (>=4.1.0); "
+                            "ASDF-in-FITS embedding will be skipped for these cutouts. Install the optional "
                             'dependency with: pip install "astrocut[all]" or pip install stdatamodels>=4.1.0',
-                            ModuleWarning
+                            ModuleWarning,
                         )
                         self._can_embed_asdf_in_fits = False
                     else:
                         self._can_embed_asdf_in_fits = True
                 except ImportError:
                     warnings.warn(
-                        'The `stdatamodels` package cannot be imported; ASDF-in-FITS embedding will be '
-                        'skipped for these cutouts. Install the optional dependency with: '
+                        "The `stdatamodels` package cannot be imported; ASDF-in-FITS embedding will be "
+                        "skipped for these cutouts. Install the optional dependency with: "
                         'pip install "astrocut[all]" or pip install stdatamodels>=4.1.0',
-                        ModuleWarning
+                        ModuleWarning,
                     )
                     self._can_embed_asdf_in_fits = False
             else:
-                warnings.warn('ASDF-in-FITS embedding requires Python 3.11 or higher. '
-                              'Skipping embedding for these cutouts.', ModuleWarning)
+                warnings.warn(
+                    "ASDF-in-FITS embedding requires Python 3.11 or higher. " "Skipping embedding for these cutouts.",
+                    ModuleWarning,
+                )
                 self._can_embed_asdf_in_fits = False
 
             fits_cutouts = []
-            for i, (file, cutouts) in enumerate(self.cutouts_by_file.items()):                
+            for i, (file, cutouts) in enumerate(self.cutouts_by_file.items()):
                 cutout = cutouts[0]
                 if self._lite:
                     tree = {
                         # Tree should only include sliced WCS and original filename
                         self._mission_kwd: {
-                            'meta': {'wcs': self._slice_gwcs(cutout, self._gwcs_objects[i]),
-                                     'orig_file': str(file)}
+                            "meta": {"wcs": self._slice_gwcs(cutout, self._gwcs_objects[i]), "orig_file": str(file)}
                         }
                     }
                 else:
                     tree = self._asdf_trees[i]
                     # Tree should only include meta
-                    tree[self._mission_kwd] = {'meta': tree[self._mission_kwd]['meta']}
+                    tree[self._mission_kwd] = {"meta": tree[self._mission_kwd]["meta"]}
 
                 # Build the PrimaryHDU with keywords
                 primary_hdu = fits.PrimaryHDU()
-                primary_hdu.header.extend([('ORIGIN', 'STScI/MAST', 'institution responsible for creating this file'),
-                                           ('DATE', str(date.today()), 'file creation date'),
-                                           ('PROCVER', __version__, 'software version'),
-                                           ('RA_OBJ', self._coordinates.ra.deg, '[deg] right ascension'),
-                                           ('DEC_OBJ', self._coordinates.dec.deg, '[deg] declination')])
-                
+                primary_hdu.header.extend(
+                    [
+                        ("ORIGIN", "STScI/MAST", "institution responsible for creating this file"),
+                        ("DATE", str(date.today()), "file creation date"),
+                        ("PROCVER", __version__, "software version"),
+                        ("RA_OBJ", self._coordinates.ra.deg, "[deg] right ascension"),
+                        ("DEC_OBJ", self._coordinates.dec.deg, "[deg] declination"),
+                    ]
+                )
+
                 # Build ImageHDU with cutout data and WCS
                 image_hdu = fits.ImageHDU(data=cutout.data, header=cutout.wcs.to_header(relax=True))
-                image_hdu.header['ORIG_FLE'] = str(file)  # Add original file to header
-                image_hdu.header['EXTNAME'] = 'CUTOUT'
+                image_hdu.header["ORIG_FLE"] = str(file)  # Add original file to header
+                image_hdu.header["EXTNAME"] = "CUTOUT"
                 hdul = fits.HDUList([primary_hdu, image_hdu])
 
                 if self._can_embed_asdf_in_fits:
@@ -175,7 +190,7 @@ class ASDFCutout(ImageCutout):
                 fits_cutouts.append(hdul_embed)
             self._fits_cutouts = fits_cutouts
         return self._fits_cutouts
-    
+
     @property
     def asdf_cutouts(self) -> List[asdf.AsdfFile]:
         """
@@ -193,20 +208,20 @@ class ASDFCutout(ImageCutout):
                 # Create the AsdfFile object and add history to it
                 af = asdf.AsdfFile(tree)
                 af.add_history_entry(
-                    f'Cutout of size {cutout.shape} at sky coordinates '
-                    f'({self._coordinates.ra.value}, {self._coordinates.dec.value})',
+                    f"Cutout of size {cutout.shape} at sky coordinates "
+                    f"({self._coordinates.ra.value}, {self._coordinates.dec.value})",
                     software={
-                        'name': 'astrocut',
-                        'author': 'Space Telescope Science Institute',
-                        'version': __version__,
-                        'homepage': 'https://astrocut.readthedocs.io/en/latest/'
-                    }
+                        "name": "astrocut",
+                        "author": "Space Telescope Science Institute",
+                        "version": __version__,
+                        "homepage": "https://astrocut.readthedocs.io/en/latest/",
+                    },
                 )
                 asdf_cutouts.append(af)
 
             self._asdf_cutouts = asdf_cutouts
         return self._asdf_cutouts
-    
+
     def _get_lite_tree(self, file_str: str, cutout: Cutout2D, gwcs: gwcs.wcs.WCS) -> dict:
         """
         Helper function to create an ASDF tree in lite mode.
@@ -227,14 +242,13 @@ class ASDFCutout(ImageCutout):
         """
         return {
             self._mission_kwd: {
-                'meta': {'wcs': self._slice_gwcs(cutout, gwcs),
-                         'orig_file': file_str},
-                'data': cutout.data
+                "meta": {"wcs": self._slice_gwcs(cutout, gwcs), "orig_file": file_str},
+                "data": cutout.data,
             }
         }
 
     def _get_cloud_http(self, input_file: Union[str, S3Path]) -> str:
-        """ 
+        """
         Get the HTTP URL of a cloud resource from an S3 URI.
 
         Parameters
@@ -249,15 +263,15 @@ class ASDFCutout(ImageCutout):
         """
         # Check if public or private by sending an HTTP request
         s3_path = S3Path.from_uri(input_file) if isinstance(input_file, str) else input_file
-        url = f'https://{s3_path.bucket}.s3.amazonaws.com/{s3_path.key}'
+        url = f"https://{s3_path.bucket}.s3.amazonaws.com/{s3_path.key}"
         resp = requests.head(url, timeout=10)
         is_anon = False if resp.status_code == 403 else True
         if not is_anon:
-            log.debug('Attempting to access private S3 bucket: %s', s3_path.bucket)
+            log.debug("Attempting to access private S3 bucket: %s", s3_path.bucket)
 
         # Create file system and get URL of file
         fs = s3fs.S3FileSystem(anon=is_anon, key=self._key, secret=self._secret, token=self._token)
-        with fs.open(input_file, 'rb') as f:
+        with fs.open(input_file, "rb") as f:
             return f.url()
 
     def _load_file_data(self, input_file: Union[str, Path, S3Path]) -> dict:
@@ -275,7 +289,7 @@ class ASDFCutout(ImageCutout):
             The ASDF tree of the input file.
         """
         # If file comes from AWS cloud bucket, get HTTP URL to open with asdf
-        if (isinstance(input_file, str) and input_file.startswith('s3://')) or isinstance(input_file, S3Path):
+        if (isinstance(input_file, str) and input_file.startswith("s3://")) or isinstance(input_file, S3Path):
             input_file = self._get_cloud_http(input_file)
 
         # Get data and GWCS object from ASDF input file
@@ -283,7 +297,7 @@ class ASDFCutout(ImageCutout):
             tree = deepcopy(af.tree)
 
         return tree
-    
+
     def _make_cutout(self, array: np.ndarray, position: tuple, wcs: WCS) -> Cutout2D:
         """
         Helper to generate a Cutout2D and return plain ndarray data.
@@ -317,7 +331,7 @@ class ASDFCutout(ImageCutout):
             cutout.data = cutout.data.value
 
         return cutout
-    
+
     def _get_cutout_data(self, tree: dict, wcs: WCS, pixel_coords: Tuple[int, int]) -> Cutout2D:
         """
         Get the cutout data from the input image.
@@ -336,8 +350,8 @@ class ASDFCutout(ImageCutout):
         img_cutout : `~astropy.nddata.Cutout2D`
             The cutout object.
         """
-        keys = list(tree[self._mission_kwd].keys()) if not self._lite else ['data']
-        data_shape = tree[self._mission_kwd]['data'].shape
+        keys = list(tree[self._mission_kwd].keys()) if not self._lite else ["data"]
+        data_shape = tree[self._mission_kwd]["data"].shape
 
         data_cutout = None  # Initialize cutout variable
         for key in keys:
@@ -346,12 +360,12 @@ class ASDFCutout(ImageCutout):
                 continue
 
             shape = obj.shape
-            is_data = key == 'data'
+            is_data = key == "data"
 
             if shape[-2:] != data_shape[-2:]:
                 continue  # Skip arrays not aligned with science data
 
-            log.debug(f'Original {key} shape: {shape}')
+            log.debug(f"Original {key} shape: {shape}")
 
             if obj.ndim == 2:
                 # Simple 2D cutout
@@ -359,7 +373,7 @@ class ASDFCutout(ImageCutout):
                 tree[self._mission_kwd][key] = cutout.data
                 if is_data:
                     data_cutout = cutout
-                log.debug(f'{key} cutout shape: {cutout.shape}')
+                log.debug(f"{key} cutout shape: {cutout.shape}")
 
             else:
                 # Cube or higher dimension array
@@ -371,12 +385,12 @@ class ASDFCutout(ImageCutout):
                     cutout_cube[idx] = cutout.data
 
                 tree[self._mission_kwd][key] = cutout_cube
-                log.debug(f'{key} cutout shape: {cutout_cube.shape}')
+                log.debug(f"{key} cutout shape: {cutout_cube.shape}")
 
         return data_cutout
 
     def _slice_gwcs(self, cutout: Cutout2D, gwcs: gwcs.wcs.WCS) -> gwcs.wcs.WCS:
-        """ 
+        """
         Slice the original gwcs object.
 
         "Slices" the original gwcs object down to the cutout shape.  This is a hack
@@ -406,15 +420,15 @@ class ASDFCutout(ImageCutout):
         xmin, xmax = slices[1].start, slices[1].stop
         ymin, ymax = slices[0].start, slices[0].stop
         shape = (xmax - xmin, ymax - ymin)
-        offsets = models.Shift(xmin, name='cutout_offset1') & models.Shift(ymin, name='cutout_offset2')
-        tmp.insert_transform('detector', offsets, after=True)
+        offsets = models.Shift(xmin, name="cutout_offset1") & models.Shift(ymin, name="cutout_offset2")
+        tmp.insert_transform("detector", offsets, after=True)
 
         # Modify the gwcs bounding box to the cutout shape
         tmp.bounding_box = ((0, shape[0] - 1), (0, shape[1] - 1))
         tmp.pixel_shape = shape
         tmp.array_shape = shape[::-1]
         return tmp
-    
+
     def _cutout_file(self, file: Union[str, Path, S3Path]):
         """
         Create a cutout from a single input file.
@@ -428,10 +442,9 @@ class ASDFCutout(ImageCutout):
         tree = self._load_file_data(file)
 
         # Skip if the file does not contain a GWCS object
-        gwcs = tree[self._mission_kwd]['meta'].get('wcs', None)
+        gwcs = tree[self._mission_kwd]["meta"].get("wcs", None)
         if gwcs is None:
-            warnings.warn(f'File {file} does not contain a GWCS object. Skipping...',
-                          DataWarning)
+            warnings.warn(f"File {file} does not contain a GWCS object. Skipping...", DataWarning)
             return
 
         # Get closest pixel coordinates and approximated WCS
@@ -441,14 +454,12 @@ class ASDFCutout(ImageCutout):
         try:
             data_cutout = self._get_cutout_data(tree, wcs, pixel_coords)
         except NoOverlapError:
-            warnings.warn(f'Cutout footprint does not overlap with data in {file}, skipping...',
-                          DataWarning)
+            warnings.warn(f"Cutout footprint does not overlap with data in {file}, skipping...", DataWarning)
             return
-        
+
         # Check that there is data in the cutout image
         if (data_cutout.data == 0).all() or (np.isnan(data_cutout.data)).all():
-            warnings.warn(f'Cutout of {file} contains no data, skipping...',
-                          DataWarning)
+            warnings.warn(f"Cutout of {file} contains no data, skipping...", DataWarning)
             return
 
         # Store the Cutout2D object
@@ -460,8 +471,8 @@ class ASDFCutout(ImageCutout):
         # Store the ASDF tree for this cutout
         file_str = str(file)
         if not self._lite:
-            tree[self._mission_kwd]['meta']['wcs'] = self._slice_gwcs(data_cutout, gwcs)
-            tree[self._mission_kwd]['meta']['orig_file'] = file_str
+            tree[self._mission_kwd]["meta"]["wcs"] = self._slice_gwcs(data_cutout, gwcs)
+            tree[self._mission_kwd]["meta"]["orig_file"] = file_str
             self._asdf_trees.append(tree)
 
         # Store cutout with filename
@@ -488,15 +499,15 @@ class ASDFCutout(ImageCutout):
         for file in self._input_files:
             self._cutout_file(file)
 
-        # If no cutouts contain data, raise exception        
+        # If no cutouts contain data, raise exception
         if not self.cutouts:
-            raise InvalidQueryError('Cutout contains no data! (Check image footprint.)')
+            raise InvalidQueryError("Cutout contains no data! (Check image footprint.)")
 
         # Log total time elapsed
-        log.debug('Total time: %.2f sec', monotonic() - start_time)
+        log.debug("Total time: %.2f sec", monotonic() - start_time)
 
         return self.cutouts
-    
+
     def _make_cutout_filename(self, file: str, output_format: str) -> str:
         """
         Generate a standardized filename for the cutout.
@@ -515,16 +526,17 @@ class ASDFCutout(ImageCutout):
         filename : str
             The generated filename for the cutout.
         """
-        return '{}_{:.7f}_{:.7f}_{}-x-{}{}_astrocut{}'.format(
+        return "{}_{:.7f}_{:.7f}_{}-x-{}{}_astrocut{}".format(
             Path(file).stem,
             self._coordinates.ra.value,
             self._coordinates.dec.value,
-            str(self._cutout_size[0]).replace(' ', ''), 
-            str(self._cutout_size[1]).replace(' ', ''),
-            '_lite' if self._lite else '',
-            output_format)
+            str(self._cutout_size[0]).replace(" ", ""),
+            str(self._cutout_size[1]).replace(" ", ""),
+            "_lite" if self._lite else "",
+            output_format,
+        )
 
-    def _write_as_format(self, output_format: str, output_dir: Union[str, Path] = '.') -> List[str]:
+    def _write_as_format(self, output_format: str, output_dir: Union[str, Path] = ".") -> List[str]:
         """
         Write the cutout to disk in the specified output format.
 
@@ -547,22 +559,22 @@ class ASDFCutout(ImageCutout):
             filename = self._make_cutout_filename(file, output_format)
             cutout_path = Path(output_dir, filename)
 
-            if output_format == '.fits':
+            if output_format == ".fits":
                 cutout = self.fits_cutouts[i]
                 with warnings.catch_warnings():
-                    warnings.simplefilter('ignore') 
+                    warnings.simplefilter("ignore")
                     cutout.writeto(cutout_path, overwrite=True, checksum=True)
 
-            elif output_format == '.asdf':
+            elif output_format == ".asdf":
                 cutout = self.asdf_cutouts[i]
                 cutout.write_to(cutout_path)
 
             cutout_paths.append(cutout_path.as_posix())
 
-        log.debug('Cutout filepaths: {}'.format(cutout_paths))
+        log.debug("Cutout filepaths: {}".format(cutout_paths))
         return cutout_paths
-    
-    def write_as_fits(self, output_dir: Union[str, Path] = '.') -> List[str]:
+
+    def write_as_fits(self, output_dir: Union[str, Path] = ".") -> List[str]:
         """
         Write the cutouts to disk or memory in FITS format.
 
@@ -576,9 +588,9 @@ class ASDFCutout(ImageCutout):
         list
             A list of paths to the cutout FITS files.
         """
-        return self._write_as_format(output_format='.fits', output_dir=output_dir)
+        return self._write_as_format(output_format=".fits", output_dir=output_dir)
 
-    def write_as_asdf(self, output_dir: Union[str, Path] = '.') -> List[str]:
+    def write_as_asdf(self, output_dir: Union[str, Path] = ".") -> List[str]:
         """
         Write the cutouts to disk or memory in ASDF format.
 
@@ -592,10 +604,15 @@ class ASDFCutout(ImageCutout):
         list
             A list of paths to the cutout ASDF files.
         """
-        return self._write_as_format(output_format='.asdf', output_dir=output_dir)
+        return self._write_as_format(output_format=".asdf", output_dir=output_dir)
 
-    def write_as_zip(self, output_dir: Union[str, Path] = '.', filename: Union[str, Path, None] = None,
-                     *, output_format: str = '.asdf') -> str:
+    def write_as_zip(
+        self,
+        output_dir: Union[str, Path] = ".",
+        filename: Union[str, Path, None] = None,
+        *,
+        output_format: str = ".asdf",
+    ) -> str:
         """
         Package the ASDF or FITS cutouts into a zip archive without writing intermediates.
 
@@ -616,12 +633,12 @@ class ASDFCutout(ImageCutout):
             Path to the created zip file.
         """
         fmt = output_format.lower().strip()
-        fmt = '.' + fmt if not fmt.startswith('.') else fmt
-        if fmt not in ('.asdf', '.fits'):
+        fmt = "." + fmt if not fmt.startswith(".") else fmt
+        if fmt not in (".asdf", ".fits"):
             raise InvalidInputError("File format must be either '.asdf' or '.fits'")
 
         def build_entries():
-            use_fits = fmt == '.fits'
+            use_fits = fmt == ".fits"
             objs = self.fits_cutouts if use_fits else self.asdf_cutouts
 
             for i, file in enumerate(self.cutouts_by_file):
@@ -629,10 +646,10 @@ class ASDFCutout(ImageCutout):
                 yield arcname, objs[i]
 
         return self._write_cutouts_to_zip(output_dir=output_dir, filename=filename, build_entries=build_entries)
-    
+
 
 def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> Tuple[Tuple[int, int], WCS]:
-    """ 
+    """
     Get the closest pixel location on an input image for a given set of coordinates.
 
     Parameters
@@ -656,13 +673,13 @@ def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> Tuple[Tupl
 
     # Update WCS header with some keywords that it's missing.
     # Otherwise, it won't work with astropy.wcs tools (TODO: Figure out why. What are these keywords for?)
-    for k in ['cpdis1', 'cpdis2', 'det2im1', 'det2im2', 'sip']:
+    for k in ["cpdis1", "cpdis2", "det2im1", "det2im2", "sip"]:
         if k not in header:
-            header[k] = 'na'
+            header[k] = "na"
 
     # New WCS object with updated header
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
+        warnings.simplefilter("ignore")
         wcs_updated = WCS(header)
 
     # Map the coordinates to a pixel's location on the 2d image
@@ -671,22 +688,29 @@ def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> Tuple[Tupl
     return pixel_coords, wcs_updated
 
 
-@deprecated_renamed_argument('output_file', None, '1.0.0', warning_type=DeprecationWarning,
-                             message='`output_file` is non-operational and will be removed in a future version.')
-def asdf_cut(input_files: List[Union[str, Path, S3Path]], 
-             ra: float, 
-             dec: float, 
-             cutout_size: int = 25,
-             output_file: Union[str, Path] = "example_roman_cutout.fits",
-             write_file: bool = True, 
-             fill_value: Union[int, float] = np.nan,
-             output_dir: Union[str, Path] = '.',
-             output_format: str = '.asdf', 
-             key: str = None,
-             secret: str = None, 
-             token: str = None,
-             lite: bool = False,
-             verbose: bool = False) -> Cutout2D:
+@deprecated_renamed_argument(
+    "output_file",
+    None,
+    "1.0.0",
+    warning_type=DeprecationWarning,
+    message="`output_file` is non-operational and will be removed in a future version.",
+)
+def asdf_cut(
+    input_files: List[Union[str, Path, S3Path]],
+    ra: float,
+    dec: float,
+    cutout_size: int = 25,
+    output_file: Union[str, Path] = "example_roman_cutout.fits",
+    write_file: bool = True,
+    fill_value: Union[int, float] = np.nan,
+    output_dir: Union[str, Path] = ".",
+    output_format: str = ".asdf",
+    key: str = None,
+    secret: str = None,
+    token: str = None,
+    lite: bool = False,
+    verbose: bool = False,
+) -> Cutout2D:
     """
     Takes one of more ASDF input files (`input_files`) and generates a cutout of designated size `cutout_size`
     around the given coordinates (`coordinates`). The cutout is written to a file or returned as an object.
@@ -704,9 +728,9 @@ def asdf_cut(input_files: List[Union[str, Path, S3Path]],
         The declination of the central cutout.
     cutout_size : int
         Optional, default 25. The image cutout pixel size.
-        Note: Odd values for `cutout_size` generally result in a cutout that is more accurately 
-        centered on the target coordinates compared to even values, due to the symmetry of the 
-        pixel grid. 
+        Note: Odd values for `cutout_size` generally result in a cutout that is more accurately
+        centered on the target coordinates compared to even values, due to the symmetry of the
+        pixel grid.
     output_file : str | Path
         Optional, default "example_roman_cutout.fits". The name of the output cutout file.
         This parameter is deprecated and will be removed in a future version.
@@ -731,7 +755,7 @@ def asdf_cut(input_files: List[Union[str, Path, S3Path]],
         cloud resource.
     lite : bool
         Optional, default False. By default, the class creates cutouts of all arrays in the input
-        file (e.g., data, error, uncertainty, variance, etc.) where the last two dimensions match the 
+        file (e.g., data, error, uncertainty, variance, etc.) where the last two dimensions match the
         shape of the science data array. It also preserves all of the metadata from the input file.
 
         If this parameter is True, the cutout will be created in "lite" mode,
@@ -744,21 +768,31 @@ def asdf_cut(input_files: List[Union[str, Path, S3Path]],
     response : str | list
         A list of cutout file paths if `write_file` is True, otherwise a list of cutout objects.
     """
-    asdf_cutout = ASDFCutout(input_files, f'{ra} {dec}', cutout_size, fill_value, key=key, 
-                             secret=secret, token=token, lite=lite, verbose=verbose)
-    
+    asdf_cutout = ASDFCutout(
+        input_files,
+        f"{ra} {dec}",
+        cutout_size,
+        fill_value,
+        key=key,
+        secret=secret,
+        token=token,
+        lite=lite,
+        verbose=verbose,
+    )
+
     if not write_file:  # Returns as Cutout2D objects
         return asdf_cutout.cutouts
-    
+
     # Get output format in standard form
-    output_format = f'.{output_format}' if not output_format.startswith('.') else output_format
+    output_format = f".{output_format}" if not output_format.startswith(".") else output_format
     output_format = output_format.lower()
 
-    if output_format == '.asdf':
+    if output_format == ".asdf":
         return asdf_cutout.write_as_asdf(output_dir)
-    elif output_format == '.fits':
+    elif output_format == ".fits":
         return asdf_cutout.write_as_fits(output_dir)
     else:
         # Error if output format not recognized
-        raise InvalidInputError(f'Output format {output_format} is not recognized. '
-                                'Valid options are ".asdf" and ".fits".')
+        raise InvalidInputError(
+            f"Output format {output_format} is not recognized. " 'Valid options are ".asdf" and ".fits".'
+        )

--- a/astrocut/asdf_spectral_subset.py
+++ b/astrocut/asdf_spectral_subset.py
@@ -691,7 +691,7 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
 
             for key, af in af_by_source_file.items():
                 file, sid = source_file_keys[key]
-                filename = f'{Path(file).stem}_subset_{sid}{"_lite" if self._lite else ""}.asdf'
+                filename = f"{Path(file).stem}_subset_{sid}{'_lite' if self._lite else ''}.asdf"
                 write_jobs.append((af, str(output_dir / filename)))
 
         elif group_by == "file":
@@ -702,7 +702,7 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
                 spectral_files=spectral_files,
             )
             for file, af in af_by_file.items():
-                filename = f'{Path(file).stem}_subset{"_lite" if self._lite else ""}.asdf'
+                filename = f"{Path(file).stem}_subset{'_lite' if self._lite else ''}.asdf"
                 write_jobs.append((af, str(output_dir / filename)))
 
         elif group_by == "combined":
@@ -712,7 +712,7 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
                 source_ids=source_ids,
                 spectral_files=spectral_files,
             )
-            filename = f'combined_spectral_subset{"_lite" if self._lite else ""}.asdf'
+            filename = f"combined_spectral_subset{'_lite' if self._lite else ''}.asdf"
             write_jobs.append((af, str(output_dir / filename)))
 
         else:

--- a/astrocut/conftest.py
+++ b/astrocut/conftest.py
@@ -7,26 +7,27 @@ import os
 
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+
     ASTROPY_HEADER = True
 except ImportError:
     ASTROPY_HEADER = False
 
 
 def pytest_configure(config):
-
     if ASTROPY_HEADER:
-
         config.option.astropy_header = True
 
         # Customize the following lines to add/remove entries from the list of
         # packages for which version numbers are displayed when running the tests.
-        PYTEST_HEADER_MODULES.pop('Pandas', None)
-        PYTEST_HEADER_MODULES.pop('h5py', None)
-        PYTEST_HEADER_MODULES.pop('Matplotlib', None)
+        PYTEST_HEADER_MODULES.pop("Pandas", None)
+        PYTEST_HEADER_MODULES.pop("h5py", None)
+        PYTEST_HEADER_MODULES.pop("Matplotlib", None)
 
         from . import __version__
+
         packagename = os.path.basename(os.path.dirname(__file__))
         TESTED_VERSIONS[packagename] = __version__
+
 
 # Uncomment the last two lines in this block to treat all DeprecationWarnings as
 # exceptions. For Astropy v2.0 or later, there are 2 additional keywords,

--- a/astrocut/cube_cutout.py
+++ b/astrocut/cube_cutout.py
@@ -1,8 +1,8 @@
-from abc import ABC, abstractmethod
-from pathlib import Path
 import warnings
+from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from itertools import product
+from pathlib import Path
 from time import monotonic
 from typing import List, Literal, Tuple, Union
 
@@ -45,7 +45,7 @@ class CubeCutout(Cutout, ABC):
     Attributes
     ----------
     cutouts_by_file : dict
-        Dictionary where each key is an input cube filename and its corresponding value is the resulting cutout as a 
+        Dictionary where each key is an input cube filename and its corresponding value is the resulting cutout as a
         ``CubeCutoutInstance`` object.
     cutouts : list
         List of cutout objects.
@@ -55,10 +55,17 @@ class CubeCutout(Cutout, ABC):
     cutout()
         Generate the cutouts.
     """
-    def __init__(self, input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
-                 cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]] = 25,
-                 fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round', 
-                 threads: Union[int, Literal['auto']] = 1, verbose: bool = False):
+
+    def __init__(
+        self,
+        input_files: List[Union[str, Path, S3Path]],
+        coordinates: Union[SkyCoord, str],
+        cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]] = 25,
+        fill_value: Union[int, float] = np.nan,
+        limit_rounding_method: str = "round",
+        threads: Union[int, Literal["auto"]] = 1,
+        verbose: bool = False,
+    ):
         super().__init__(input_files, coordinates, cutout_size, fill_value, limit_rounding_method, verbose)
 
         # Assign the number of threads to use when making cutout
@@ -93,22 +100,16 @@ class CubeCutout(Cutout, ABC):
             The cube data.
         """
         # Suppress FITSFixedWarning from astropy
-        warnings.filterwarnings('ignore', category=wcs.FITSFixedWarning)
+        warnings.filterwarnings("ignore", category=wcs.FITSFixedWarning)
 
         # Options when opening the cube file
-        fits_options = {
-            'mode': 'denywrite',
-            'lazy_load_hdus': True
-        }
+        fits_options = {"mode": "denywrite", "lazy_load_hdus": True}
 
         # Add options based on the file's location
-        if isinstance(file, str) and file.startswith('s3://'):  # cloud-hosted file
-            fits_options.update({
-                'use_fsspec': True,
-                'fsspec_kwargs': {'default_block_size': 10_000, 'anon': True}
-            })
+        if isinstance(file, str) and file.startswith("s3://"):  # cloud-hosted file
+            fits_options.update({"use_fsspec": True, "fsspec_kwargs": {"default_block_size": 10_000, "anon": True}})
         else:
-            fits_options['memmap'] = True
+            fits_options["memmap"] = True
             self._threads = 1  # disable threading for local storage access
 
         return fits.open(file, **fits_options)
@@ -145,7 +146,7 @@ class CubeCutout(Cutout, ABC):
                 data_ind = 0
             elif data_ind == (len(table_data) // 2) - 1:
                 # Error if all indices have been checked
-                raise wcs.NoWcsKeywordsFoundError('No FFI rows contain valid WCS keywords.')
+                raise wcs.NoWcsKeywordsFoundError("No FFI rows contain valid WCS keywords.")
 
             # Making sure we have a row with wcs info.
             row = table_data[data_ind]
@@ -155,7 +156,7 @@ class CubeCutout(Cutout, ABC):
                 # If not found, move to the next
                 data_ind += 1
 
-        log.debug('Using WCS from row %s out of %s', data_ind, len(table_data))
+        log.debug("Using WCS from row %s out of %s", data_ind, len(table_data))
 
         # Convert the row into a FITS header
         wcs_header = fits.Header()
@@ -170,11 +171,10 @@ class CubeCutout(Cutout, ABC):
         # Populate the image keywords dictionary
         for kwd in self._img_kwds:
             self._img_kwds[kwd][0] = wcs_header.get(kwd)
-        
+
         # Add the FFI file reference
-        self._img_kwds['WCS_FFI'] = [table_row['FFI_FILE'],
-                                     'FFI used for cutout WCS']
-        
+        self._img_kwds["WCS_FFI"] = [table_row["FFI_FILE"], "FFI used for cutout WCS"]
+
         return WCS(wcs_header, relax=True)
 
     def _add_column_wcs(self, table_header: fits.Header, wcs_dict: dict):
@@ -184,20 +184,20 @@ class CubeCutout(Cutout, ABC):
         Parameters
         ----------
         table_header : `~astropy.io.fits.Header`
-            The table header for the cutout table that will be modified in place to include 
+            The table header for the cutout table that will be modified in place to include
             WCS information.
         wcs_dict : dict
-            Dictionary of wcs keyword/value pairs to be added to each array column in the 
+            Dictionary of wcs keyword/value pairs to be added to each array column in the
             cutout table header.
         """
         # Mapping of FITS table keywords to descriptions
         keyword_comments = {
-            'TTYPE': 'column name',
-            'TFORM': 'column format',
-            'TUNIT': 'unit',
-            'TDISP': 'display format',
-            'TDIM': 'multi-dimensional array spec',
-            'TNULL': 'null value'
+            "TTYPE": "column name",
+            "TFORM": "column format",
+            "TUNIT": "unit",
+            "TDISP": "display format",
+            "TDIM": "multi-dimensional array spec",
+            "TNULL": "null value",
         }
 
         for kwd in table_header:
@@ -206,9 +206,9 @@ class CubeCutout(Cutout, ABC):
                 if key in kwd:
                     table_header.comments[kwd] = comment
                     break
-            
+
             # If the column is a 2D array (indicated by 'TDIM'), add WCS info
-            if 'TDIM' in kwd and kwd[:-1] == 'TTYPE':
+            if "TDIM" in kwd and kwd[:-1] == "TTYPE":
                 for wcs_key, (val, com) in wcs_dict.items():
                     table_header.insert(kwd, (wcs_key.format(int(kwd[-1]) - 1), val, com))
 
@@ -228,25 +228,25 @@ class CubeCutout(Cutout, ABC):
 
     def _apply_header_inherit(self, hdu_list: fits.HDUList):
         """
-        The INHERIT keyword indicated that keywords from the primary header should be duplicated in 
-        the headers of all subsequent extensions.  This function performs this addition in place to 
+        The INHERIT keyword indicated that keywords from the primary header should be duplicated in
+        the headers of all subsequent extensions.  This function performs this addition in place to
         the given HDUList.
-        
+
         Parameters
         ----------
         hdu_list : `~astropy.io.fits.HDUList`
             The hdu list to apply the INHERIT keyword to.
         """
         primary_header = hdu_list[0].header
-        reserved_kwds = {'COMMENT', 'SIMPLE', 'BITPIX', 'EXTEND', 'NEXTEND'}
+        reserved_kwds = {"COMMENT", "SIMPLE", "BITPIX", "EXTEND", "NEXTEND"}
 
         for hdu in hdu_list[1:]:
             header = hdu.header
-            if header.get('INHERIT', False):
+            if header.get("INHERIT", False):
                 for kwd, val in primary_header.items():
                     if (kwd not in header) and (kwd not in reserved_kwds):
                         header[kwd] = (val, primary_header.comments[kwd])
-    
+
     @abstractmethod
     def _cutout_file(self, file: Union[str, Path, S3Path]):
         """
@@ -254,8 +254,8 @@ class CubeCutout(Cutout, ABC):
 
         This method is abstract and should be defined in subclasses.
         """
-        raise NotImplementedError('Subclasses must implement this method.')
-    
+        raise NotImplementedError("Subclasses must implement this method.")
+
     def cutout(self):
         """
         Generate cutouts from a list of input cube files.
@@ -273,13 +273,13 @@ class CubeCutout(Cutout, ABC):
             self._cutout_file(file)
 
         if not self.cutouts_by_file:
-            raise InvalidQueryError('Cube cutout contains no data! (Check image footprint.)')
+            raise InvalidQueryError("Cube cutout contains no data! (Check image footprint.)")
 
         # Log total time elapsed
-        log.debug('Total time: %.2f sec', (monotonic() - start_time))
+        log.debug("Total time: %.2f sec", (monotonic() - start_time))
 
         return self.cutouts
-    
+
     class CubeCutoutInstance(ABC):
         """
         Represents an individual cutout with its own data, uncertainty, and aperture arrays.
@@ -317,32 +317,40 @@ class CubeCutout(Cutout, ABC):
             The input cube filename.
         """
 
-        def __init__(self, cube: fits.HDUList, file: Union[str, Path, S3Path], cube_wcs: WCS, 
-                     has_uncert: bool, parent: 'CubeCutout'):
+        def __init__(
+            self,
+            cube: fits.HDUList,
+            file: Union[str, Path, S3Path],
+            cube_wcs: WCS,
+            has_uncert: bool,
+            parent: "CubeCutout",
+        ):
             self._parent = parent
             self.cube_filename = file
             self.cube_wcs = cube_wcs
             self.wcs_fit = {
-                'WCS_MSEP': [None, '[deg] Max offset between cutout WCS and FFI WCS'],
-                'WCS_SIG': [None, '[deg] Error measurement of cutout WCS fit'],
+                "WCS_MSEP": [None, "[deg] Max offset between cutout WCS and FFI WCS"],
+                "WCS_SIG": [None, "[deg] Error measurement of cutout WCS fit"],
             }
 
             # Get cutout limits
             self.cutout_lims = self._parent._get_cutout_limits(cube_wcs)
 
             # Get cutout data
-            self.data, self.uncertainty, self.aperture = self._get_cutout_data(cube[1].section, 
-                                                                               self._parent._threads, has_uncert)
+            self.data, self.uncertainty, self.aperture = self._get_cutout_data(
+                cube[1].section, self._parent._threads, has_uncert
+            )
             self.shape = self.data.shape
-            
+
             # Get cutout WCS
             self.wcs = self._get_full_cutout_wcs(cube_wcs, cube[2].header)
 
             # Fit the cutout WCS
             self._fit_cutout_wcs(self.data.shape[1:])
 
-        def _get_cutout_data(self, transposed_cube: fits.ImageHDU.section, threads: int, 
-                             has_uncert: bool = True) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        def _get_cutout_data(
+            self, transposed_cube: fits.ImageHDU.section, threads: int, has_uncert: bool = True
+        ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
             """
             Extract a cutout from an image/uncertainty cube that has been transposed to have time on the longest axis.
 
@@ -362,7 +370,7 @@ class CubeCutout(Cutout, ABC):
             uncert_cutout : `numpy.array` or `None`
                 The untransposed uncertainty cutout array if `self._product` is 'SPOC'. Otherwise, returns `None`.
             aperture : `numpy.array`
-                The aperture array. This is a 2D array that is the same size as a single cutout that is 1 where 
+                The aperture array. This is a 2D array that is the same size as a single cutout that is 1 where
                 there is image data and 0 where there isn't.
             """
             # Compute cutout limits based on WCS
@@ -377,11 +385,11 @@ class CubeCutout(Cutout, ABC):
             xmin, padding[1, 0] = max(0, xmin), max(0, -xmin)
             ymin, padding[2, 0] = max(0, ymin), max(0, -ymin)
             xmax, padding[1, 1] = min(xmax, xmax_cube), max(0, xmax - xmax_cube)
-            ymax, padding[2, 1] = min(ymax, ymax_cube), max(0, ymax - ymax_cube)    
-            
+            ymax, padding[2, 1] = min(ymax, ymax_cube), max(0, ymax - ymax_cube)
+
             # Perform the cutout
-            if threads == 'auto' or threads > 1:
-                max_workers = None if threads == 'auto' else threads
+            if threads == "auto" or threads > 1:
+                max_workers = None if threads == "auto" else threads
                 with ThreadPoolExecutor(max_workers=max_workers) as pool:
                     # Increase download performance by making remote cutouts inside of a threadpool
                     # astropy.io.fits Section class executes a list comprehension, generating a sequence of http range
@@ -398,21 +406,21 @@ class CubeCutout(Cutout, ABC):
             # Extract image and uncertainty cutouts
             img_cutout = np.moveaxis(cutout[:, :, :, 0], 2, 0)
             uncert_cutout = np.moveaxis(cutout[:, :, :, 1], 2, 0) if has_uncert else None
-            
+
             # Create aperture mask
             aperture = np.ones((xmax - xmin, ymax - ymin), dtype=np.int32)
 
             # Apply padding if needed
             if padding.any():
-                img_cutout = np.pad(img_cutout, padding, 'constant', constant_values=self._parent._fill_value)
+                img_cutout = np.pad(img_cutout, padding, "constant", constant_values=self._parent._fill_value)
                 if has_uncert:
-                    uncert_cutout = np.pad(uncert_cutout, padding, 'constant', constant_values=self._parent._fill_value)
-                aperture = np.pad(aperture, padding[1:], 'constant', constant_values=0)
+                    uncert_cutout = np.pad(uncert_cutout, padding, "constant", constant_values=self._parent._fill_value)
+                aperture = np.pad(aperture, padding[1:], "constant", constant_values=0)
 
-            log.debug('Image cutout cube shape: %s', img_cutout.shape)
+            log.debug("Image cutout cube shape: %s", img_cutout.shape)
             if has_uncert:
-                log.debug('Uncertainty cutout cube shape: %s', uncert_cutout.shape)
-        
+                log.debug("Uncertainty cutout cube shape: %s", uncert_cutout.shape)
+
             return img_cutout, uncert_cutout, aperture
 
         @abstractmethod
@@ -422,20 +430,20 @@ class CubeCutout(Cutout, ABC):
 
             This method is abstract and should be defined in subclasses.
             """
-            raise NotImplementedError('Subclasses must implement this method.')
+            raise NotImplementedError("Subclasses must implement this method.")
 
         def _fit_cutout_wcs(self, cutout_shape: Tuple[int, int]) -> Tuple[float, float]:
             """
-            Given a full (including SIP coefficients) WCS for the cutout, 
+            Given a full (including SIP coefficients) WCS for the cutout,
             calculate the best fit linear WCS and a measure of the goodness-of-fit.
-            
+
             The new WCS is stored in ``self.wcs``.
             Goodness-of-fit measures are returned and stored in ``self.wcs_fit``.
 
             Parameters
             ----------
             cutout_wcs :  `~astropy.wcs.WCS`
-                The full (including SIP coefficients) cutout WCS object 
+                The full (including SIP coefficients) cutout WCS object
             cutout_shape : tuple
                 The shape of the cutout in the form (width, height).
 
@@ -466,7 +474,7 @@ class CubeCutout(Cutout, ABC):
             step_size = 1
             while (width / step_size) * (height / step_size) > 100:
                 step_size += 1
-                
+
             # Create evenly spaced pixel indices along the x and y axes
             xvals = np.arange(0, width, step_size).tolist()
             if xvals[-1] != width - 1:
@@ -475,27 +483,27 @@ class CubeCutout(Cutout, ABC):
             yvals = np.arange(0, height, step_size).tolist()
             if yvals[-1] != height - 1:
                 yvals.append(height - 1)
-            
+
             # Generate pixel coordinate pairs
             pix_inds = np.array(list(product(xvals, yvals)))
 
             # Convert pixel coordinates to world coordinates
-            world_pix = SkyCoord(self.wcs.all_pix2world(pix_inds, 0), unit='deg')
+            world_pix = SkyCoord(self.wcs.all_pix2world(pix_inds, 0), unit="deg")
 
             # Fit a linear WCS
-            linear_wcs = fit_wcs_from_points([pix_inds[:, 0], pix_inds[:, 1]], world_pix, proj_point='center')
+            linear_wcs = fit_wcs_from_points([pix_inds[:, 0], pix_inds[:, 1]], world_pix, proj_point="center")
             self.wcs = linear_wcs
 
             # Evaluate fit using all the pixels in the cutout
             full_pix_inds = np.array(list(product(range(width), range(height))))
-            world_pix_original = SkyCoord(self.wcs.all_pix2world(full_pix_inds, 0), unit='deg')
-            world_pix_fitted = SkyCoord(linear_wcs.all_pix2world(full_pix_inds, 0), unit='deg')
+            world_pix_original = SkyCoord(self.wcs.all_pix2world(full_pix_inds, 0), unit="deg")
+            world_pix_fitted = SkyCoord(linear_wcs.all_pix2world(full_pix_inds, 0), unit="deg")
 
             # Compute fit residuals
-            dists = world_pix_original.separation(world_pix_fitted).to('deg')
+            dists = world_pix_original.separation(world_pix_fitted).to("deg")
             max_dist = dists.max().value
             sigma = np.sqrt(np.sum(dists.value**2))
 
             # Store fit quality metrics
-            self.wcs_fit['WCS_MSEP'][0] = max_dist
-            self.wcs_fit['WCS_SIG'][0] = sigma
+            self.wcs_fit["WCS_MSEP"][0] = max_dist
+            self.wcs_fit["WCS_SIG"][0] = sigma

--- a/astrocut/cube_factory.py
+++ b/astrocut/cube_factory.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
 from copy import deepcopy
 from datetime import date
 from pathlib import Path
 from time import monotonic
 from typing import List, Optional, Union
-import warnings
 
 import numpy as np
 from astropy.io import fits
@@ -15,6 +15,7 @@ from astropy.table import Column, Table
 # May fail on older Python versions or on Windows
 try:
     from mmap import MADV_SEQUENTIAL
+
     mmap_imported = True
 except ImportError:
     mmap_imported = False
@@ -24,7 +25,7 @@ from .exceptions import DataWarning, InvalidInputError
 from .utils.utils import _handle_verbose
 
 
-class CubeFactory():
+class CubeFactory:
     """
     Class for creating image cubes. This class is built to accept TESS SPOC FFI files,
     but can be extended to work with other types of image files.
@@ -35,7 +36,7 @@ class CubeFactory():
         The maximum amount of memory to make available for building the data cube in GB.
         Note, this is the maximum amount of space to be used for the cube array only,
         so should not be set to the full amount of memory on the system.
-    
+
     Methods
     -------
     make_cube(file_list, cube_file, sector, max_memory, verbose)
@@ -44,27 +45,28 @@ class CubeFactory():
         Updates an existing cube file with new FITS images.
     """
 
-    ERROR_MSG = ('One or more incorrect file types were input. Please input only SPOC FFI files when '
-                 'using ``CubeFactory``.')
+    ERROR_MSG = (
+        "One or more incorrect file types were input. Please input only SPOC FFI files when " "using ``CubeFactory``."
+    )
 
     def __init__(self, max_memory: int = 50):
-        """ Setting up the class members """
+        """Setting up the class members"""
 
         self._max_memory = max_memory  # in GB
         self._block_size = None  # Number of rows
         self._num_blocks = None
         self._cube_shape = None
-        
-        self._time_keyword = 'TSTART'  # TESS-specific
-        self._last_file_keywords = ['DATE-END', 'TSTOP']  # TESS-specific (assumed to be in extension 1)
-        self._image_header_keywords = ['CAMERA', 'CCD']  # TESS-specific
-        self._template_requirements = {'WCSAXES': 2}  # TESS-specific (assumed to be in extension 1)
-        self._file_keyword = 'FFI_FILE'  # TESS-specific, used to build the info table
-        self._keywords_in_use = ['XTENSION', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2', 'PCOUNT', 'GCOUNT', 'TFIELDS']
+
+        self._time_keyword = "TSTART"  # TESS-specific
+        self._last_file_keywords = ["DATE-END", "TSTOP"]  # TESS-specific (assumed to be in extension 1)
+        self._image_header_keywords = ["CAMERA", "CCD"]  # TESS-specific
+        self._template_requirements = {"WCSAXES": 2}  # TESS-specific (assumed to be in extension 1)
+        self._file_keyword = "FFI_FILE"  # TESS-specific, used to build the info table
+        self._keywords_in_use = ["XTENSION", "BITPIX", "NAXIS", "NAXIS1", "NAXIS2", "PCOUNT", "GCOUNT", "TFIELDS"]
 
         self._file_list = None
         self._template_file = None
-        
+
         self._primary_header = None
         self._info_table = None
         self._cube_file = None
@@ -72,7 +74,7 @@ class CubeFactory():
         # Number of axes in the first dimension of image data, SPOC has both data and error values
         self._naxis1 = 2
 
-        # Used when updating an existing cube 
+        # Used when updating an existing cube
         self._old_cols = None
         self._update = False
         self._cube_append = None
@@ -101,7 +103,7 @@ class CubeFactory():
         except IndexError:
             # If image does not have a second extension, raise an error
             raise ValueError(self.ERROR_MSG)
-        
+
     def _get_img_shape(self, img_data: fits.HDUList) -> tuple:
         """
         Get the shape of the image data.
@@ -119,7 +121,7 @@ class CubeFactory():
         return img_data[self._img_ext].data.shape
 
     def _configure_cube(self, file_list: List[str], **extra_keywords: dict):
-        """ 
+        """
         Iterate through the input files and set up the basic parameters and primary header for the data cube.
 
         Parameters
@@ -134,26 +136,28 @@ class CubeFactory():
         ValueError
             If any of the input files are not in the expected format.
         """
-        
+
         file_list = np.array(file_list)
         image_shape = None
         start_times = np.zeros(len(file_list))
 
         # Iterate through files
         for i, image in enumerate(file_list):
-            with fits.open(image, mode='denywrite', memmap=True) as img_data:
+            with fits.open(image, mode="denywrite", memmap=True) as img_data:
                 # Add the image start time to array
                 start_times[i] = self._get_img_start_time(img_data)
 
                 if image_shape is None:  # Only need to fill this once
                     image_shape = self._get_img_shape(img_data)
-                
+
                 if self._template_file is None:  # Only check for template if one doesn't exist
                     # Template file must match the template requirements
-                    if all(img_data[self._img_ext].header.get(key) == value for key, value 
-                           in self._template_requirements.items()):
+                    if all(
+                        img_data[self._img_ext].header.get(key) == value
+                        for key, value in self._template_requirements.items()
+                    ):
                         self._template_file = image
-                
+
         # Sort the files by start time
         self._file_list = file_list[np.argsort(start_times)]
 
@@ -170,19 +174,21 @@ class CubeFactory():
             self._cube_shape = (image_shape[0], image_shape[1], len(self._file_list), self._naxis1)
 
             # Set up the primary header with earliest file
-            with fits.open(self._file_list[0], mode='denywrite', memmap=True) as first_file:
+            with fits.open(self._file_list[0], mode="denywrite", memmap=True) as first_file:
                 # Make a copy of the header and remove the checksum
                 header = deepcopy(first_file[0].header)
-                header.remove('CHECKSUM', ignore_missing=True)
+                header.remove("CHECKSUM", ignore_missing=True)
 
                 # Adding standard keywords
-                header['ORIGIN'] = 'STScI/MAST'
-                header['DATE'] = str(date.today())
+                header["ORIGIN"] = "STScI/MAST"
+                header["DATE"] = str(date.today())
 
                 # Adding factory specific keywords
                 for kwd in self._image_header_keywords:
-                    header[kwd] = (first_file[self._img_ext].header[kwd], 
-                                   first_file[self._img_ext].header.comments[kwd])
+                    header[kwd] = (
+                        first_file[self._img_ext].header[kwd],
+                        first_file[self._img_ext].header.comments[kwd],
+                    )
 
                 # Adding the extra keywords passed in
                 for kwd, value in extra_keywords.items():
@@ -192,28 +198,26 @@ class CubeFactory():
             self._cube_shape = self._cube_append.shape
 
             # Update the primary header with new history
-            with fits.open(self._cube_file, mode='update', memmap=True) as cube_hdu:
+            with fits.open(self._cube_file, mode="update", memmap=True) as cube_hdu:
                 header = cube_hdu[0].header
-                header['HISTORY'] = f'Updated on {str(date.today())} with new image delivery.'             
-                header['HISTORY'] = f'First image is {Path(self._file_list[0]).name}.'
-                
+                header["HISTORY"] = f"Updated on {str(date.today())} with new image delivery."
+                header["HISTORY"] = f"First image is {Path(self._file_list[0]).name}."
+
         # Adding the keywords from the last file
-        with fits.open(self._file_list[-1], mode='denywrite', memmap=True) as last_file:
+        with fits.open(self._file_list[-1], mode="denywrite", memmap=True) as last_file:
             for kwd in self._last_file_keywords:
                 header[kwd] = (last_file[self._img_ext].header[kwd], last_file[self._img_ext].header.comments[kwd])
 
         # Set extension name
-        header['EXTNAME'] = 'PRIMARY'
+        header["EXTNAME"] = "PRIMARY"
 
         self._primary_header = header
-
 
     def _build_info_table(self):
         """
         Read the keywords and set up the table to hold the image headers from every input file.
         """
-        with fits.open(self._template_file, mode='denywrite', memmap=True) as template_data:
-            
+        with fits.open(self._template_file, mode="denywrite", memmap=True) as template_data:
             # The image specific header information will be saved in a table in the image extension
             img_header = template_data[self._img_ext].header
 
@@ -224,7 +228,7 @@ class CubeFactory():
             for kwd, val, cmt in img_header.cards:
                 # Determine column type
                 if isinstance(val, str):
-                    tpe = 'S' + str(len(val))  # TODO: Maybe switch to U?
+                    tpe = "S" + str(len(val))  # TODO: Maybe switch to U?
                 elif isinstance(val, int):
                     tpe = np.int32
                 else:
@@ -233,16 +237,14 @@ class CubeFactory():
                 # Add column if it doesn't already exist
                 if kwd not in existing_cols:
                     existing_cols.append(kwd)
-                    cols.append(Column(name=kwd, dtype=tpe, length=length, meta={'comment': cmt}))
-                    
+                    cols.append(Column(name=kwd, dtype=tpe, length=length, meta={"comment": cmt}))
+
             # Adding a column for the input file names
-            cols.append(Column(name=self._file_keyword,
-                               dtype=f'S{len(Path(self._template_file).name)}',
-                               length=length))
-            
+            cols.append(Column(name=self._file_keyword, dtype=f"S{len(Path(self._template_file).name)}", length=length))
+
             # Build Table from columns
             self._info_table = Table(cols)
-        
+
     def _build_cube_file(self, cube_file: str):
         """
         Build the cube file on disk with the primary header, cube extension header,
@@ -252,8 +254,8 @@ class CubeFactory():
 
         Parameters
         ----------
-        cube_file : str 
-            The filename/path to save the output cube in. 
+        cube_file : str
+            The filename/path to save the output cube in.
         """
         # Ensure that the output directory exists
         dir = Path(cube_file).parent
@@ -261,19 +263,19 @@ class CubeFactory():
             dir.mkdir(parents=True)
 
         # Write the primary header
-        hdu0 = fits.PrimaryHDU(header=self._primary_header)            
-        hdul = fits.HDUList([hdu0])            
+        hdu0 = fits.PrimaryHDU(header=self._primary_header)
+        hdul = fits.HDUList([hdu0])
         hdul.writeto(cube_file, overwrite=True)
 
         # Make the cube header and write it
         data = np.zeros((100, 100, 10, 2), dtype=np.float32)
         hdu = fits.ImageHDU(data)
         header = hdu.header
-        header['NAXIS4'], header['NAXIS3'], header['NAXIS2'], header['NAXIS1'] = self._cube_shape
+        header["NAXIS4"], header["NAXIS3"], header["NAXIS2"], header["NAXIS1"] = self._cube_shape
 
         # Write the header into the cube as an array of bytes
-        with open(cube_file, 'ab') as CUBE:
-            CUBE.write(bytearray(header.tostring(), encoding='utf-8'))
+        with open(cube_file, "ab") as CUBE:
+            CUBE.write(bytearray(header.tostring(), encoding="utf-8"))
 
         # Expand the file to fit the full data cube
         # FITS requires all blocks to be a multiple of 2880
@@ -281,9 +283,9 @@ class CubeFactory():
         file_len = Path(cube_file).stat().st_size
 
         # Seek to end of file and write null byte
-        with open(cube_file, 'r+b') as CUBE:
+        with open(cube_file, "r+b") as CUBE:
             CUBE.seek(file_len + cubesize_in_bytes - 1)
-            CUBE.write(b'\0')
+            CUBE.write(b"\0")
 
         self._cube_file = cube_file
 
@@ -327,8 +329,9 @@ class CubeFactory():
         """
         return img_data[1].header.get(kwd, nulval)
 
-    def _write_block(self, cube_hdu: fits.HDUList, start_row: int = 0, end_row: Optional[int] = None, 
-                     fill_info_table: bool = False):
+    def _write_block(
+        self, cube_hdu: fits.HDUList, start_row: int = 0, end_row: Optional[int] = None, fill_info_table: bool = False
+    ):
         """
         Write a block of the cube with data from input images.
 
@@ -346,14 +349,14 @@ class CubeFactory():
         # Initializing the sub-cube
         nrows = (self._cube_shape[0] - start_row) if (end_row is None) else (end_row - start_row)
         sub_cube = np.zeros((nrows, *self._cube_shape[1:]), dtype=np.float32)
-        
+
         # Loop through input files
         for i, fle in enumerate(self._file_list):
             st = monotonic()
-            with fits.open(fle, mode='denywrite', memmap=True) as img_data:
+            with fits.open(fle, mode="denywrite", memmap=True) as img_data:
                 # Write data from input image to sub-cube
                 self._write_to_sub_cube(sub_cube, i, img_data, start_row, end_row)
-                
+
                 if fill_info_table:  # Also save the header info in the info table
                     # Iterate over every keyword in the primary header
                     for kwd in self._info_table.columns:
@@ -363,14 +366,14 @@ class CubeFactory():
                         else:
                             # Determine null value based on dtype
                             nulval = None
-                            if self._info_table[kwd].dtype.name == 'int32':
+                            if self._info_table[kwd].dtype.name == "int32":
                                 nulval = 0
-                            elif self._info_table[kwd].dtype.char == 'S':  # hacky way to check if it's a string
-                                nulval = ''
+                            elif self._info_table[kwd].dtype.char == "S":  # hacky way to check if it's a string
+                                nulval = ""
                             # Assign the keyword value from the image header
                             self._info_table[kwd][i] = self._get_header_keyword(kwd, img_data, nulval)
 
-            log.debug('Completed file %d in %.3f sec.', i, monotonic() - st)
+            log.debug("Completed file %d in %.3f sec.", i, monotonic() - st)
 
         # Fill block and flush to disk
         if not self._update:
@@ -395,15 +398,15 @@ class CubeFactory():
         for kwd in self._info_table.columns:
             # Determine column type
             if self._info_table[kwd].dtype == np.float64:
-                tpe = 'D'
+                tpe = "D"
             elif self._info_table[kwd].dtype == np.int32:
-                tpe = 'J'
+                tpe = "J"
             else:
-                tpe = str(self._info_table[kwd].dtype).replace('S', 'A').strip('|')
+                tpe = str(self._info_table[kwd].dtype).replace("S", "A").strip("|")
 
             # Create Column object and add to array
             cols.append(fits.Column(name=kwd, format=tpe, array=self._info_table[kwd]))
-        
+
         # Create the table HDU
         col_def = fits.ColDefs(cols)
         table_hdu = fits.BinTableHDU.from_columns(col_def)
@@ -412,26 +415,26 @@ class CubeFactory():
         for kwd in self._info_table.columns:
             if kwd in self._keywords_in_use:
                 continue  # skipping the keyword already in use
-            table_hdu.header[kwd] = self._info_table[kwd].meta.get('comment', '')
+            table_hdu.header[kwd] = self._info_table[kwd].meta.get("comment", "")
 
         # Append to the cube file
-        with fits.open(self._cube_file, mode='update', memmap=True) as cube_hdus:
+        with fits.open(self._cube_file, mode="update", memmap=True) as cube_hdus:
             if self._update:
-                # If we're updating the cube, get rid of the existing table 
-                # so we can replace it with the new one. 
+                # If we're updating the cube, get rid of the existing table
+                # so we can replace it with the new one.
                 cube_hdus.pop(index=2)
             cube_hdus.append(table_hdu)
 
     def _update_info_table(self):
-        """ 
+        """
         Update an existing info table with rows from a newly created info table.
         """
         # Extract header information from the template file
-        with fits.open(self._template_file, mode='denywrite', memmap=True) as template_data:
+        with fits.open(self._template_file, mode="denywrite", memmap=True) as template_data:
             img_header = template_data[self._img_ext].header
 
         # Open the existing cube file to extract the original table
-        with fits.open(self._cube_file, mode='readonly') as hdul:
+        with fits.open(self._cube_file, mode="readonly") as hdul:
             original_table = hdul[2].data
 
         # Prepare columns for the updated table
@@ -439,7 +442,7 @@ class CubeFactory():
         for kwd, val, cmt in img_header.cards:
             # Determine dtype
             if isinstance(val, str):
-                dtype = f'S{len(val)}'  # Using `S` type for binary FITS tables
+                dtype = f"S{len(val)}"  # Using `S` type for binary FITS tables
             elif isinstance(val, int):
                 dtype = np.int32
             else:
@@ -447,21 +450,27 @@ class CubeFactory():
 
             # Append new data to the existing column
             updated_column = np.concatenate((original_table[kwd], self._info_table[kwd]))
-            cols.append(Column(updated_column, name=kwd, dtype=dtype, meta={'comment': cmt}))
+            cols.append(Column(updated_column, name=kwd, dtype=dtype, meta={"comment": cmt}))
 
         # Handle file column separately
         file_updated_column = np.concatenate((original_table[self._file_keyword], self._info_table[self._file_keyword]))
         str_length = len(Path(self._template_file).name)
-        cols.append(Column(file_updated_column, name=self._file_keyword, dtype=f'S{str_length}'))
+        cols.append(Column(file_updated_column, name=self._file_keyword, dtype=f"S{str_length}"))
 
         # Create the updated info table
         self._info_table = Table(cols)
 
-    def make_cube(self, file_list: List[str], cube_file: str = 'img-cube.fits', sector: Optional[int] = None, 
-                  max_memory: int = 50, verbose: bool = True):
+    def make_cube(
+        self,
+        file_list: List[str],
+        cube_file: str = "img-cube.fits",
+        sector: Optional[int] = None,
+        max_memory: int = 50,
+        verbose: bool = True,
+    ):
         """
-        Turns a list of FITS image files into one large data cube. Input images must all have the same 
-        footprint and resolution. The resulting data cube is transposed for quicker cutouts. This function 
+        Turns a list of FITS image files into one large data cube. Input images must all have the same
+        footprint and resolution. The resulting data cube is transposed for quicker cutouts. This function
         can take some time to run, exactly how much time will depend on the number
         of input files and the maximum allowed memory. The runtime will be fastest if the
         entire data cube can be held in memory, however that can be quite large (~40GB for a full
@@ -472,7 +481,7 @@ class CubeFactory():
         file_list : array
             The list of FITS image files to cube.
         cube_file : str
-            Optional.  The filename/path to save the output cube in. 
+            Optional.  The filename/path to save the output cube in.
         sector : int
             Optional.  TESS sector to add as header keyword (not present in FFI files).
         max_memory : float
@@ -480,12 +489,12 @@ class CubeFactory():
             the data cube in GB. Note, this is the maximum amount of space to be used for the cube
             array only, so should not be set to the full amount of memory on the system.
         verbose : bool
-            Optional. If True, intermediate information is printed. 
+            Optional. If True, intermediate information is printed.
 
         Returns
         -------
         response: string or None
-            If successful, returns the path to the cube FITS file, 
+            If successful, returns the path to the cube FITS file,
             if unsuccessful returns None.
         """
         # Log messages based on verbosity
@@ -496,29 +505,29 @@ class CubeFactory():
         self._update = False
 
         # Set up the basic cube parameters
-        sector = (sector, 'Observing sector')
+        sector = (sector, "Observing sector")
 
         # Configure the cube and set up the primary header
         self._configure_cube(file_list, sector=sector)
-    
-        log.debug('Using %s to initialize the image header table.', Path(self._template_file).name)
-        log.debug('Cube will be made in %d blocks of %d rows each.', self._num_blocks, self._block_size)
+
+        log.debug("Using %s to initialize the image header table.", Path(self._template_file).name)
+        log.debug("Cube will be made in %d blocks of %d rows each.", self._num_blocks, self._block_size)
 
         # Set up the table to hold the individual image headers
         self._build_info_table()
-        
+
         # Write the empty file, ready for the cube to be added
         self._build_cube_file(cube_file)
 
         # Fill the image cube
-        with fits.open(self._cube_file, mode='update', memmap=True) as cube_hdu:
-            # mmap: "allows you to take advantage of lower-level operating system 
-            # functionality to read files as if they were one large string or array. 
-            # This can provide significant performance improvements in code that 
+        with fits.open(self._cube_file, mode="update", memmap=True) as cube_hdu:
+            # mmap: "allows you to take advantage of lower-level operating system
+            # functionality to read files as if they were one large string or array.
+            # This can provide significant performance improvements in code that
             # requires a lot of file I/O."
             if mmap_imported:
                 mm = fits.util._get_array_mmap(cube_hdu[1].data)
-                # madvise: "Send advice option to the kernel about the memory region 
+                # madvise: "Send advice option to the kernel about the memory region
                 # beginning at start and extending length bytes."
                 mm.madvise(MADV_SEQUENTIAL)
 
@@ -531,19 +540,25 @@ class CubeFactory():
 
                 fill_info_table = True if (i == 0) else False
                 self._write_block(cube_hdu, start_row, end_row, fill_info_table)
-                  
-                log.debug('Completed block %d of %d', i + 1, self._num_blocks)
+
+                log.debug("Completed block %d of %d", i + 1, self._num_blocks)
 
         # Add the info table to the cube file
         self._write_info_table()
-        log.debug('Total time elapsed: %.2f min', (monotonic() - start_time) / 60)
+        log.debug("Total time elapsed: %.2f min", (monotonic() - start_time) / 60)
 
         return self._cube_file
-    
-    def update_cube(self, file_list: List[str], cube_file: str, sector: Optional[int] = None, max_memory: int = 50,
-                    verbose: bool = True):
-        """ 
-        Updates an existing cube file with new FITS images. Same functionality as `CutoutFactory.make_cube`, 
+
+    def update_cube(
+        self,
+        file_list: List[str],
+        cube_file: str,
+        sector: Optional[int] = None,
+        max_memory: int = 50,
+        verbose: bool = True,
+    ):
+        """
+        Updates an existing cube file with new FITS images. Same functionality as `CutoutFactory.make_cube`,
         but working on an already existing file rather than building a new one. This function will:
 
         1. Create a new cube consisting of the new images that will be appended to the existing cube
@@ -563,12 +578,12 @@ class CubeFactory():
             the data cube in GB. Note, this is the maximum amount of space to be used for the cube
             array only, so should not be set to the full amount of memory on the system.
         verbose : bool
-            Optional. If True, intermediate information is printed.  
+            Optional. If True, intermediate information is printed.
 
         Returns
         -------
         response: string or None
-            If successful, returns the path to the updated cube FITS file, 
+            If successful, returns the path to the updated cube FITS file,
             if unsuccessful returns None.
         """
         # Log messages based on verbosity
@@ -580,10 +595,11 @@ class CubeFactory():
         # If the cube file is not found, raise an error
         cube_path = Path(cube_file)
         if not cube_path.exists():
-            raise InvalidInputError('Cube file was not found at the location provided. Please ensure the '
-                                    'correct path was provided.')
+            raise InvalidInputError(
+                "Cube file was not found at the location provided. Please ensure the " "correct path was provided."
+            )
         self._cube_file = cube_file
-        log.debug('Updating cube file: %s', cube_file)
+        log.debug("Updating cube file: %s", cube_file)
 
         # Extract existing image filenames from the cube to prevent duplicates
         existing_files = set(fits.getdata(self._cube_file, 2)[self._file_keyword])
@@ -592,14 +608,14 @@ class CubeFactory():
         # Warn about and remove duplicates
         removed_files = set(file_list) - set(filtered_file_list)
         for file in removed_files:
-            warnings.warn(f'Removed duplicate file: {Path(file).name}', DataWarning)
+            warnings.warn(f"Removed duplicate file: {Path(file).name}", DataWarning)
 
         # If no new images are found, raise an error
         if not filtered_file_list:
-            raise InvalidInputError('No new images were found in the provided file list.')
+            raise InvalidInputError("No new images were found in the provided file list.")
 
-        log.debug('%d new images found!', len(filtered_file_list))
-        
+        log.debug("%d new images found!", len(filtered_file_list))
+
         # Creating an empty cube that will be appended to the existing cube
         original_cube = fits.getdata(cube_file, 1)
         new_cube_shape = list(original_cube.shape)
@@ -607,21 +623,21 @@ class CubeFactory():
         self._cube_append = np.zeros(new_cube_shape)
 
         # Set up the basic cube parameters
-        self._configure_cube(filtered_file_list, sector=(sector, 'Observing sector'))
-        log.debug('Images will be appended in %d blocks of %d rows each.', self._num_blocks, self._block_size)
-        
+        self._configure_cube(filtered_file_list, sector=(sector, "Observing sector"))
+        log.debug("Images will be appended in %d blocks of %d rows each.", self._num_blocks, self._block_size)
+
         # Starting a new info table from scratch with new rows
         self._build_info_table()
 
-        # Update the image cube 
-        with fits.open(self._cube_file, mode='update', memmap=True) as cube_hdu:
-            # mmap: "allows you to take advantage of lower-level operating system 
-            # functionality to read files as if they were one large string or array. 
-            # This can provide significant performance improvements in code that 
+        # Update the image cube
+        with fits.open(self._cube_file, mode="update", memmap=True) as cube_hdu:
+            # mmap: "allows you to take advantage of lower-level operating system
+            # functionality to read files as if they were one large string or array.
+            # This can provide significant performance improvements in code that
             # requires a lot of file I/O."
             if mmap_imported:
                 mm = fits.util._get_array_mmap(cube_hdu[1].data)
-                # madvise: "Send advice option to the kernel about the memory region 
+                # madvise: "Send advice option to the kernel about the memory region
                 # beginning at start and extending length bytes."
                 mm.madvise(MADV_SEQUENTIAL)
 
@@ -636,21 +652,21 @@ class CubeFactory():
                 # Filling in the cube file with data from new images
                 # The info table also gets updated here
                 self._write_block(cube_hdu, start_row, end_row, fill_info_table=True)
-                log.debug('Completed block %d of %d', i + 1, self._num_blocks)
-       
+                log.debug("Completed block %d of %d", i + 1, self._num_blocks)
+
         # Append the new cube to the existing cube
         new_cube = np.concatenate((original_cube, self._cube_append), axis=2)
 
         # Replace cube data in FITS file
-        with fits.open(self._cube_file, mode='update') as hdul:
-            log.debug('Original cube of size: %s', original_cube.shape)
-            log.debug('will now be replaced with cube of size: %s', new_cube.shape)
-            log.debug('for file ``%s``', cube_file)
+        with fits.open(self._cube_file, mode="update") as hdul:
+            log.debug("Original cube of size: %s", original_cube.shape)
+            log.debug("will now be replaced with cube of size: %s", new_cube.shape)
+            log.debug("for file ``%s``", cube_file)
             hdul[1].data = new_cube
 
         # Update and write the info table
         self._update_info_table()
         self._write_info_table()
-        log.debug('Total time elapsed: %.2f min', (monotonic() - start_time) / 60)
+        log.debug("Total time elapsed: %.2f min", (monotonic() - start_time) / 60)
 
         return self._cube_file

--- a/astrocut/cube_factory.py
+++ b/astrocut/cube_factory.py
@@ -46,7 +46,7 @@ class CubeFactory:
     """
 
     ERROR_MSG = (
-        "One or more incorrect file types were input. Please input only SPOC FFI files when " "using ``CubeFactory``."
+        "One or more incorrect file types were input. Please input only SPOC FFI files when using ``CubeFactory``."
     )
 
     def __init__(self, max_memory: int = 50):
@@ -596,7 +596,7 @@ class CubeFactory:
         cube_path = Path(cube_file)
         if not cube_path.exists():
             raise InvalidInputError(
-                "Cube file was not found at the location provided. Please ensure the " "correct path was provided."
+                "Cube file was not found at the location provided. Please ensure the correct path was provided."
             )
         self._cube_file = cube_file
         log.debug("Updating cube file: %s", cube_file)

--- a/astrocut/cutout_factory.py
+++ b/astrocut/cutout_factory.py
@@ -3,7 +3,7 @@
 """This module implements the cutout functionality."""
 
 from pathlib import Path
-from typing import Literal, Optional, Union, List, Tuple
+from typing import List, Literal, Optional, Tuple, Union
 
 import astropy.units as u
 import numpy as np
@@ -14,26 +14,38 @@ from s3path import S3Path
 from .tess_cube_cutout import TessCubeCutout
 
 
-class CutoutFactory():
+class CutoutFactory:
     """
     Class for creating image cutouts from TESS image cube files.
 
-    This class encompasses all of the cutout functionality.  
-    In the current version, this means creating cutout target pixel files from 
+    This class encompasses all of the cutout functionality.
+    In the current version, this means creating cutout target pixel files from
     TESS full frame images cubes.
 
     This class is maintained for backwards compatibility. For maximum flexibility, we recommend using the
     `~astrocut.TessCubeCutout` class.
     """
 
-    @deprecated_renamed_argument('product', None, since='1.1.0', message='The `product` argument is deprecated and '
-                                 'will be removed in a future version. Astrocut will only support cutouts from '
-                                 'SPOC products.')
-    def cube_cut(self, cube_file: Union[str, Path, S3Path], coordinates: Union[SkyCoord, str],
-                 cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]], 
-                 product: str = 'SPOC', target_pixel_file: Optional[str] = None, 
-                 output_path: Union[str, Path] = '.', memory_only: bool = False, 
-                 threads: Union[int, Literal["auto"]] = 1, verbose: bool = False):
+    @deprecated_renamed_argument(
+        "product",
+        None,
+        since="1.1.0",
+        message="The `product` argument is deprecated and "
+        "will be removed in a future version. Astrocut will only support cutouts from "
+        "SPOC products.",
+    )
+    def cube_cut(
+        self,
+        cube_file: Union[str, Path, S3Path],
+        coordinates: Union[SkyCoord, str],
+        cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]],
+        product: str = "SPOC",
+        target_pixel_file: Optional[str] = None,
+        output_path: Union[str, Path] = ".",
+        memory_only: bool = False,
+        threads: Union[int, Literal["auto"]] = 1,
+        verbose: bool = False,
+    ):
         """
         Takes a cube file (as created by `~astrocut.CubeFactory`), and makes a cutout target pixel
         file of the given size around the given coordinates. The target pixel file is formatted like
@@ -87,34 +99,46 @@ class CutoutFactory():
             or the path to the target pixel file if saved to disk.
             If unsuccessful returns None.
         """
-        cube_cutout = TessCubeCutout(input_files=cube_file,
-                                     coordinates=coordinates,
-                                     cutout_size=cutout_size,
-                                     product=product,
-                                     threads=threads,
-                                     verbose=verbose)
-        
+        cube_cutout = TessCubeCutout(
+            input_files=cube_file,
+            coordinates=coordinates,
+            cutout_size=cutout_size,
+            product=product,
+            threads=threads,
+            verbose=verbose,
+        )
+
         # Assign these attributes to be backwards compatible
         cutout_obj = cube_cutout.cutouts_by_file[cube_file]
         self.cube_wcs = cutout_obj.cube_wcs
         self.center_coord = cube_cutout._coordinates
         self.cutout_lims = cutout_obj.cutout_lims
         self.cutout_wcs = cutout_obj.wcs
-        
+
         if memory_only:
             return cube_cutout.tpf_cutouts[0]
-        
-        return cube_cutout.write_as_tpf(output_dir=output_path, 
-                                        output_file=target_pixel_file)[0]
-    
 
-@deprecated_renamed_argument('product', None, since='1.1.0', message='The `product` argument is deprecated and will be '
-                             'removed in a future version. Astrocut will only support cutouts from SPOC products.')
-def cube_cut(cube_file: Union[str, Path, S3Path], coordinates: Union[SkyCoord, str],
-             cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]], 
-             product: str = 'SPOC', target_pixel_file: Optional[str] = None, 
-             output_path: Union[str, Path] = '.', memory_only: bool = False, 
-             threads: Union[int, Literal["auto"]] = 1, verbose: bool = False):
+        return cube_cutout.write_as_tpf(output_dir=output_path, output_file=target_pixel_file)[0]
+
+
+@deprecated_renamed_argument(
+    "product",
+    None,
+    since="1.1.0",
+    message="The `product` argument is deprecated and will be "
+    "removed in a future version. Astrocut will only support cutouts from SPOC products.",
+)
+def cube_cut(
+    cube_file: Union[str, Path, S3Path],
+    coordinates: Union[SkyCoord, str],
+    cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]],
+    product: str = "SPOC",
+    target_pixel_file: Optional[str] = None,
+    output_path: Union[str, Path] = ".",
+    memory_only: bool = False,
+    threads: Union[int, Literal["auto"]] = 1,
+    verbose: bool = False,
+):
     """
     Takes a cube file (as created by `~astrocut.CubeFactory`), and makes a cutout target pixel
     file of the given size around the given coordinates. The target pixel file is formatted like
@@ -168,15 +192,16 @@ def cube_cut(cube_file: Union[str, Path, S3Path], coordinates: Union[SkyCoord, s
         or the path to the target pixel file if saved to disk.
         If unsuccessful, returns None.
     """
-    cube_cutout = TessCubeCutout(input_files=cube_file,
-                                 coordinates=coordinates,
-                                 cutout_size=cutout_size,
-                                 product=product,
-                                 threads=threads,
-                                 verbose=verbose)
-            
+    cube_cutout = TessCubeCutout(
+        input_files=cube_file,
+        coordinates=coordinates,
+        cutout_size=cutout_size,
+        product=product,
+        threads=threads,
+        verbose=verbose,
+    )
+
     if memory_only:
         return cube_cutout.tpf_cutouts[0]
-    
-    return cube_cutout.write_as_tpf(output_dir=output_path, 
-                                    output_file=target_pixel_file)[0]
+
+    return cube_cutout.write_as_tpf(output_dir=output_path, output_file=target_pixel_file)[0]

--- a/astrocut/cutout_processing.py
+++ b/astrocut/cutout_processing.py
@@ -59,9 +59,9 @@ def _combine_headers(headers, constant_only=False):
 
             n_vk += 1
             for i, hdr in enumerate(headers):
-                varying_keywords.append((f"F{i+1:02}_K{n_vk:02}", kwd, "Keyword"))
-                varying_keywords.append((f"F{i+1:02}_V{n_vk:02}", hdr[kwd], "Value"))
-                varying_keywords.append((f"F{i+1:02}_C{n_vk:02}", hdr.comments[kwd], "Comment"))
+                varying_keywords.append((f"F{i + 1:02}_K{n_vk:02}", kwd, "Keyword"))
+                varying_keywords.append((f"F{i + 1:02}_V{n_vk:02}", hdr[kwd], "Value"))
+                varying_keywords.append((f"F{i + 1:02}_C{n_vk:02}", hdr.comments[kwd], "Comment"))
 
     # TODO: Add wcs checking? How?
     return fits.Header(uniform_cards + varying_keywords)
@@ -429,7 +429,7 @@ def center_on_path(
     if not target_pixel_file:
         target = "path" if not target else target
         target_pixel_file = (
-            f"{target}_{primary_header['TSTART']}-{primary_header['TSTop']}_" f"{size[0]}-x-{size[1]}_astrocut.fits"
+            f"{target}_{primary_header['TSTART']}-{primary_header['TSTop']}_{size[0]}-x-{size[1]}_astrocut.fits"
         )
 
     # Replace any slashes/spaces for filename conventions

--- a/astrocut/cutout_processing.py
+++ b/astrocut/cutout_processing.py
@@ -2,21 +2,20 @@
 
 """This module contains various cutout post-processing tools."""
 
-import numpy as np
-import warnings
 import os
+import warnings
 
-from astropy.io import fits
+import numpy as np
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from astropy.table import Table, vstack
-from astropy.wcs import WCS
 from astropy.time import Time
-
-from scipy.interpolate import splprep, splev
+from astropy.wcs import WCS
+from scipy.interpolate import splev, splprep
 
 from . import log
-from .utils.utils import get_fits, _handle_verbose
 from .exceptions import DataWarning, InvalidInputError
+from .utils.utils import _handle_verbose, get_fits
 
 
 def _combine_headers(headers, constant_only=False):
@@ -42,23 +41,22 @@ def _combine_headers(headers, constant_only=False):
     # Allowing the function to gracefully handle being given a single header
     if len(headers) == 1:
         return headers[0]
-    
+
     uniform_cards = []
     varying_keywords = []
     n_vk = 0
-    
+
     for kwd in headers[0]:
-        
         # Skip checksums etc
-        if kwd in ('S_REGION', 'CHECKSUM', 'DATASUM'):
+        if kwd in ("S_REGION", "CHECKSUM", "DATASUM"):
             continue
-        
+
         if (np.array([x[kwd] for x in headers[1:]]) == headers[0][kwd]).all():
             uniform_cards.append(headers[0].cards[kwd])
         else:
             if constant_only:  # Removing non-constant kewords in this case
                 continue
- 
+
             n_vk += 1
             for i, hdr in enumerate(headers):
                 varying_keywords.append((f"F{i+1:02}_K{n_vk:02}", kwd, "Keyword"))
@@ -66,7 +64,7 @@ def _combine_headers(headers, constant_only=False):
                 varying_keywords.append((f"F{i+1:02}_C{n_vk:02}", hdr.comments[kwd], "Comment"))
 
     # TODO: Add wcs checking? How?
-    return fits.Header(uniform_cards+varying_keywords)
+    return fits.Header(uniform_cards + varying_keywords)
 
 
 def _get_bounds(x, y, size):
@@ -77,11 +75,12 @@ def _get_bounds(x, y, size):
     x = np.array(np.atleast_1d(x))
     y = np.array(np.atleast_1d(y))
 
-    lower_x = np.rint(x - size[0]/2)
-    lower_y = np.rint(y - size[1]/2)
+    lower_x = np.rint(x - size[0] / 2)
+    lower_y = np.rint(y - size[1] / 2)
 
-    return np.stack((np.stack((lower_x, lower_x + size[0]), axis=1),
-                     np.stack((lower_y, lower_y + size[1]), axis=1)), axis=1).astype(int)
+    return np.stack(
+        (np.stack((lower_x, lower_x + size[0]), axis=1), np.stack((lower_y, lower_y + size[1]), axis=1)), axis=1
+    ).astype(int)
 
 
 def _combine_bounds(bounds1, bounds2):
@@ -90,13 +89,13 @@ def _combine_bounds(bounds1, bounds2):
     combine them into a new [[x_min, x_max],[y_min, y_max]], that
     encompasses both initial bounds.
     """
-    
+
     bounds_comb = np.zeros((2, 2), dtype=int)
     bounds_comb[0, 0] = bounds1[0, 0] if (bounds1[0, 0] < bounds2[0, 0]) else bounds2[0, 0]
     bounds_comb[1, 0] = bounds1[1, 0] if (bounds1[1, 0] < bounds2[1, 0]) else bounds2[1, 0]
     bounds_comb[0, 1] = bounds1[0, 1] if (bounds1[0, 1] > bounds2[0, 1]) else bounds2[0, 1]
     bounds_comb[1, 1] = bounds1[1, 1] if (bounds1[1, 1] > bounds2[1, 1]) else bounds2[1, 1]
-    
+
     return bounds_comb
 
 
@@ -114,36 +113,35 @@ def _get_args(bounds, img_wcs):
     `~astropy.wcs.WCS` object return a center coordinate and size
     ([ny, nx] pixels) suitable for creating a rectangular cutout.
     """
-    nx = bounds[0, 1]-bounds[0, 0]
-    ny = bounds[1, 1]-bounds[1, 0]
-    x = nx/2 + bounds[0, 0]
-    y = ny/2 + bounds[1, 0]
-    return {"coordinates": img_wcs.pixel_to_world(x, y),
-            "size": (ny, nx)}
+    nx = bounds[0, 1] - bounds[0, 0]
+    ny = bounds[1, 1] - bounds[1, 0]
+    x = nx / 2 + bounds[0, 0]
+    y = ny / 2 + bounds[1, 0]
+    return {"coordinates": img_wcs.pixel_to_world(x, y), "size": (ny, nx)}
 
 
 def _moving_target_focus(path, size, cutout_fles, verbose=False):
     """
-    Given a moving target path (list of RA/Decs) and size, that intersects with 
-    the given cutout(s) make a cutout of requested size centered on the 
+    Given a moving target path (list of RA/Decs) and size, that intersects with
+    the given cutout(s) make a cutout of requested size centered on the
     moving target given by the path.
-    
+
     Note: No resampling is done so there will be some jitter in the moving target
     placement.
-    
+
     Parameters
     ----------
     path : `~astropy.table.Table`
         Table (or similar) object with columns "time," containing `~astropy.time.Time`
         objects and "position," containing `~astropy.coordinate.Skycoord` objects.
     size : array
-        Size in pixels of the cutout rectangle centered on the path locations ther will be 
+        Size in pixels of the cutout rectangle centered on the path locations ther will be
         returned. Formatted as [ny,nx]
     cutout_fles : list
         List of strings that are Target Pixel File paths.
     verbose : bool
         Optional. If true intermediate information is printed.
-        
+
     Returns
     -------
     response : `~astropy.table.Table`
@@ -151,60 +149,64 @@ def _moving_target_focus(path, size, cutout_fles, verbose=False):
     """
     # Log messages based on verbosity
     _handle_verbose(verbose)
-    
+
     cutout_table_list = list()
-    
+
     tck_tuple, u = splprep([path["position"].ra, path["position"].dec], u=path["time"].jd, s=0)
-    
+
     for fle in cutout_fles:
-        log.debug('Processing file: %s', fle)
-        
+        log.debug("Processing file: %s", fle)
+
         # Get the stuff we need from the cutout file
         hdu = fits.open(fle)
         cutout_table = Table(hdu[1].data)
         cutout_wcs = WCS(hdu[2].header)
         hdu.close()
-        
-        
+
         path["x"], path["y"] = cutout_wcs.world_to_pixel(path["position"])
         # This line might need to be refined
-        rel_pts = ((path["x"] - size[0]/2 >= 0) & (path["x"] + size[0]/2 < cutout_wcs.array_shape[1]) & 
-                   (path["y"] - size[1]/2 >= 0) & (path["y"] + size[1]/2 < cutout_wcs.array_shape[0]))
-        
+        rel_pts = (
+            (path["x"] - size[0] / 2 >= 0)
+            & (path["x"] + size[0] / 2 < cutout_wcs.array_shape[1])
+            & (path["y"] - size[1] / 2 >= 0)
+            & (path["y"] + size[1] / 2 < cutout_wcs.array_shape[0])
+        )
+
         if sum(rel_pts) == 0:
             continue
-         
+
         cutout_table["time_jd"] = cutout_table["TIME"] + 2457000  # TESS specific code
-        cutout_table = cutout_table[(cutout_table["time_jd"] >= np.min(path["time"][rel_pts].jd)) & 
-                                    (cutout_table["time_jd"] <= np.max(path["time"][rel_pts].jd))]
-        
+        cutout_table = cutout_table[
+            (cutout_table["time_jd"] >= np.min(path["time"][rel_pts].jd))
+            & (cutout_table["time_jd"] <= np.max(path["time"][rel_pts].jd))
+        ]
+
         cutout_table["positions"] = SkyCoord(*splev(cutout_table["time_jd"], tck_tuple), unit="deg")
         cutout_table["x"], cutout_table["y"] = cutout_wcs.world_to_pixel(cutout_table["positions"])
         cutout_table["bounds"] = _get_bounds(cutout_table["x"], cutout_table["y"], size)
-        
-        
+
         cutout_table["TGT_X"] = cutout_table["x"] - cutout_table["bounds"][:, 0, 0]
         cutout_table["TGT_Y"] = cutout_table["y"] - cutout_table["bounds"][:, 1, 0]
-        
+
         cutout_table["TGT_RA"] = cutout_table["positions"].ra.value
         cutout_table["TGT_DEC"] = cutout_table["positions"].dec.value
 
         # This is y vs x beacuse of the way the pixels are stored by fits
         cutout_table["bounds"] = [(slice(*y), slice(*x)) for x, y in cutout_table["bounds"]]
-        
+
         cutout_table["RAW_CNTS"] = [x["RAW_CNTS"][tuple(x["bounds"])] for x in cutout_table]
         cutout_table["FLUX"] = [x["FLUX"][tuple(x["bounds"])] for x in cutout_table]
         cutout_table["FLUX_ERR"] = [x["FLUX_ERR"][tuple(x["bounds"])] for x in cutout_table]
         cutout_table["FLUX_BKG"] = [x["FLUX_BKG"][tuple(x["bounds"])] for x in cutout_table]
         cutout_table["FLUX_BKG_ERR"] = [x["FLUX_BKG_ERR"][tuple(x["bounds"])] for x in cutout_table]
-        
-        cutout_table.remove_columns(['time_jd', 'bounds', 'x', 'y', "positions"])
+
+        cutout_table.remove_columns(["time_jd", "bounds", "x", "y", "positions"])
         cutout_table_list.append(cutout_table)
-        
+
     cutout_table = vstack(cutout_table_list)
     cutout_table.sort("TIME")
-    
-    return cutout_table 
+
+    return cutout_table
 
 
 def _configure_bintable_header(new_header, table_headers):
@@ -219,46 +221,46 @@ def _configure_bintable_header(new_header, table_headers):
     for kwd in table_headers[0]:
         if "TTYPE" not in kwd:
             continue
-        
+
         colname = table_headers[0][kwd]
         num = kwd.replace("TTYPE", "")
-    
+
         cards = []
-        for att in ['TTYPE', 'TFORM', 'TUNIT', 'TDISP', 'TDIM']:
+        for att in ["TTYPE", "TFORM", "TUNIT", "TDISP", "TDIM"]:
             try:
-                cards.append(table_headers[0].cards[att+num])
+                cards.append(table_headers[0].cards[att + num])
             except KeyError:
                 pass  # if we don't have info for this keyword, just skip it
-        
+
         column_info[colname] = (num, cards)
 
     # Adding column descriptions and additional info
     for kwd in new_header:
         if "TTYPE" not in kwd:
             continue
-        
+
         colname = new_header[kwd]
         num = kwd.replace("TTYPE", "")
-    
+
         info_row = column_info.get(colname)
         if not info_row:
-            new_header.comments[kwd] = 'column name'
-            new_header.comments[kwd.replace("TTYPE", "TFORM")] = 'column format'
+            new_header.comments[kwd] = "column name"
+            new_header.comments[kwd.replace("TTYPE", "TFORM")] = "column format"
             continue
-    
+
         info_num = info_row[0]
         cards = info_row[1]
-    
+
         for key, val, desc in cards:
             key_new = key.replace(info_num, num)
             try:
                 ext_card = new_header.cards[key_new]
-            
+
                 if ext_card[1]:
                     val = ext_card[1]
                 if ext_card[2]:
                     desc = ext_card[2]
-                
+
                 new_header[key_new] = (val, desc)
             except KeyError:  # card does not already exist, just add new one
                 new_header.set(key_new, val, desc, after=kwd)
@@ -269,8 +271,9 @@ def _configure_bintable_header(new_header, table_headers):
         if kwd in new_header:  # Don't overwrite anything already there
             continue
 
-        if any(x in kwd for x in ["WCA", "WCS", "CTY", "CRP", "CRV", "CUN",
-                                  "CDL", "11PC", "12PC", "21PC", "22PC"]):  # Skipping column WCS keywords
+        if any(
+            x in kwd for x in ["WCA", "WCS", "CTY", "CRP", "CRV", "CUN", "CDL", "11PC", "12PC", "21PC", "22PC"]
+        ):  # Skipping column WCS keywords
             continue
 
         new_header.append(shared_keywords.cards[kwd])
@@ -279,77 +282,78 @@ def _configure_bintable_header(new_header, table_headers):
 def path_to_footprints(path, size, img_wcs, max_pixels=10000):
     """
     Given a path that intersects with a wcs footprint, return
-    one or more rectangles that fully contain that intersection 
-    (plus padding given by 'size') with each rectangle no more than 
+    one or more rectangles that fully contain that intersection
+    (plus padding given by 'size') with each rectangle no more than
     max_pixels in size.
-    
+
     Parameters
     ----------
     path : `~astropy.coordinate.SkyCoord`
         SkyCoord object list of coordinates that represent a continuous path.
     size : array
-        Size of the rectangle centered on the path locations that must 
+        Size of the rectangle centered on the path locations that must
         be included in the returned footprint(s). Formatted as [ny,nx]
     img_wcs : `~astropy.wcs.WCS`
         WCS object the path intersects with. Must include naxis information.
     max_pixels : int
         Optional, default 10000. The maximum area in pixels for individual
         footprints.
-        
+
     Returns
     -------
     response : list
        List of footprints, each a dictionary of the form:
        {'center_coord': `~astropy.coordinate.SkyCoord`, 'size': [ny,nx]}
     """
-    
+
     x, y = img_wcs.world_to_pixel(path)
-    
+
     # Removing any coordinates outside of the img wcs
     valid_locs = ((x >= 0) & (x < img_wcs.array_shape[0])) & ((y >= 0) & (y < img_wcs.array_shape[1]))
     x = x[valid_locs]
     y = y[valid_locs]
-    
+
     bounds_list = _get_bounds(x, y, size)
 
     combined_bounds = list()
     cur_bounds = bounds_list[0]
     for bounds in bounds_list[1:]:
         new_bounds = _combine_bounds(cur_bounds, bounds)
-        
+
         if _area(new_bounds) > max_pixels:
             combined_bounds.append(cur_bounds)
             cur_bounds = bounds
         else:
             cur_bounds = new_bounds
-            
+
     combined_bounds.append(cur_bounds)
-    
+
     footprints = []
     for bounds in combined_bounds:
         footprints.append(_get_args(bounds, img_wcs))
-        
-    return footprints 
+
+    return footprints
 
 
-def center_on_path(path, size, cutout_fles, target=None, img_wcs=None,
-                   target_pixel_file=None, output_path=".", verbose=True):
+def center_on_path(
+    path, size, cutout_fles, target=None, img_wcs=None, target_pixel_file=None, output_path=".", verbose=True
+):
     """
-    Given a moving target path that crosses through one or more cutout files 
-    (as produced by `cube_cut`/tesscut) and size, create a target pixel file 
-    containint a cutout of the requested size centered on the moving target 
+    Given a moving target path that crosses through one or more cutout files
+    (as produced by `cube_cut`/tesscut) and size, create a target pixel file
+    containint a cutout of the requested size centered on the moving target
     given in the providedpath.
-    
+
     Note: No resampling is done so there will be some jitter in the moving target
     placement.
-    
+
     Parameters
     ----------
     path : `~astropy.table.Table`
         Table (or similar) object with columns "time," containing `~astropy.time.Time`
         objects and "position," containing `~astropy.coordinate.Skycoord` objects.
     size : array
-        Size in pixels of the cutout rectangle centered on the path locations ther will be 
+        Size in pixels of the cutout rectangle centered on the path locations ther will be
         returned. Formatted as [ny,nx]
     cutout_fles : list
         List of strings, Target Pixel File paths that the path crosses.
@@ -359,21 +363,21 @@ def center_on_path(path, size, cutout_fles, target=None, img_wcs=None,
         Optional WCS object that is the WCS from the original image (TESS FFI usually)
         all the cutouts came from.
     target_pixel_file : str
-        Optional. The name for the output target pixel file. 
-        If no name is supplied, the file will be named: 
+        Optional. The name for the output target pixel file.
+        If no name is supplied, the file will be named:
         ``<target/path>_<cutout_size>_<time range>_astrocut.fits``
     output_path : str
-        Optional. The path where the output file is saved. 
+        Optional. The path where the output file is saved.
         The current directory is default.
     verbose : bool
-            Optional. If true intermediate information is printed. 
-        
+            Optional. If true intermediate information is printed.
+
     Returns
     -------
     response : str
         The file path for the output target pixel file.
     """
-    
+
     # TODO: add ability to take sizes like in rest of cutout functionality
     # Log messages based on verbosity
     _handle_verbose(verbose)
@@ -384,20 +388,20 @@ def center_on_path(path, size, cutout_fles, target=None, img_wcs=None,
     primary_header_list = list()
     table_headers = list()
     for fle in cutout_fles:
-        hdu = fits.open(fle, mode='denywrite', memmap=True)
+        hdu = fits.open(fle, mode="denywrite", memmap=True)
         primary_header_list.append(hdu[0].header)
         table_headers.append(hdu[1].header)
         hdu.close()
     # Building the new primary header
     primary_header = _combine_headers(primary_header_list, constant_only=True)
-    primary_header['DATE'] = Time.now().to_value('iso', subfmt='date')
+    primary_header["DATE"] = Time.now().to_value("iso", subfmt="date")
     if target:
         primary_header["OBJECT"] = (target, "Moving target object name/identifier")
     primary_header["TSTART"] = cutout_table["TIME"].min()
     primary_header["TSTOP"] = cutout_table["TIME"].max()
 
     primary_hdu = fits.PrimaryHDU(header=primary_header)
-    
+
     # Building the cutout table extension
     mt_cutout_fits_table = fits.table_to_hdu(cutout_table)
     _configure_bintable_header(mt_cutout_fits_table.header, table_headers)
@@ -405,34 +409,34 @@ def center_on_path(path, size, cutout_fles, target=None, img_wcs=None,
     # Building the aperture extension if possible
     if img_wcs:
         aperture = np.zeros(img_wcs.array_shape, dtype=np.int32)
-        x_arr, y_arr = img_wcs.world_to_pixel(SkyCoord(cutout_table["TGT_RA"],
-                                                       cutout_table["TGT_DEC"], unit='deg'))
-        x_2 = size[0]/2
-        y_2 = size[1]/2
-        
+        x_arr, y_arr = img_wcs.world_to_pixel(SkyCoord(cutout_table["TGT_RA"], cutout_table["TGT_DEC"], unit="deg"))
+        x_2 = size[0] / 2
+        y_2 = size[1] / 2
+
         for x, y in zip(x_arr, y_arr):
-            aperture[int(x-x_2): int(x+x_2), int(y-y_2): int(y+y_2)] = 1
+            aperture[int(x - x_2) : int(x + x_2), int(y - y_2) : int(y + y_2)] = 1
 
         aperture_hdu = fits.ImageHDU(data=aperture)
-        aperture_hdu.header['EXTNAME'] = 'APERTURE'
+        aperture_hdu.header["EXTNAME"] = "APERTURE"
         aperture_hdu.header.extend(img_wcs.to_header(relax=True).cards)
-        aperture_hdu.header['INHERIT'] = True
+        aperture_hdu.header["INHERIT"] = True
 
         mt_hdu_list = fits.HDUList(hdus=[primary_hdu, mt_cutout_fits_table, aperture_hdu])
 
     else:
         mt_hdu_list = fits.HDUList(hdus=[primary_hdu, mt_cutout_fits_table])
-        
+
     if not target_pixel_file:
         target = "path" if not target else target
-        target_pixel_file = (f"{target}_{primary_header['TSTART']}-{primary_header['TSTop']}_"
-                             f"{size[0]}-x-{size[1]}_astrocut.fits")
-    
+        target_pixel_file = (
+            f"{target}_{primary_header['TSTART']}-{primary_header['TSTop']}_" f"{size[0]}-x-{size[1]}_astrocut.fits"
+        )
+
     # Replace any slashes/spaces for filename conventions
-    target_pixel_file = target_pixel_file.replace('/', '-').replace(' ', '_')
+    target_pixel_file = target_pixel_file.replace("/", "-").replace(" ", "_")
 
     filename = os.path.join(output_path, target_pixel_file)
-    
+
     mt_hdu_list.writeto(filename, overwrite=True, checksum=True)
 
     return filename
@@ -440,15 +444,15 @@ def center_on_path(path, size, cutout_fles, target=None, img_wcs=None,
 
 def build_default_combine_function(template_hdu_arr, no_data_val=np.nan):
     """
-    Given an array of `~astropy.io.fits.ImageHdu` objects, 
-    initialize a function to combine an array of the same size/shape 
+    Given an array of `~astropy.io.fits.ImageHdu` objects,
+    initialize a function to combine an array of the same size/shape
     images where each pixel the mean of all images with available
     data at that pixel.
 
     Parameters
     ----------
     template_hdu_arr : list
-        A list of `~astropy.io.fits.ImageHdu` objects that will be 
+        A list of `~astropy.io.fits.ImageHdu` objects that will be
         used to create the image combine function.
     no_data_val : scaler
         Optional. The image value that indicates "no data" at a particular pixel.
@@ -459,9 +463,9 @@ def build_default_combine_function(template_hdu_arr, no_data_val=np.nan):
     response : func
         The combiner function that can be applying to other arrays of images.
     """
-    
+
     img_arrs = np.array([hdu.data for hdu in template_hdu_arr])
-   
+
     if np.isnan(no_data_val):
         templates = (~np.isnan(img_arrs)).astype(float)
     else:
@@ -474,13 +478,13 @@ def build_default_combine_function(template_hdu_arr, no_data_val=np.nan):
 
     def combine_function(cutout_hdu_arr):
         """
-        Combiner function that takes an array of `~astropy.io.fits.ImageHdu` 
+        Combiner function that takes an array of `~astropy.io.fits.ImageHdu`
         objects and cobines them into a single image.
 
         Parameters
         ----------
         cutout_hdu_arr : list
-            Array of `~astropy.io.fits.ImageHdu` objects that will be 
+            Array of `~astropy.io.fits.ImageHdu` objects that will be
             combined into a single image.
 
         Returns
@@ -488,13 +492,13 @@ def build_default_combine_function(template_hdu_arr, no_data_val=np.nan):
         response : array
             The combined image array.
         """
-        
+
         cutout_imgs = np.array([hdu.data for hdu in cutout_hdu_arr])
         nans = np.bitwise_and.reduce(np.isnan(cutout_imgs), axis=0)
-        
+
         cutout_imgs[np.isnan(cutout_imgs)] = 0  # don't want any nans because they mess up multiple/add
- 
-        combined_img = np.sum(templates*cutout_imgs, axis=0)
+
+        combined_img = np.sum(templates * cutout_imgs, axis=0)
         combined_img[nans] = np.nan  # putting nans back if we need to
 
         return combined_img
@@ -502,14 +506,12 @@ def build_default_combine_function(template_hdu_arr, no_data_val=np.nan):
     return combine_function
 
 
-
-class CutoutsCombiner():
+class CutoutsCombiner:
     """
     Class for combining cutouts.
     """
 
     def __init__(self, fits_list=None, exts=None, img_combiner=None):
-
         self.input_hdulists = None
         self.center_coord = None
         if fits_list:
@@ -520,10 +522,8 @@ class CutoutsCombiner():
         if img_combiner:
             self.combine_images = img_combiner
         else:  # load up the default combiner
-            self.build_img_combiner(build_default_combine_function,
-                                    builder_args=[self.input_hdulists[0], np.nan])
-        
-            
+            self.build_img_combiner(build_default_combine_function, builder_args=[self.input_hdulists[0], np.nan])
+
     def load(self, fits_list, exts=None):
         """
         Load the input cutouts and select the desired fits extensions.
@@ -537,7 +537,7 @@ class CutoutsCombiner():
             Optional. List of fits extensions to combine.
             Default is None, which means all extensions will be combined.
             If the first extension is a PrimaryHeader with no data it will
-            be skipped.      
+            be skipped.
         """
 
         if isinstance(fits_list[0], str):  # input is filenames
@@ -546,7 +546,7 @@ class CutoutsCombiner():
             cutout_hdulists = fits_list
         else:
             raise InvalidInputError("Unsupported input format!")
-        
+
         if exts is None:
             # Go ahead and deal with possible presence of a primaryHeader and no data as first ext
             if not cutout_hdulists[0][0].data:
@@ -560,21 +560,18 @@ class CutoutsCombiner():
 
         # Try to find the center coordinate
         try:
-            ra = cutout_hdulists[0][0].header['RA_OBJ']
-            dec = cutout_hdulists[0][0].header['DEC_OBJ']
-            self.center_coord = SkyCoord(f"{ra} {dec}", unit='deg')
-            
-        except KeyError:
-            warnings.warn("Could not find RA/Dec header keywords, center coord will be wrong.",
-                          DataWarning)
-            self.center_coord = SkyCoord("0 0", unit='deg')
-            
-        except ValueError:
-            warnings.warn("Invalid RA/Dec values, center coord will be wrong.",
-                          DataWarning)
-            self.center_coord = SkyCoord("0 0", unit='deg')
+            ra = cutout_hdulists[0][0].header["RA_OBJ"]
+            dec = cutout_hdulists[0][0].header["DEC_OBJ"]
+            self.center_coord = SkyCoord(f"{ra} {dec}", unit="deg")
 
-            
+        except KeyError:
+            warnings.warn("Could not find RA/Dec header keywords, center coord will be wrong.", DataWarning)
+            self.center_coord = SkyCoord("0 0", unit="deg")
+
+        except ValueError:
+            warnings.warn("Invalid RA/Dec values, center coord will be wrong.", DataWarning)
+            self.center_coord = SkyCoord("0 0", unit="deg")
+
     def build_img_combiner(self, function_builder, builder_args):
         """
         Build the function that will combine cutout extensions.
@@ -586,21 +583,20 @@ class CutoutsCombiner():
         builder_args : list
             Array of arguments for the function builder
         """
-        
+
         self.combine_images = function_builder(*builder_args)
-   
-        
+
     def combine(self, output_file="./cutout.fits", memory_only=False):
         """
         Combine cutouts and either save the output to a FITS file,
-        
+
 
         Parameters
         ----------
         output_file : str
             Optional. The filename for the combined cutout file.
         memory_only : bool
-            Default value False. If set to true, instead of the combined cutout file being 
+            Default value False. If set to true, instead of the combined cutout file being
             written to disk it is returned as a `~astropy.io.fit.HDUList` object. If set to
             True, output_file is ignored.
 
@@ -614,9 +610,8 @@ class CutoutsCombiner():
         hdu_list = []
 
         for ext_hdus in self.input_hdulists:
-            
             new_header = self.combine_headers([hdu.header for hdu in ext_hdus])
-        
+
             new_img = self.combine_images([hdu.data for hdu in ext_hdus])
             hdu_list.append(fits.ImageHDU(data=new_img, header=new_header))
 

--- a/astrocut/exceptions.py
+++ b/astrocut/exceptions.py
@@ -11,14 +11,16 @@ class InvalidQueryError(Exception):
     """
     Errors related to invalid queries.
     """
+
     pass
 
 
 class InvalidInputError(Exception):
     """
-    Exception to be issued when user input is incorrect in a 
+    Exception to be issued when user input is incorrect in a
     way that prevents the function from running.
     """
+
     pass
 
 
@@ -27,6 +29,7 @@ class UnsupportedPythonError(Exception):
     Exception to be issued when attempting to use astrocut with
     an unsupported version of Python.
     """
+
     pass
 
 
@@ -35,6 +38,7 @@ class InputWarning(AstropyWarning):
     Warning to be issued when user input is incorrect in
     some way but doesn't prevent the function from running.
     """
+
     pass
 
 
@@ -42,6 +46,7 @@ class TypeWarning(AstropyWarning):
     """
     Warnings to do with data types.
     """
+
     pass
 
 
@@ -49,6 +54,7 @@ class DataWarning(AstropyWarning):
     """
     Warnings to do with data content.
     """
+
     pass
 
 
@@ -56,4 +62,5 @@ class ModuleWarning(AstropyWarning):
     """
     Warnings to do with optional modules.
     """
+
     pass

--- a/astrocut/fits_cutout.py
+++ b/astrocut/fits_cutout.py
@@ -1,23 +1,23 @@
+import warnings
 from datetime import date
 from pathlib import Path
 from time import monotonic
 from typing import List, Literal, Optional, Tuple, Union
-import warnings
 
+import numpy as np
 from astropy import log as astropy_log
 from astropy.coordinates import SkyCoord
-from astropy.nddata import NoOverlapError
 from astropy.io import fits
 from astropy.io.fits import HDUList
+from astropy.nddata import NoOverlapError
 from astropy.units import Quantity
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.wcs import WCS
-import numpy as np
 from s3path import S3Path
 
+from . import __version__, log
 from .exceptions import DataWarning, InvalidQueryError
 from .image_cutout import ImageCutout
-from . import __version__, log
 
 
 class FITSCutout(ImageCutout):
@@ -62,11 +62,19 @@ class FITSCutout(ImageCutout):
         Write the cutouts to files in FITS format.
     """
 
-    def __init__(self, input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str],
-                 cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
-                 fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round',
-                 extension: Optional[Union[int, List[int], Literal['all']]] = None,
-                 single_outfile: bool = True, verbose: bool = False, *, fsspec_kwargs: Optional[dict] = None):
+    def __init__(
+        self,
+        input_files: List[Union[str, Path, S3Path]],
+        coordinates: Union[SkyCoord, str],
+        cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
+        fill_value: Union[int, float] = np.nan,
+        limit_rounding_method: str = "round",
+        extension: Optional[Union[int, List[int], Literal["all"]]] = None,
+        single_outfile: bool = True,
+        verbose: bool = False,
+        *,
+        fsspec_kwargs: Optional[dict] = None,
+    ):
         # Superclass constructor
         super().__init__(input_files, coordinates, cutout_size, fill_value, limit_rounding_method, verbose)
 
@@ -101,14 +109,20 @@ class FITSCutout(ImageCutout):
         # Setting up the Primary HDU
         keywords = dict()
         if self._coordinates:
-            keywords = {'RA_OBJ': (self._coordinates.ra.deg, '[deg] right ascension'),
-                        'DEC_OBJ': (self._coordinates.dec.deg, '[deg] declination')}
+            keywords = {
+                "RA_OBJ": (self._coordinates.ra.deg, "[deg] right ascension"),
+                "DEC_OBJ": (self._coordinates.dec.deg, "[deg] declination"),
+            }
 
         # Build the primary HDU with keywords
         primary_hdu = fits.PrimaryHDU()
-        primary_hdu.header.extend([('ORIGIN', 'STScI/MAST', 'institution responsible for creating this file'),
-                                   ('DATE', str(date.today()), 'file creation date'),
-                                   ('PROCVER', __version__, 'software version')])
+        primary_hdu.header.extend(
+            [
+                ("ORIGIN", "STScI/MAST", "institution responsible for creating this file"),
+                ("DATE", str(date.today()), "file creation date"),
+                ("PROCVER", __version__, "software version"),
+            ]
+        )
         for kwd in keywords:
             primary_hdu.header[kwd] = keywords[kwd]
 
@@ -149,19 +163,22 @@ class FITSCutout(ImageCutout):
         """
         # Skip files with no image data
         if len(infile_exts) == 0:
-            warnings.warn(f'No image extensions with data found in {input_file}, skipping...', DataWarning)
+            warnings.warn(f"No image extensions with data found in {input_file}, skipping...", DataWarning)
             return []
 
         if self._extension is None:
             cutout_exts = infile_exts[:1]  # Take the first image extension
-        elif self._extension == 'all':
+        elif self._extension == "all":
             cutout_exts = infile_exts  # Take all the extensions
         else:  # User input extentions
             cutout_exts = [x for x in infile_exts if x in self._extension]
             if len(cutout_exts) < len(self._extension):
-                empty_exts = ','.join([str(x) for x in self._extension if x not in cutout_exts])
-                warnings.warn(f'Not all requested extensions in {input_file} are image extensions or have '
-                              f'data, extension(s) {empty_exts} will be skipped.', DataWarning)
+                empty_exts = ",".join([str(x) for x in self._extension if x not in cutout_exts])
+                warnings.warn(
+                    f"Not all requested extensions in {input_file} are image extensions or have "
+                    f"data, extension(s) {empty_exts} will be skipped.",
+                    DataWarning,
+                )
 
         return cutout_exts
 
@@ -183,13 +200,13 @@ class FITSCutout(ImageCutout):
         """
         # Account for cloud-hosted files
         fsspec_kwargs = None
-        if 's3://' in input_file:
-            fsspec_kwargs = {'anon': True}
+        if "s3://" in input_file:
+            fsspec_kwargs = {"anon": True}
             if self._fsspec_kwargs:
                 fsspec_kwargs.update(self._fsspec_kwargs)
 
         # Open the file
-        hdulist = fits.open(input_file, mode='denywrite', memmap=True, fsspec_kwargs=fsspec_kwargs)
+        hdulist = fits.open(input_file, mode="denywrite", memmap=True, fsspec_kwargs=fsspec_kwargs)
 
         # Sorting out which extension(s) to cutout
         infile_exts = np.where([hdu.is_image and hdu.size > 0 for hdu in hdulist])[0]
@@ -227,19 +244,27 @@ class FITSCutout(ImageCutout):
             astropy_log.addHandler(hd)
 
         no_sip = False
-        if (len(log_list) > 0):
-            if ('Inconsistent SIP distortion information' in log_list[0].msg):
+        if len(log_list) > 0:
+            if "Inconsistent SIP distortion information" in log_list[0].msg:
                 # Remove sip coefficients
                 img_wcs.sip = None
                 no_sip = True
             else:  # Message(s) we didn't prepare for we want to go ahead and display
                 for log_rec in log_list:
-                    astropy_log.log(log_rec.levelno, log_rec.msg, extra={'origin': log_rec.name})
+                    astropy_log.log(log_rec.levelno, log_rec.msg, extra={"origin": log_rec.name})
 
         return (img_wcs, no_sip)
 
-    def _hducut(self, cutout_data: np.ndarray, cutout_wcs: WCS, hdu_header: fits.Header, no_sip: bool,
-                ind: int, primary_filename: fits.Header, is_empty: bool) -> fits.ImageHDU:
+    def _hducut(
+        self,
+        cutout_data: np.ndarray,
+        cutout_wcs: WCS,
+        hdu_header: fits.Header,
+        no_sip: bool,
+        ind: int,
+        primary_filename: fits.Header,
+        is_empty: bool,
+    ) -> fits.ImageHDU:
         """
         Create a cutout HDU from an image HDU.
 
@@ -272,24 +297,24 @@ class FITSCutout(ImageCutout):
             hdu_header.update(cutout_wcs.to_header(relax=True))  # relax arg is for sip distortions if they exist
 
         # Naming the extension and preserving the original name
-        hdu_header['O_EXT_NM'] = (hdu_header.get('EXTNAME'), 'Original extension name.')
-        hdu_header['EXTNAME'] = 'CUTOUT'
+        hdu_header["O_EXT_NM"] = (hdu_header.get("EXTNAME"), "Original extension name.")
+        hdu_header["EXTNAME"] = "CUTOUT"
 
         # Moving the filename, if present, into the ORIG_FLE keyword
-        hdu_header['ORIG_FLE'] = (hdu_header.get('FILENAME'), 'Original image filename.')
-        hdu_header.remove('FILENAME', ignore_missing=True)
+        hdu_header["ORIG_FLE"] = (hdu_header.get("FILENAME"), "Original image filename.")
+        hdu_header.remove("FILENAME", ignore_missing=True)
 
         # Check that there is data in the cutout image
         if is_empty:
-            hdu_header['EMPTY'] = (True, 'Indicates no data in cutout image.')
+            hdu_header["EMPTY"] = (True, "Indicates no data in cutout image.")
 
         # Create the cutout HDU
         cutout_hdu = fits.ImageHDU(header=hdu_header, data=cutout_data)
 
         # Adding a few more keywords
-        cutout_hdu.header['ORIG_EXT'] = (ind, 'Extension in original file.')
-        if not cutout_hdu.header.get('ORIG_FLE') and primary_filename:
-            cutout_hdu.header['ORIG_FLE'] = primary_filename
+        cutout_hdu.header["ORIG_EXT"] = (ind, "Extension in original file.")
+        if not cutout_hdu.header.get("ORIG_FLE") and primary_filename:
+            cutout_hdu.header["ORIG_FLE"] = primary_filename
 
         return cutout_hdu
 
@@ -319,7 +344,7 @@ class FITSCutout(ImageCutout):
                 img_hdu = hdulist[ind]
                 hdu_header = fits.Header(img_hdu.header, copy=True)
                 img_wcs, no_sip = self._get_img_wcs(hdu_header)
-                primary_filename = hdulist[0].header.get('FILENAME')
+                primary_filename = hdulist[0].header.get("FILENAME")
 
                 # Create the cutout
                 # Eventually, this will be replaced by a call to Cutout2D
@@ -334,25 +359,34 @@ class FITSCutout(ImageCutout):
                     cutouts.append(cutout)
 
                 # Also save the cutouts as ImageHDU objects for FITS output
-                fits_cutouts.append(self._hducut(cutout.data, cutout.wcs, hdu_header, no_sip, ind,
-                                                 primary_filename, is_empty))
+                fits_cutouts.append(
+                    self._hducut(cutout.data, cutout.wcs, hdu_header, no_sip, ind, primary_filename, is_empty)
+                )
 
             except OSError as err:
-                warnings.warn(f'Error {err} encountered when performing cutout on {file}, '
-                              f'extension {ind}, skipping...', DataWarning)
+                warnings.warn(
+                    f"Error {err} encountered when performing cutout on {file}, " f"extension {ind}, skipping...",
+                    DataWarning,
+                )
                 num_empty += 1
             except NoOverlapError:
-                warnings.warn(f'Cutout footprint does not overlap with data in {file}, '
-                              f'extension {ind}, skipping...', DataWarning)
+                warnings.warn(
+                    f"Cutout footprint does not overlap with data in {file}, " f"extension {ind}, skipping...",
+                    DataWarning,
+                )
                 num_empty += 1
             except InvalidQueryError:
-                warnings.warn(f'Cutout footprint does not overlap with data in {file}, '
-                              f'extension {ind}, skipping...', DataWarning)
+                warnings.warn(
+                    f"Cutout footprint does not overlap with data in {file}, " f"extension {ind}, skipping...",
+                    DataWarning,
+                )
                 num_empty += 1
             except ValueError as err:
-                if 'Input position contains invalid values' in str(err):
-                    warnings.warn(f'Cutout footprint does not overlap with data in {file}, '
-                                  f'extension {ind}, skipping...', DataWarning)
+                if "Input position contains invalid values" in str(err):
+                    warnings.warn(
+                        f"Cutout footprint does not overlap with data in {file}, " f"extension {ind}, skipping...",
+                        DataWarning,
+                    )
                     num_empty += 1
                 else:
                     raise
@@ -361,7 +395,7 @@ class FITSCutout(ImageCutout):
         hdulist.close()
 
         if num_empty == len(cutout_inds):  # No extensions have cutout data
-            warnings.warn(f'Cutout of {file} contains no data, skipping...', DataWarning)
+            warnings.warn(f"Cutout of {file} contains no data, skipping...", DataWarning)
         else:  # At least one extension has cutout data
             # Save cutouts
             self.cutouts_by_file[file] = cutouts
@@ -390,14 +424,14 @@ class FITSCutout(ImageCutout):
 
         # If no cutouts contain data, raise exception
         if not self.cutouts_by_file:
-            raise InvalidQueryError('Cutout contains no data! (Check image footprint.)')
+            raise InvalidQueryError("Cutout contains no data! (Check image footprint.)")
 
         # Log total time elapsed
-        log.debug('Total time: %.2f sec', monotonic() - start_time)
+        log.debug("Total time: %.2f sec", monotonic() - start_time)
 
         return self.fits_cutouts
 
-    def write_as_fits(self, output_dir: Union[str, Path] = '.', cutout_prefix: str = 'cutout') -> List[str]:
+    def write_as_fits(self, output_dir: Union[str, Path] = ".", cutout_prefix: str = "cutout") -> List[str]:
         """
         Write the cutouts to memory or to a file in FITS format.
 
@@ -409,19 +443,19 @@ class FITSCutout(ImageCutout):
         Path(output_dir).mkdir(parents=True, exist_ok=True)
 
         if self._single_outfile:  # one output file for all input files
-            log.debug('Returning cutout as a single FITS file.')
+            log.debug("Returning cutout as a single FITS file.")
 
             cutout_fits = self.fits_cutouts[0]
             filename = self._make_cutout_filename(cutout_prefix)
             cutout_path = Path(output_dir, filename)
             with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
+                warnings.simplefilter("ignore")
                 cutout_fits.writeto(cutout_path, overwrite=True, checksum=True)
             # Return file path or memory object
             return [cutout_path.as_posix()]
 
         else:  # one output file per input file
-            log.debug('Returning cutouts as individual FITS files.')
+            log.debug("Returning cutouts as individual FITS files.")
 
             cutout_paths = []
             for i, file in enumerate(self.hdu_cutouts_by_file):
@@ -429,15 +463,15 @@ class FITSCutout(ImageCutout):
                 filename = self._make_cutout_filename(Path(file).stem)
                 cutout_path = Path(output_dir, filename)
                 with warnings.catch_warnings():
-                    warnings.simplefilter('ignore')
+                    warnings.simplefilter("ignore")
                     cutout_fits.writeto(cutout_path, overwrite=True, checksum=True)
                 # Append file path or memory object
                 cutout_paths.append(cutout_path.as_posix())
 
-            log.debug('Cutout filepaths: {}'.format(cutout_paths))
+            log.debug("Cutout filepaths: {}".format(cutout_paths))
             return cutout_paths
 
-    def write_as_zip(self, output_dir: Union[str, Path] = '.', filename: Union[str, Path, None] = None) -> str:
+    def write_as_zip(self, output_dir: Union[str, Path] = ".", filename: Union[str, Path, None] = None) -> str:
         """
         Package the FITS cutouts into a zip archive without writing intermediate files.
 
@@ -455,10 +489,11 @@ class FITSCutout(ImageCutout):
         str
             Path to the created zip file.
         """
+
         def build_entries():
             if self._single_outfile:
                 # Mirror the single-file naming used by write_as_fits
-                arcname = self._make_cutout_filename('cutout')
+                arcname = self._make_cutout_filename("cutout")
                 hdu = self.fits_cutouts[0]
                 yield arcname, hdu
             else:
@@ -506,7 +541,7 @@ class FITSCutout(ImageCutout):
             The WCS for the cutout.
         """
 
-        def __init__(self, img_data: fits.Section, img_wcs: WCS, parent: 'FITSCutout'):
+        def __init__(self, img_data: fits.Section, img_wcs: WCS, parent: "FITSCutout"):
             # Calculate cutout limits
             cutout_lims = parent._get_cutout_limits(img_wcs)
 
@@ -517,8 +552,7 @@ class FITSCutout(ImageCutout):
 
             self.wcs = self._get_cutout_wcs(img_wcs, cutout_lims)
 
-        def _get_cutout_data(self, data: fits.Section, cutout_lims: np.ndarray,
-                             parent: 'FITSCutout') -> np.ndarray:
+        def _get_cutout_data(self, data: fits.Section, cutout_lims: np.ndarray, parent: "FITSCutout") -> np.ndarray:
             """
             Extract the cutout data from an image.
 
@@ -536,7 +570,7 @@ class FITSCutout(ImageCutout):
             cutout_data : `numpy.ndarray`
                 The cutout data.
             """
-            log.debug('Original image shape: %s', data.shape)
+            log.debug("Original image shape: %s", data.shape)
 
             # Get the limits for the cutout
             # These limits are not guaranteed to be within the image footprint
@@ -545,17 +579,19 @@ class FITSCutout(ImageCutout):
 
             # Check the cutout is on the image
             if (xmax <= 0) or (xmin >= xmax_img) or (ymax <= 0) or (ymin >= ymax_img):
-                raise InvalidQueryError('Cutout location is not in image footprint!')
+                raise InvalidQueryError("Cutout location is not in image footprint!")
 
             # Adjust limits to fit within image bounds
             xmin_clipped, xmax_clipped = max(0, xmin), min(xmax_img, xmax)
             ymin_clipped, ymax_clipped = max(0, ymin), min(ymax_img, ymax)
 
             # Compute padding required (before and after in x and y)
-            padding = np.array([
-                (max(0, -ymin), max(0, ymax - ymax_img)),  # (top, bottom)
-                (max(0, -xmin), max(0, xmax - xmax_img))   # (left, right)
-            ])
+            padding = np.array(
+                [
+                    (max(0, -ymin), max(0, ymax - ymax_img)),  # (top, bottom)
+                    (max(0, -xmin), max(0, xmax - xmax_img)),  # (left, right)
+                ]
+            )
 
             # Extract the cutout
             img_cutout = data[ymin_clipped:ymax_clipped, xmin_clipped:xmax_clipped]
@@ -567,9 +603,9 @@ class FITSCutout(ImageCutout):
 
             # Adding padding to the cutout so that it's the expected size
             if padding.any():  # only do if we need to pad
-                img_cutout = np.pad(img_cutout, padding, 'constant', constant_values=parent._fill_value)
+                img_cutout = np.pad(img_cutout, padding, "constant", constant_values=parent._fill_value)
 
-            log.debug('Image cutout shape: %s', img_cutout.shape)
+            log.debug("Image cutout shape: %s", img_cutout.shape)
 
             return img_cutout
 
@@ -594,34 +630,49 @@ class FITSCutout(ImageCutout):
             wcs_header = img_wcs.to_header(relax=True)
 
             # Adjusting the CRPIX values
-            wcs_header['CRPIX1'] -= cutout_lims[0, 0]
-            wcs_header['CRPIX2'] -= cutout_lims[1, 0]
+            wcs_header["CRPIX1"] -= cutout_lims[0, 0]
+            wcs_header["CRPIX2"] -= cutout_lims[1, 0]
 
             # Adding the physical WCS keywords
-            wcs_header.set('WCSNAMEP', 'PHYSICAL', 'name of world coordinate system alternate P')
-            wcs_header.set('WCSAXESP', 2, 'number of WCS physical axes')
-            wcs_header.set('CTYPE1P', 'RAWX', 'physical WCS axis 1 type CCD col')
-            wcs_header.set('CUNIT1P', 'PIXEL', 'physical WCS axis 1 unit')
-            wcs_header.set('CRPIX1P', 1, 'reference CCD column')
-            wcs_header.set('CRVAL1P', cutout_lims[0, 0] + 1, 'value at reference CCD column')
-            wcs_header.set('CDELT1P', 1.0, 'physical WCS axis 1 step')
-            wcs_header.set('CTYPE2P', 'RAWY', 'physical WCS axis 2 type CCD col')
-            wcs_header.set('CUNIT2P', 'PIXEL', 'physical WCS axis 2 unit')
-            wcs_header.set('CRPIX2P', 1, 'reference CCD row')
-            wcs_header.set('CRVAL2P', cutout_lims[1, 0] + 1, 'value at reference CCD row')
-            wcs_header.set('CDELT2P', 1.0, 'physical WCS axis 2 step')
+            wcs_header.set("WCSNAMEP", "PHYSICAL", "name of world coordinate system alternate P")
+            wcs_header.set("WCSAXESP", 2, "number of WCS physical axes")
+            wcs_header.set("CTYPE1P", "RAWX", "physical WCS axis 1 type CCD col")
+            wcs_header.set("CUNIT1P", "PIXEL", "physical WCS axis 1 unit")
+            wcs_header.set("CRPIX1P", 1, "reference CCD column")
+            wcs_header.set("CRVAL1P", cutout_lims[0, 0] + 1, "value at reference CCD column")
+            wcs_header.set("CDELT1P", 1.0, "physical WCS axis 1 step")
+            wcs_header.set("CTYPE2P", "RAWY", "physical WCS axis 2 type CCD col")
+            wcs_header.set("CUNIT2P", "PIXEL", "physical WCS axis 2 unit")
+            wcs_header.set("CRPIX2P", 1, "reference CCD row")
+            wcs_header.set("CRVAL2P", cutout_lims[1, 0] + 1, "value at reference CCD row")
+            wcs_header.set("CDELT2P", 1.0, "physical WCS axis 2 step")
 
             return WCS(wcs_header)
 
 
-@deprecated_renamed_argument('correct_wcs', None, '1.0.0', warning_type=DeprecationWarning,
-                             message='`correct_wcs` is non-operational and will be removed in a future version.')
-def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str],
-             cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
-             correct_wcs: bool = False, extension: Optional[Union[int, List[int], Literal['all']]] = None,
-             single_outfile: bool = True, cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.',
-             memory_only: bool = False, fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round',
-             verbose=False, *, fsspec_kwargs: Optional[dict] = None) -> Union[str, List[str], List[HDUList]]:
+@deprecated_renamed_argument(
+    "correct_wcs",
+    None,
+    "1.0.0",
+    warning_type=DeprecationWarning,
+    message="`correct_wcs` is non-operational and will be removed in a future version.",
+)
+def fits_cut(
+    input_files: List[Union[str, Path, S3Path]],
+    coordinates: Union[SkyCoord, str],
+    cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
+    correct_wcs: bool = False,
+    extension: Optional[Union[int, List[int], Literal["all"]]] = None,
+    single_outfile: bool = True,
+    cutout_prefix: str = "cutout",
+    output_dir: Union[str, Path] = ".",
+    memory_only: bool = False,
+    fill_value: Union[int, float] = np.nan,
+    limit_rounding_method: str = "round",
+    verbose=False,
+    *,
+    fsspec_kwargs: Optional[dict] = None,
+) -> Union[str, List[str], List[HDUList]]:
     """
     Takes one or more FITS files with the same WCS/pointing, makes the same cutout in each file,
     and returns the result either in a single FITS file with one cutout per extension or in
@@ -682,8 +733,17 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
         If memory_only is True, a list of `~astropy.io.fit.HDUList` objects is returned instead of
         file name(s).
     """
-    fits_cutout = FITSCutout(input_files, coordinates, cutout_size, fill_value, limit_rounding_method,
-                             extension, single_outfile, verbose=verbose, fsspec_kwargs=fsspec_kwargs)
+    fits_cutout = FITSCutout(
+        input_files,
+        coordinates,
+        cutout_size,
+        fill_value,
+        limit_rounding_method,
+        extension,
+        single_outfile,
+        verbose=verbose,
+        fsspec_kwargs=fsspec_kwargs,
+    )
 
     if memory_only:
         return fits_cutout.fits_cutouts
@@ -692,14 +752,25 @@ def fits_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[Sky
     return cutout_paths[0] if len(cutout_paths) == 1 else cutout_paths
 
 
-def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str],
-            cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25, stretch: str = 'asinh',
-            minmax_percent: Optional[List[int]] = None, minmax_value: Optional[List[int]] = None,
-            invert: bool = False, img_format: str = '.jpg', colorize: bool = False,
-            cutout_prefix: str = 'cutout', output_dir: Union[str, Path] = '.',
-            extension: Optional[Union[int, List[int], Literal['all']]] = None, fill_value: Union[int, float] = np.nan,
-            limit_rounding_method: str = 'round', verbose=False, *, fsspec_kwargs: Optional[dict] = None
-            ) -> Union[str, List[str]]:
+def img_cut(
+    input_files: List[Union[str, Path, S3Path]],
+    coordinates: Union[SkyCoord, str],
+    cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
+    stretch: str = "asinh",
+    minmax_percent: Optional[List[int]] = None,
+    minmax_value: Optional[List[int]] = None,
+    invert: bool = False,
+    img_format: str = ".jpg",
+    colorize: bool = False,
+    cutout_prefix: str = "cutout",
+    output_dir: Union[str, Path] = ".",
+    extension: Optional[Union[int, List[int], Literal["all"]]] = None,
+    fill_value: Union[int, float] = np.nan,
+    limit_rounding_method: str = "round",
+    verbose=False,
+    *,
+    fsspec_kwargs: Optional[dict] = None,
+) -> Union[str, List[str]]:
     """
     Takes one or more fits files with the same WCS/pointing, makes the same cutout in each file,
     and returns the result either as a single color image or in individual image files.
@@ -767,9 +838,18 @@ def img_cut(input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyC
         the output filepaths.
     """
 
-    fits_cutout = FITSCutout(input_files, coordinates, cutout_size, fill_value, limit_rounding_method,
-                             extension, verbose=verbose, fsspec_kwargs=fsspec_kwargs)
+    fits_cutout = FITSCutout(
+        input_files,
+        coordinates,
+        cutout_size,
+        fill_value,
+        limit_rounding_method,
+        extension,
+        verbose=verbose,
+        fsspec_kwargs=fsspec_kwargs,
+    )
 
-    cutout_paths = fits_cutout.write_as_img(stretch, minmax_percent, minmax_value, invert, colorize, img_format,
-                                            output_dir, cutout_prefix)
+    cutout_paths = fits_cutout.write_as_img(
+        stretch, minmax_percent, minmax_value, invert, colorize, img_format, output_dir, cutout_prefix
+    )
     return cutout_paths

--- a/astrocut/fits_cutout.py
+++ b/astrocut/fits_cutout.py
@@ -365,26 +365,26 @@ class FITSCutout(ImageCutout):
 
             except OSError as err:
                 warnings.warn(
-                    f"Error {err} encountered when performing cutout on {file}, " f"extension {ind}, skipping...",
+                    f"Error {err} encountered when performing cutout on {file}, extension {ind}, skipping...",
                     DataWarning,
                 )
                 num_empty += 1
             except NoOverlapError:
                 warnings.warn(
-                    f"Cutout footprint does not overlap with data in {file}, " f"extension {ind}, skipping...",
+                    f"Cutout footprint does not overlap with data in {file}, extension {ind}, skipping...",
                     DataWarning,
                 )
                 num_empty += 1
             except InvalidQueryError:
                 warnings.warn(
-                    f"Cutout footprint does not overlap with data in {file}, " f"extension {ind}, skipping...",
+                    f"Cutout footprint does not overlap with data in {file}, extension {ind}, skipping...",
                     DataWarning,
                 )
                 num_empty += 1
             except ValueError as err:
                 if "Input position contains invalid values" in str(err):
                     warnings.warn(
-                        f"Cutout footprint does not overlap with data in {file}, " f"extension {ind}, skipping...",
+                        f"Cutout footprint does not overlap with data in {file}, extension {ind}, skipping...",
                         DataWarning,
                     )
                     num_empty += 1

--- a/astrocut/footprint_cutout.py
+++ b/astrocut/footprint_cutout.py
@@ -7,7 +7,7 @@ import astropy.units as u
 import fsspec
 import numpy as np
 from astropy.coordinates import SkyCoord
-from astropy.table import Table, Column
+from astropy.table import Column, Table
 from cachetools import TTLCache, cached
 from spherical_geometry.polygon import SphericalPolygon
 from spherical_geometry.vector import radec_to_vector
@@ -34,7 +34,7 @@ class FootprintCutout(Cutout, ABC):
         Method to use for rounding the cutout limits. Options are 'round', 'ceil', and 'floor'.
     sequence : int | list | None
         Default None. Sequence(s) from which to generate cutouts. Can provide a single
-        sequence number as an int or a list of sequence numbers. If not specified, 
+        sequence number as an int or a list of sequence numbers. If not specified,
         cutouts will be generated from all sequences that contain the cutout.
     verbose : bool
         If True, log messages are printed to the console.
@@ -45,10 +45,15 @@ class FootprintCutout(Cutout, ABC):
         Fetch the cloud files that contain the cutout and generate the cutouts.
     """
 
-    def __init__(self, coordinates: Union[SkyCoord, str], 
-                 cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]] = 25,
-                 fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round', 
-                 sequence: Union[int, List[int], None] = None, verbose: bool = False):
+    def __init__(
+        self,
+        coordinates: Union[SkyCoord, str],
+        cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]] = 25,
+        fill_value: Union[int, float] = np.nan,
+        limit_rounding_method: str = "round",
+        sequence: Union[int, List[int], None] = None,
+        verbose: bool = False,
+    ):
         super().__init__([], coordinates, cutout_size, fill_value, limit_rounding_method, verbose)
 
         # Assigning other attributes
@@ -63,7 +68,7 @@ class FootprintCutout(Cutout, ABC):
 
         This method is abstract and should be implemented in subclasses.
         """
-        raise NotImplementedError('Subclasses must implement this method.')
+        raise NotImplementedError("Subclasses must implement this method.")
 
     @staticmethod
     def _s_region_to_polygon(s_region: Column) -> Column:
@@ -74,7 +79,7 @@ class FootprintCutout(Cutout, ABC):
         Parameters
         ----------
         s_region : `~astropy.table.Column`
-            Column containing the s_region string. Example input: 'POLYGON 229.80771900 -75.17048500 
+            Column containing the s_region string. Example input: 'POLYGON 229.80771900 -75.17048500
             241.67788000 -63.95992300 269.94872000 -64.39276400 277.87862300 -75.57754400'
 
         Returns
@@ -82,6 +87,7 @@ class FootprintCutout(Cutout, ABC):
         polygon : `~astropy.table.Column`
             Column containing `~spherical_geometry.polygon.SphericalPolygon` objects representing each s_region.
         """
+
         def ind_sregion_to_polygon(s_reg):
             """
             Helper function to convert s_region string to a `~spherical_geometry.polygon.SphericalPolygon` object.
@@ -95,12 +101,12 @@ class FootprintCutout(Cutout, ABC):
             -------
             `~spherical_geometry.polygon.SphericalPolygon`
                 A SphericalPolygon object created from the provided coordinates.
-            
+
             Raises
             ------
             ValueError
                 If the S_REGION type is not 'POLYGON'.
-            
+
             """
             # Split input string into individual components
             sr_list = s_reg.strip().split()
@@ -108,7 +114,7 @@ class FootprintCutout(Cutout, ABC):
             # Extract the region type (first element of list)
             reg_type = sr_list[0].upper()
 
-            if reg_type == 'POLYGON':
+            if reg_type == "POLYGON":
                 # Extract RA and Dec values
                 # RAs are at odd indices
                 ras = np.array(sr_list[1::2], dtype=float)
@@ -122,10 +128,10 @@ class FootprintCutout(Cutout, ABC):
                 # Create SphericalPolygon object
                 return SphericalPolygon.from_radec(ras, decs)
             else:
-                raise ValueError(f'Unsupported s_region type: {reg_type}.')
+                raise ValueError(f"Unsupported s_region type: {reg_type}.")
 
         return np.vectorize(ind_sregion_to_polygon)(s_region)
-    
+
     @staticmethod
     def _ffi_intersect(ffi_list: Table, polygon: SphericalPolygon) -> np.ndarray:
         """
@@ -143,11 +149,12 @@ class FootprintCutout(Cutout, ABC):
         intersect : `~numpy.ndarray`
             Boolean array indicating whether each FFI intersects with the cutout.
         """
+
         def single_intersect(ffi, polygon):
             return ffi.intersects_poly(polygon)
 
-        return np.vectorize(single_intersect)(ffi_list['polygon'], polygon)
-    
+        return np.vectorize(single_intersect)(ffi_list["polygon"], polygon)
+
 
 @cached(cache=FFI_TTLCACHE, lock=Lock())
 def get_ffis(s3_footprint_cache: str) -> Table:
@@ -169,11 +176,11 @@ def get_ffis(s3_footprint_cache: str) -> Table:
         Table containing information about FFIs and their footprints.
     """
     # Open footprint file with fsspec
-    with fsspec.open(s3_footprint_cache, s3={'anon': True}) as f:
+    with fsspec.open(s3_footprint_cache, s3={"anon": True}) as f:
         ffis = json.load(f)
 
     # Compute spherical polygons
-    ffis['polygon'] = FootprintCutout._s_region_to_polygon(ffis['s_region'])
+    ffis["polygon"] = FootprintCutout._s_region_to_polygon(ffis["s_region"])
 
     # Convert to Astropy table
     ffis = Table(ffis)
@@ -185,7 +192,7 @@ def _crossmatch_point(ra: SkyCoord, dec: SkyCoord, all_ffis: Table) -> np.ndarra
     """
     Returns the indices of the Full Frame Images (FFIs) that contain the given RA and
     Dec coordinates by checking which FFI polygons contain the point.
-    
+
     Parameters
     ----------
     ra : SkyCoord
@@ -194,7 +201,7 @@ def _crossmatch_point(ra: SkyCoord, dec: SkyCoord, all_ffis: Table) -> np.ndarra
         Declination in degrees.
     all_ffis : `~astropy.table.Table`
         Table of FFIs to crossmatch with the point.
-        
+
     Returns
     -------
     ffi_inds : `~numpy.ndarray`
@@ -202,9 +209,9 @@ def _crossmatch_point(ra: SkyCoord, dec: SkyCoord, all_ffis: Table) -> np.ndarra
     """
     ffi_inds = []
     vector_coord = radec_to_vector(ra, dec)
-    for sector in np.unique(all_ffis['sequence_number']):
+    for sector in np.unique(all_ffis["sequence_number"]):
         # Returns a 2-long array where the first element is indexes and the 2nd element is empty
-        sector_ffi_inds = np.where(all_ffis['sequence_number'] == sector)[0]
+        sector_ffi_inds = np.where(all_ffis["sequence_number"] == sector)[0]
 
         for ind in sector_ffi_inds:
             if all_ffis[ind]["polygon"].contains_point(vector_coord):
@@ -213,8 +220,9 @@ def _crossmatch_point(ra: SkyCoord, dec: SkyCoord, all_ffis: Table) -> np.ndarra
     return np.array(ffi_inds, dtype=int)
 
 
-def _crossmatch_polygon(ra: SkyCoord, dec: SkyCoord, all_ffis: Table, px_size: np.ndarray,
-                        arcsec_per_px: int = 21) -> np.ndarray:
+def _crossmatch_polygon(
+    ra: SkyCoord, dec: SkyCoord, all_ffis: Table, px_size: np.ndarray, arcsec_per_px: int = 21
+) -> np.ndarray:
     """
     Returns the indices of the Full Frame Images (FFIs) that intersect with the given cutout footprint
     by checking which FFI polygons intersect with the cutout polygon.
@@ -258,14 +266,15 @@ def _crossmatch_polygon(ra: SkyCoord, dec: SkyCoord, all_ffis: Table, px_size: n
     cutout_fp = SphericalPolygon.from_radec(ras, decs, center=(ra, dec))
 
     # Find indices of FFIs that intersect with the cutout
-    ffi_inds = np.vectorize(lambda ffi: ffi.intersects_poly(cutout_fp))(all_ffis['polygon'])
+    ffi_inds = np.vectorize(lambda ffi: ffi.intersects_poly(cutout_fp))(all_ffis["polygon"])
     ffi_inds = FootprintCutout._ffi_intersect(all_ffis, cutout_fp)
 
     return ffi_inds
 
 
-def ra_dec_crossmatch(all_ffis: Table, coordinates: Union[SkyCoord, str], cutout_size, 
-                      arcsec_per_px: int = 21) -> Table:
+def ra_dec_crossmatch(
+    all_ffis: Table, coordinates: Union[SkyCoord, str], cutout_size, arcsec_per_px: int = 21
+) -> Table:
     """
     Returns the Full Frame Images (FFIs) whose footprints overlap with a cutout of a given position and size.
 
@@ -286,8 +295,8 @@ def ra_dec_crossmatch(all_ffis: Table, coordinates: Union[SkyCoord, str], cutout
         units of pixels. `~astropy.units.Quantity` objects must be in pixel or
         angular units.
 
-        If a cutout size of zero is provided, the function will return FFIs that contain 
-        the exact RA and Dec position. If a non-zero cutout size is provided, the function 
+        If a cutout size of zero is provided, the function will return FFIs that contain
+        the exact RA and Dec position. If a non-zero cutout size is provided, the function
         will return FFIs whose footprints overlap with the cutout area.
     arcsec_per_px : int, optional
         Default 21. The number of arcseconds per pixel in an image. Used to determine
@@ -302,9 +311,9 @@ def ra_dec_crossmatch(all_ffis: Table, coordinates: Union[SkyCoord, str], cutout
     # Convert coordinates to SkyCoord
     if not isinstance(coordinates, SkyCoord):
         try:
-            coordinates = SkyCoord(coordinates, unit='deg')
+            coordinates = SkyCoord(coordinates, unit="deg")
         except ValueError as e:
-            raise InvalidInputError(f'Invalid coordinates input: {e}')
+            raise InvalidInputError(f"Invalid coordinates input: {e}")
     ra, dec = coordinates.ra, coordinates.dec
 
     px_size = np.zeros(2, dtype=object)

--- a/astrocut/image_cutout.py
+++ b/astrocut/image_cutout.py
@@ -234,7 +234,7 @@ class ImageCutout(Cutout, ABC):
         except ValueError as e:
             output_format = Path(file_path).suffix
             warnings.warn(
-                f"Cutout could not be saved in {output_format} format: {e}. " "Please try a different output format.",
+                f"Cutout could not be saved in {output_format} format: {e}. Please try a different output format.",
                 DataWarning,
             )
             return False
@@ -414,7 +414,7 @@ class ImageCutout(Cutout, ABC):
             transform = LinearStretch()
         else:
             raise InvalidInputError(
-                f"Stretch {stretch} is not supported!" "Valid options are: asinh, sinh, sqrt, log, linear."
+                f"Stretch {stretch} is not supported!Valid options are: asinh, sinh, sqrt, log, linear."
             )
 
         # Adding the scaling to the transform

--- a/astrocut/image_cutout.py
+++ b/astrocut/image_cutout.py
@@ -1,20 +1,27 @@
-from abc import abstractmethod, ABC
-from pathlib import Path
-from typing import List, Optional, Union, Tuple
 import warnings
-
-from astropy.coordinates import SkyCoord
-from astropy.units import Quantity
-from astropy.visualization import (SqrtStretch, LogStretch, AsinhStretch, SinhStretch, LinearStretch,
-                                   MinMaxInterval, ManualInterval, AsymmetricPercentileInterval)
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.units import Quantity
+from astropy.visualization import (
+    AsinhStretch,
+    AsymmetricPercentileInterval,
+    LinearStretch,
+    LogStretch,
+    ManualInterval,
+    MinMaxInterval,
+    SinhStretch,
+    SqrtStretch,
+)
 from PIL import Image
 from s3path import S3Path
 
 from . import log
-from .exceptions import DataWarning, InputWarning, InvalidInputError
 from .cutout import Cutout
+from .exceptions import DataWarning, InputWarning, InvalidInputError
 
 
 class ImageCutout(Cutout, ABC):
@@ -56,10 +63,15 @@ class ImageCutout(Cutout, ABC):
         Apply given stretch and scaling to an image array.
     """
 
-    def __init__(self, input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
-                 cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
-                 fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round',
-                 verbose: bool = False):
+    def __init__(
+        self,
+        input_files: List[Union[str, Path, S3Path]],
+        coordinates: Union[SkyCoord, str],
+        cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
+        fill_value: Union[int, float] = np.nan,
+        limit_rounding_method: str = "round",
+        verbose: bool = False,
+    ):
         super().__init__(input_files, coordinates, cutout_size, fill_value, limit_rounding_method, verbose)
 
         # Stores the image cutouts as PIL.Image objects
@@ -76,10 +88,15 @@ class ImageCutout(Cutout, ABC):
         if not self._image_cutouts:
             self._image_cutouts = self.get_image_cutouts()
         return self._image_cutouts
-    
-    def get_image_cutouts(self, stretch: Optional[str] = 'asinh', minmax_percent: Optional[List[int]] = None, 
-                          minmax_value: Optional[List[int]] = None, invert: Optional[bool] = False, 
-                          colorize: Optional[bool] = False) -> List[Image.Image]:
+
+    def get_image_cutouts(
+        self,
+        stretch: Optional[str] = "asinh",
+        minmax_percent: Optional[List[int]] = None,
+        minmax_value: Optional[List[int]] = None,
+        invert: Optional[bool] = False,
+        colorize: Optional[bool] = False,
+    ) -> List[Image.Image]:
         """
         Get the cutouts as `~PIL.Image` objects given certain normalization parameters. This method also sets
         the `image_cutouts` attribute.
@@ -90,7 +107,7 @@ class ImageCutout(Cutout, ABC):
             Optional, default 'asinh'. The stretch to apply to the image array.
             Valid values are: asinh, sinh, sqrt, log, linear
         minmax_percent : array
-            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric) 
+            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric)
             when scaling the image. The format is [lower percentile, upper percentile], where pixel
             values below the lower percentile and above the upper percentile are clipped.
             Only one of minmax_percent and minmax_value should be specified.
@@ -110,9 +127,9 @@ class ImageCutout(Cutout, ABC):
             List of `~PIL.Image` objects representing the cutouts.
         """
         # Validate the stretch parameter
-        valid_stretches = ['asinh', 'sinh', 'sqrt', 'log', 'linear']
+        valid_stretches = ["asinh", "sinh", "sqrt", "log", "linear"]
         if not isinstance(stretch, str) or stretch.lower() not in valid_stretches:
-            raise InvalidInputError(f'Stretch {stretch} is not recognized. Valid options are {valid_stretches}.')
+            raise InvalidInputError(f"Stretch {stretch} is not recognized. Valid options are {valid_stretches}.")
         stretch = stretch.lower()
 
         # Apply default scaling for image outputs
@@ -124,10 +141,14 @@ class ImageCutout(Cutout, ABC):
 
             # Check for the correct number of cutouts
             if len(all_cutouts) < 3:
-                raise InvalidInputError(('Color cutouts require 3 input images (RGB).'
-                                         'If you supplied 3 images one of the cutouts may have been empty.'))
+                raise InvalidInputError(
+                    (
+                        "Color cutouts require 3 input images (RGB)."
+                        "If you supplied 3 images one of the cutouts may have been empty."
+                    )
+                )
             if len(all_cutouts) > 3:
-                warnings.warn('Too many inputs for a color cutout, only the first three will be used.', InputWarning)
+                warnings.warn("Too many inputs for a color cutout, only the first three will be used.", InputWarning)
                 all_cutouts = all_cutouts[:3]
 
             img_arrs = []
@@ -148,7 +169,7 @@ class ImageCutout(Cutout, ABC):
             self._image_cutouts = image_cutouts
 
         return self._image_cutouts
-    
+
     @abstractmethod
     def _cutout_file(self, file: Union[str, Path, S3Path]):
         """
@@ -156,7 +177,7 @@ class ImageCutout(Cutout, ABC):
 
         This method is abstract and should be defined in subclasses.
         """
-        raise NotImplementedError('Subclasses must implement this method.')
+        raise NotImplementedError("Subclasses must implement this method.")
 
     @abstractmethod
     def cutout(self):
@@ -165,8 +186,8 @@ class ImageCutout(Cutout, ABC):
 
         This method is abstract and should be defined in subclasses.
         """
-        raise NotImplementedError('Subclasses must implement this method.')
-    
+        raise NotImplementedError("Subclasses must implement this method.")
+
     def _parse_output_format(self, output_format: str) -> str:
         """
         Parse the output format string and return it in a standardized format.
@@ -183,12 +204,12 @@ class ImageCutout(Cutout, ABC):
         """
         # Put format in standard format
         out_lower = output_format.lower()
-        output_format = f'.{out_lower}' if not output_format.startswith('.') else out_lower
-    
+        output_format = f".{out_lower}" if not output_format.startswith(".") else out_lower
+
         # Error if the output format is not supported
         if output_format not in Image.registered_extensions().keys():
-            raise InvalidInputError(f'Output format {output_format} is not supported.')
-        
+            raise InvalidInputError(f"Output format {output_format} is not supported.")
+
         return output_format
 
     def _save_img_to_file(self, im: Image, file_path: str) -> bool:
@@ -212,24 +233,36 @@ class ImageCutout(Cutout, ABC):
             return True
         except ValueError as e:
             output_format = Path(file_path).suffix
-            warnings.warn(f'Cutout could not be saved in {output_format} format: {e}. '
-                          'Please try a different output format.', DataWarning)
+            warnings.warn(
+                f"Cutout could not be saved in {output_format} format: {e}. " "Please try a different output format.",
+                DataWarning,
+            )
             return False
         except KeyError as e:
             output_format = Path(file_path).suffix
-            warnings.warn(f'Cutout could not be saved in {output_format} format due to a KeyError: {e}. '
-                          'Please try a different output format.', DataWarning)
+            warnings.warn(
+                f"Cutout could not be saved in {output_format} format due to a KeyError: {e}. "
+                "Please try a different output format.",
+                DataWarning,
+            )
             return False
         except OSError as e:
-            warnings.warn(f'Cutout could not be saved: {e}', DataWarning)
+            warnings.warn(f"Cutout could not be saved: {e}", DataWarning)
             return False
 
-    def write_as_img(self, stretch: Optional[str] = 'asinh', minmax_percent: Optional[List[int]] = None, 
-                     minmax_value: Optional[List[int]] = None, invert: Optional[bool] = False, 
-                     colorize: Optional[bool] = False, output_format: str = '.jpg', 
-                     output_dir: Union[str, Path] = '.', cutout_prefix: str = 'cutout') -> Union[str, List[str]]:
+    def write_as_img(
+        self,
+        stretch: Optional[str] = "asinh",
+        minmax_percent: Optional[List[int]] = None,
+        minmax_value: Optional[List[int]] = None,
+        invert: Optional[bool] = False,
+        colorize: Optional[bool] = False,
+        output_format: str = ".jpg",
+        output_dir: Union[str, Path] = ".",
+        cutout_prefix: str = "cutout",
+    ) -> Union[str, List[str]]:
         """
-        Write the cutout to memory or to a file in an image format. If colorize is set, the first 3 cutouts 
+        Write the cutout to memory or to a file in an image format. If colorize is set, the first 3 cutouts
         will be combined into a single RGB image. Otherwise, each cutout will be written to a separate file.
 
         Parameters
@@ -238,7 +271,7 @@ class ImageCutout(Cutout, ABC):
             Optional, default 'asinh'. The stretch to apply to the image array.
             Valid values are: asinh, sinh, sqrt, log, linear
         minmax_percent : array
-            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric) 
+            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric)
             when scaling the image. The format is [lower percentile, upper percentile], where pixel
             values below the lower percentile and above the upper percentile are clipped.
             Only one of minmax_percent and minmax_value shoul be specified.
@@ -280,13 +313,13 @@ class ImageCutout(Cutout, ABC):
         # Set up output files and write them
         if colorize:  # Combine first three cutouts into a single RGB image
             # Write the colorized cutout to disk
-            filename = '{}_{:.7f}_{:.7f}_{}-x-{}_astrocut{}'.format(
+            filename = "{}_{:.7f}_{:.7f}_{}-x-{}_astrocut{}".format(
                 cutout_prefix,
                 self._coordinates.ra.value,
                 self._coordinates.dec.value,
-                str(self._cutout_size[0]).replace(' ', ''), 
-                str(self._cutout_size[1]).replace(' ', ''),
-                output_format
+                str(self._cutout_size[0]).replace(" ", ""),
+                str(self._cutout_size[1]).replace(" ", ""),
+                output_format,
             )
 
             # Attempt to write image to file
@@ -299,15 +332,16 @@ class ImageCutout(Cutout, ABC):
             cutout_paths = []  # Store the paths of the written cutout files
             for i, file in enumerate(self.cutouts_by_file):
                 # Write individual cutouts to disk
-                filename = '{}_{:.7f}_{:.7f}_{}-x-{}_astrocut_{}{}'.format(
+                filename = "{}_{:.7f}_{:.7f}_{}-x-{}_astrocut_{}{}".format(
                     Path(file).stem,
                     self._coordinates.ra.value,
                     self._coordinates.dec.value,
-                    str(self._cutout_size[0]).replace(' ', ''), 
-                    str(self._cutout_size[1]).replace(' ', ''),
+                    str(self._cutout_size[0]).replace(" ", ""),
+                    str(self._cutout_size[1]).replace(" ", ""),
                     i,
-                    output_format)
-                
+                    output_format,
+                )
+
                 # Attempt to write image to file
                 cutout_path = Path(output_dir, filename).as_posix()
                 success = self._save_img_to_file(image_cutouts[i], cutout_path)
@@ -318,12 +352,17 @@ class ImageCutout(Cutout, ABC):
                     cutout_path = None
                 cutout_paths.append(cutout_path)
 
-        log.debug('Cutout filepaths: {}'.format(cutout_paths))
+        log.debug("Cutout filepaths: {}".format(cutout_paths))
         return cutout_paths
-    
+
     @staticmethod
-    def normalize_img(img_arr: np.ndarray, stretch: str = 'asinh', minmax_percent: Optional[List[int]] = None, 
-                      minmax_value: Optional[List[int]] = None, invert: bool = False) -> np.ndarray:
+    def normalize_img(
+        img_arr: np.ndarray,
+        stretch: str = "asinh",
+        minmax_percent: Optional[List[int]] = None,
+        minmax_value: Optional[List[int]] = None,
+        invert: bool = False,
+    ) -> np.ndarray:
         """
         Apply given stretch and scaling to an image array.
 
@@ -335,7 +374,7 @@ class ImageCutout(Cutout, ABC):
             Optional, default 'asinh'. The stretch to apply to the image array.
             Valid values are: asinh, sinh, sqrt, log, linear
         minmax_percent : array
-            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric) 
+            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric)
             when scaling the image. The format is [lower percentile, upper percentile], where pixel
             values below the lower percentile and above the upper percentile are clipped.
             Only one of minmax_percent and minmax_value shoul be specified.
@@ -360,30 +399,32 @@ class ImageCutout(Cutout, ABC):
 
         # Check if the input image array is empty
         if img_arr.size == 0:
-            raise InvalidInputError('Input image array is empty.')
+            raise InvalidInputError("Input image array is empty.")
 
         # Setting up the transform with the stretch
-        if stretch == 'asinh':
+        if stretch == "asinh":
             transform = AsinhStretch()
-        elif stretch == 'sinh':
+        elif stretch == "sinh":
             transform = SinhStretch()
-        elif stretch == 'sqrt':
+        elif stretch == "sqrt":
             transform = SqrtStretch()
-        elif stretch == 'log':
+        elif stretch == "log":
             transform = LogStretch()
-        elif stretch == 'linear':
+        elif stretch == "linear":
             transform = LinearStretch()
         else:
-            raise InvalidInputError(f'Stretch {stretch} is not supported!'
-                                    'Valid options are: asinh, sinh, sqrt, log, linear.')
+            raise InvalidInputError(
+                f"Stretch {stretch} is not supported!" "Valid options are: asinh, sinh, sqrt, log, linear."
+            )
 
         # Adding the scaling to the transform
         if minmax_percent is not None:
             transform += AsymmetricPercentileInterval(*minmax_percent)
-            
+
             if minmax_value is not None:
-                warnings.warn('Both minmax_percent and minmax_value are set, minmax_value will be ignored.', 
-                              InputWarning)
+                warnings.warn(
+                    "Both minmax_percent and minmax_value are set, minmax_value will be ignored.", InputWarning
+                )
         elif minmax_value is not None:
             transform += ManualInterval(*minmax_value)
         else:  # Default, scale the entire image range to [0,1]
@@ -398,10 +439,15 @@ class ImageCutout(Cutout, ABC):
         np.subtract(255, norm_img, out=norm_img, where=invert)
 
         return norm_img
-    
 
-def normalize_img(img_arr: np.ndarray, stretch: str = 'asinh', minmax_percent: Optional[List[int]] = None, 
-                  minmax_value: Optional[List[int]] = None, invert: bool = False) -> np.ndarray:
+
+def normalize_img(
+    img_arr: np.ndarray,
+    stretch: str = "asinh",
+    minmax_percent: Optional[List[int]] = None,
+    minmax_value: Optional[List[int]] = None,
+    invert: bool = False,
+) -> np.ndarray:
     """
     Apply given stretch and scaling to an image array.
 
@@ -413,7 +459,7 @@ def normalize_img(img_arr: np.ndarray, stretch: str = 'asinh', minmax_percent: O
         Optional, default 'asinh'. The stretch to apply to the image array.
         Valid values are: asinh, sinh, sqrt, log, linear
     minmax_percent : array
-        Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric) 
+        Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric)
         when scaling the image. The format is [lower percentile, upper percentile], where pixel
         values below the lower percentile and above the upper percentile are clipped.
         Only one of minmax_percent and minmax_value shoul be specified.
@@ -430,8 +476,6 @@ def normalize_img(img_arr: np.ndarray, stretch: str = 'asinh', minmax_percent: O
     response : array
         The normalized image array, in the form in an integer arrays with values in the range 0-255.
     """
-    return ImageCutout.normalize_img(img_arr=img_arr,
-                                     stretch=stretch,
-                                     minmax_percent=minmax_percent,
-                                     minmax_value=minmax_value,
-                                     invert=invert)
+    return ImageCutout.normalize_img(
+        img_arr=img_arr, stretch=stretch, minmax_percent=minmax_percent, minmax_value=minmax_value, invert=invert
+    )

--- a/astrocut/tess_cube_cutout.py
+++ b/astrocut/tess_cube_cutout.py
@@ -1,7 +1,7 @@
+import warnings
 from pathlib import Path
 from time import monotonic
-from typing import List, Union, Tuple, Literal
-import warnings
+from typing import List, Literal, Tuple, Union
 
 import astropy.units as u
 import numpy as np
@@ -46,7 +46,7 @@ class TessCubeCutout(CubeCutout):
     Attributes
     ----------
     cutouts_by_file : dict
-        Dictionary where each key is an input cube filename and its corresponding value is the resulting cutout as a 
+        Dictionary where each key is an input cube filename and its corresponding value is the resulting cutout as a
         ``CubeCutoutInstance`` object.
     cutouts : list
         List of cutout objects.
@@ -62,69 +62,81 @@ class TessCubeCutout(CubeCutout):
         Write the cutouts to target pixel files.
     """
 
-    @deprecated_renamed_argument('product', None, since='1.1.0', message='The `product` argument is deprecated and '
-                                 'will be removed in a future version. Astrocut will only support cutouts from '
-                                 'SPOC products.')
-    def __init__(self, input_files: List[Union[str, Path, S3Path]], coordinates: Union[SkyCoord, str], 
-                 cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]] = 25,
-                 fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round', 
-                 threads: Union[int, Literal['auto']] = 1, product: str = 'SPOC', verbose: bool = False):
+    @deprecated_renamed_argument(
+        "product",
+        None,
+        since="1.1.0",
+        message="The `product` argument is deprecated and "
+        "will be removed in a future version. Astrocut will only support cutouts from "
+        "SPOC products.",
+    )
+    def __init__(
+        self,
+        input_files: List[Union[str, Path, S3Path]],
+        coordinates: Union[SkyCoord, str],
+        cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]] = 25,
+        fill_value: Union[int, float] = np.nan,
+        limit_rounding_method: str = "round",
+        threads: Union[int, Literal["auto"]] = 1,
+        product: str = "SPOC",
+        verbose: bool = False,
+    ):
         super().__init__(input_files, coordinates, cutout_size, fill_value, limit_rounding_method, threads, verbose)
 
         # Validate and set the product
-        if product.upper() not in ['SPOC', 'TICA']:
+        if product.upper() not in ["SPOC", "TICA"]:
             raise InvalidInputError('Product for TESS cube cutouts must be either "SPOC" or "TICA".')
         self._product = product.upper()
 
         # Whether the cube has uncertainty data
-        self._has_uncertainty = self._product == 'SPOC'
+        self._has_uncertainty = self._product == "SPOC"
 
         # Keyword corresponding to WCS axis
-        self._wcs_axes_keyword = 'CTYPE2'
+        self._wcs_axes_keyword = "CTYPE2"
 
         # Expected value for the WCS axis keyword
-        self._wcs_axes_value = 'DEC--TAN-SIP'
+        self._wcs_axes_value = "DEC--TAN-SIP"
 
         # Keywords to skip when adding to the cutout WCS header
         # These are TICA-specific image keywords that are specific to a single FFI or just not helpful
-        self._skip_kwds = ['TIME', 'EXPTIME', 'FILTER']
+        self._skip_kwds = ["TIME", "EXPTIME", "FILTER"]
 
         # Extra keywords from the FFI image headers in SPOC (TESS-specific)
         # These are applied to both SPOC and TICA cutouts for consistency.
         self._img_kwds = {
-            'BACKAPP': [None, 'background is subtracted'],
-            'CDPP0_5': [None, 'RMS CDPP on 0.5-hr time scales'],
-            'CDPP1_0': [None, 'RMS CDPP on 1.0-hr time scales'],
-            'CDPP2_0': [None, 'RMS CDPP on 2.0-hr time scales'],
-            'CROWDSAP': [None, 'Ratio of target flux to total flux in op. ap.'],
-            'DEADAPP': [None, 'deadtime applied'],
-            'DEADC': [None, 'deadtime correction'],
-            'EXPOSURE': [None, '[d] time on source'],
-            'FLFRCSAP': [None, 'Frac. of target flux w/in the op. aperture'],
-            'FRAMETIM': [None, '[s] frame time [INT_TIME + READTIME]'],
-            'FXDOFF': [None, 'compression fixed offset'],
-            'GAINA': [None, '[electrons/count] CCD output A gain'],
-            'GAINB': [None, '[electrons/count] CCD output B gain'],
-            'GAINC': [None, '[electrons/count] CCD output C gain'],
-            'GAIND': [None, '[electrons/count] CCD output D gain'],
-            'INT_TIME': [None, '[s] photon accumulation time per frame'],
-            'LIVETIME': [None, '[d] TELAPSE multiplied by DEADC'],
-            'MEANBLCA': [None, '[count] FSW mean black level CCD output A'],
-            'MEANBLCB': [None, '[count] FSW mean black level CCD output B'],
-            'MEANBLCC': [None, '[count] FSW mean black level CCD output C'],
-            'MEANBLCD': [None, '[count] FSW mean black level CCD output D'],
-            'NREADOUT': [None, 'number of read per cadence'],
-            'NUM_FRM': [None, 'number of frames per time stamp'],
-            'READNOIA': [None, '[electrons] read noise CCD output A'],
-            'READNOIB': [None, '[electrons] read noise CCD output B'],
-            'READNOIC': [None, '[electrons] read noise CCD output C'],
-            'READNOID': [None, '[electrons] read noise CCD output D'],
-            'READTIME': [None, '[s] readout time per frame'],
-            'TIERRELA': [None, '[d] relative time error'],
-            'TIMEDEL': [None, '[d] time resolution of data'],
-            'TIMEPIXR': [None, 'bin time beginning=0 middle=0.5 end=1'],
-            'TMOFST11': [None, '(s) readout delay for camera 1 and ccd 1'],
-            'VIGNAPP': [None, 'vignetting or collimator correction applied'],
+            "BACKAPP": [None, "background is subtracted"],
+            "CDPP0_5": [None, "RMS CDPP on 0.5-hr time scales"],
+            "CDPP1_0": [None, "RMS CDPP on 1.0-hr time scales"],
+            "CDPP2_0": [None, "RMS CDPP on 2.0-hr time scales"],
+            "CROWDSAP": [None, "Ratio of target flux to total flux in op. ap."],
+            "DEADAPP": [None, "deadtime applied"],
+            "DEADC": [None, "deadtime correction"],
+            "EXPOSURE": [None, "[d] time on source"],
+            "FLFRCSAP": [None, "Frac. of target flux w/in the op. aperture"],
+            "FRAMETIM": [None, "[s] frame time [INT_TIME + READTIME]"],
+            "FXDOFF": [None, "compression fixed offset"],
+            "GAINA": [None, "[electrons/count] CCD output A gain"],
+            "GAINB": [None, "[electrons/count] CCD output B gain"],
+            "GAINC": [None, "[electrons/count] CCD output C gain"],
+            "GAIND": [None, "[electrons/count] CCD output D gain"],
+            "INT_TIME": [None, "[s] photon accumulation time per frame"],
+            "LIVETIME": [None, "[d] TELAPSE multiplied by DEADC"],
+            "MEANBLCA": [None, "[count] FSW mean black level CCD output A"],
+            "MEANBLCB": [None, "[count] FSW mean black level CCD output B"],
+            "MEANBLCC": [None, "[count] FSW mean black level CCD output C"],
+            "MEANBLCD": [None, "[count] FSW mean black level CCD output D"],
+            "NREADOUT": [None, "number of read per cadence"],
+            "NUM_FRM": [None, "number of frames per time stamp"],
+            "READNOIA": [None, "[electrons] read noise CCD output A"],
+            "READNOIB": [None, "[electrons] read noise CCD output B"],
+            "READNOIC": [None, "[electrons] read noise CCD output C"],
+            "READNOID": [None, "[electrons] read noise CCD output D"],
+            "READTIME": [None, "[s] readout time per frame"],
+            "TIERRELA": [None, "[d] relative time error"],
+            "TIMEDEL": [None, "[d] time resolution of data"],
+            "TIMEPIXR": [None, "bin time beginning=0 middle=0.5 end=1"],
+            "TMOFST11": [None, "(s) readout delay for camera 1 and ccd 1"],
+            "VIGNAPP": [None, "vignetting or collimator correction applied"],
         }
 
         # Dictionary to hold TPF objects by filename
@@ -139,7 +151,7 @@ class TessCubeCutout(CubeCutout):
         Return the cutouts as a list of `astropy.io.fits.HDUList` target pixel file objects.
         """
         return list(self.tpf_cutouts_by_file.values())
-    
+
     def _get_cutout_wcs_dict(self, cutout_wcs: WCS, cutout_lims: np.ndarray) -> dict:
         """
         Create a dictionary of WCS keywords for the cutout.
@@ -152,54 +164,54 @@ class TessCubeCutout(CubeCutout):
             The WCS object for the cutout.
         cutout_lims : `~numpy.ndarray`
             The limits of the cutout in pixel coordinates.
-        
+
         Returns
         -------
         cutout_wcs_dict : dict
-            Cutout WCS column header keywords as dictionary of 
+            Cutout WCS column header keywords as dictionary of
             ``{<kwd format string>: [value, desc]} pairs.``
         """
         wcs_header = cutout_wcs.to_header()
-        wcs_axes = wcs_header.get('WCSAXES', 2)  # Default to 2 if missing
+        wcs_axes = wcs_header.get("WCSAXES", 2)  # Default to 2 if missing
 
         # Create the cutout WCS dictionary
         cutout_wcs_dict = {
             # Number of axes
-            'WCAX{}': [wcs_axes, 'Number of WCS axes'],
+            "WCAX{}": [wcs_axes, "Number of WCS axes"],
             # Celestial WCS Keywords
-            '1CTYP{}': [wcs_header['CTYPE1'], 'right ascension coordinate type'],
-            '2CTYP{}': [wcs_header['CTYPE2'], 'declination coordinate type'],
-            '1CRPX{}': [wcs_header['CRPIX1'], '[pixel] reference pixel along image axis 1'],
-            '2CRPX{}': [wcs_header['CRPIX2'], '[pixel] reference pixel along image axis 2'],
-            '1CRVL{}': [wcs_header['CRVAL1'], '[deg] right ascension at reference pixel'],
-            '2CRVL{}': [wcs_header['CRVAL2'], '[deg] declination at reference pixel'],
-            '1CUNI{}': [wcs_header['CUNIT1'], 'physical unit in column dimension'],
-            '2CUNI{}': [wcs_header['CUNIT2'], 'physical unit in row dimension'],
-            '1CDLT{}': [wcs_header['CDELT1'], '[deg] pixel scale in RA dimension'],
-            '2CDLT{}': [wcs_header['CDELT1'], '[deg] pixel scale in DEC dimension'],
+            "1CTYP{}": [wcs_header["CTYPE1"], "right ascension coordinate type"],
+            "2CTYP{}": [wcs_header["CTYPE2"], "declination coordinate type"],
+            "1CRPX{}": [wcs_header["CRPIX1"], "[pixel] reference pixel along image axis 1"],
+            "2CRPX{}": [wcs_header["CRPIX2"], "[pixel] reference pixel along image axis 2"],
+            "1CRVL{}": [wcs_header["CRVAL1"], "[deg] right ascension at reference pixel"],
+            "2CRVL{}": [wcs_header["CRVAL2"], "[deg] declination at reference pixel"],
+            "1CUNI{}": [wcs_header["CUNIT1"], "physical unit in column dimension"],
+            "2CUNI{}": [wcs_header["CUNIT2"], "physical unit in row dimension"],
+            "1CDLT{}": [wcs_header["CDELT1"], "[deg] pixel scale in RA dimension"],
+            "2CDLT{}": [wcs_header["CDELT1"], "[deg] pixel scale in DEC dimension"],
             # Coordinate transformation matrix (PC) keywords
-            '11PC{}': [wcs_header['PC1_1'], 'Coordinate transformation matrix element'],
-            '12PC{}': [wcs_header['PC1_2'], 'Coordinate transformation matrix element'],
-            '21PC{}': [wcs_header['PC2_1'], 'Coordinate transformation matrix element'],
-            '22PC{}': [wcs_header['PC2_2'], 'Coordinate transformation matrix element'],
+            "11PC{}": [wcs_header["PC1_1"], "Coordinate transformation matrix element"],
+            "12PC{}": [wcs_header["PC1_2"], "Coordinate transformation matrix element"],
+            "21PC{}": [wcs_header["PC2_1"], "Coordinate transformation matrix element"],
+            "22PC{}": [wcs_header["PC2_2"], "Coordinate transformation matrix element"],
             # Physical keywords
-            'WCSN{}P': ['PHYSICAL', 'table column WCS name'],
-            'WCAX{}P': [2, 'table column physical WCS dimensions'],
-            '1CTY{}P': ['RAWX', 'table column physical WCS axis 1 type, CCD col'],
-            '2CTY{}P': ['RAWY', 'table column physical WCS axis 2 type, CCD row'],
-            '1CUN{}P': ['PIXEL', 'table column physical WCS axis 1 unit'],
-            '2CUN{}P': ['PIXEL', 'table column physical WCS axis 2 unit'],
-            '1CRV{}P': [cutout_lims[0, 0] + 1, 'table column physical WCS ax 1 ref value'],
-            '2CRV{}P': [cutout_lims[1, 0] + 1, 'table column physical WCS ax 2 ref value'],
+            "WCSN{}P": ["PHYSICAL", "table column WCS name"],
+            "WCAX{}P": [2, "table column physical WCS dimensions"],
+            "1CTY{}P": ["RAWX", "table column physical WCS axis 1 type, CCD col"],
+            "2CTY{}P": ["RAWY", "table column physical WCS axis 2 type, CCD row"],
+            "1CUN{}P": ["PIXEL", "table column physical WCS axis 1 unit"],
+            "2CUN{}P": ["PIXEL", "table column physical WCS axis 2 unit"],
+            "1CRV{}P": [cutout_lims[0, 0] + 1, "table column physical WCS ax 1 ref value"],
+            "2CRV{}P": [cutout_lims[1, 0] + 1, "table column physical WCS ax 2 ref value"],
             # TODO: can we calculate these? or are they fixed?
-            '1CDL{}P': [1.0, 'table column physical WCS a1 step'],    
-            '2CDL{}P': [1.0, 'table column physical WCS a2 step'],
-            '1CRP{}P': [1, 'table column physical WCS a1 reference'],
-            '2CRP{}P': [1, 'table column physical WCS a2 reference'],
+            "1CDL{}P": [1.0, "table column physical WCS a1 step"],
+            "2CDL{}P": [1.0, "table column physical WCS a2 step"],
+            "1CRP{}P": [1, "table column physical WCS a1 reference"],
+            "2CRP{}P": [1, "table column physical WCS a2 reference"],
         }
 
         return cutout_wcs_dict
-    
+
     def _update_primary_header(self, primary_header: fits.Header):
         """
         Updates the primary header of the cutout target pixel file.
@@ -214,104 +226,154 @@ class TessCubeCutout(CubeCutout):
             The primary header from the cube file that will be modified in place for the cutout.
         """
         # Add cutout-specific metadata
-        primary_header.update({
-            'CREATOR': ('astrocut', 'software used to produce this file'),
-            'PROCVER': (__version__, 'software version'),
-            'FFI_TYPE': (self._product, 'the FFI type used to make the cutouts'),
-            'RA_OBJ': (self._coordinates.ra.deg, '[deg] right ascension'),
-            'DEC_OBJ': (self._coordinates.dec.deg, '[deg] declination'),
-            'TIMEREF': ('SOLARSYSTEM' if self._product == 'SPOC' else None, 
-                        'barycentric correction applied to times'),
-            'TASSIGN': ('SPACECRAFT' if self._product == 'SPOC' else None, 
-                        'where time is assigned'),
-            'TIMESYS': ('TDB', 'time system is Barycentric Dynamical Time (TDB)'),
-            'BJDREFI': (2457000, 'integer part of BTJD reference date'),
-            'BJDREFF': (0.00000000, 'fraction of the day in BTJD reference date'),
-            'TIMEUNIT': ('d', 'time unit for TIME, TSTART, and TSTOP')
-        })
+        primary_header.update(
+            {
+                "CREATOR": ("astrocut", "software used to produce this file"),
+                "PROCVER": (__version__, "software version"),
+                "FFI_TYPE": (self._product, "the FFI type used to make the cutouts"),
+                "RA_OBJ": (self._coordinates.ra.deg, "[deg] right ascension"),
+                "DEC_OBJ": (self._coordinates.dec.deg, "[deg] declination"),
+                "TIMEREF": (
+                    "SOLARSYSTEM" if self._product == "SPOC" else None,
+                    "barycentric correction applied to times",
+                ),
+                "TASSIGN": ("SPACECRAFT" if self._product == "SPOC" else None, "where time is assigned"),
+                "TIMESYS": ("TDB", "time system is Barycentric Dynamical Time (TDB)"),
+                "BJDREFI": (2457000, "integer part of BTJD reference date"),
+                "BJDREFF": (0.00000000, "fraction of the day in BTJD reference date"),
+                "TIMEUNIT": ("d", "time unit for TIME, TSTART, and TSTOP"),
+            }
+        )
 
         # TODO : The name of FIRST_FFI (and LAST_FFI) is too long to be a header kwd value.
         # Find a way to include these in the headers without breaking astropy (maybe abbreviate?).
-        # primary_header['FIRST_FFI'] = (self.first_ffi, 'the FFI used for the primary header 
+        # primary_header['FIRST_FFI'] = (self.first_ffi, 'the FFI used for the primary header
         # keyword values, except TSTOP')
         # primary_header['LAST_FFI'] = (self.last_ffi, 'the FFI used for the TSTOP keyword value')
 
-        if self._product == 'TICA':
+        if self._product == "TICA":
             # Adding some missing keywords for TICA cutouts
-            primary_header.update({
-                'EXTVER': ('1', 'extension version number (not format version)'),
-                'SIMDATA': (False, 'file is based on simulated data'),
-                'NEXTEND': ('2', 'number of standard extensions'),
-                'TSTART': (primary_header['STARTTJD'], 'observation start time in TJD of first FFI'),
-                'TSTOP': (primary_header['ENDTJD'], 'observation stop time in TJD of last FFI'),
-                'CAMERA': (primary_header['CAMNUM'], 'Camera number'),
-                'CCD': (primary_header['CCDNUM'], 'CCD chip number'),
-                'ASTATE': (None, 'archive state F indicates single orbit processing'),
-                'CRMITEN': (primary_header['CRM'], 'spacecraft cosmic ray mitigation enabled'),
-                'CRBLKSZ': (None, '[exposures] s/c cosmic ray mitigation block siz'),
-                'FFIINDEX': (primary_header['CADENCE'], 'number of FFI cadence interval of first FFI'),
-                'DATA_REL': (None, 'data release version number'),
-                'FILEVER': (None, 'file format version'),
-                'RADESYS': (None, 'reference frame of celestial coordinates'),
-                'SCCONFIG': (None, 'spacecraft configuration ID'),
-                'TIMVERSN': (None, 'OGIP memo number for file format')
-            })
+            primary_header.update(
+                {
+                    "EXTVER": ("1", "extension version number (not format version)"),
+                    "SIMDATA": (False, "file is based on simulated data"),
+                    "NEXTEND": ("2", "number of standard extensions"),
+                    "TSTART": (primary_header["STARTTJD"], "observation start time in TJD of first FFI"),
+                    "TSTOP": (primary_header["ENDTJD"], "observation stop time in TJD of last FFI"),
+                    "CAMERA": (primary_header["CAMNUM"], "Camera number"),
+                    "CCD": (primary_header["CCDNUM"], "CCD chip number"),
+                    "ASTATE": (None, "archive state F indicates single orbit processing"),
+                    "CRMITEN": (primary_header["CRM"], "spacecraft cosmic ray mitigation enabled"),
+                    "CRBLKSZ": (None, "[exposures] s/c cosmic ray mitigation block siz"),
+                    "FFIINDEX": (primary_header["CADENCE"], "number of FFI cadence interval of first FFI"),
+                    "DATA_REL": (None, "data release version number"),
+                    "FILEVER": (None, "file format version"),
+                    "RADESYS": (None, "reference frame of celestial coordinates"),
+                    "SCCONFIG": (None, "spacecraft configuration ID"),
+                    "TIMVERSN": (None, "OGIP memo number for file format"),
+                }
+            )
 
-            date_obs = Time(primary_header['TSTART'] + primary_header['BJDREFI'], format='jd').iso
-            date_end = Time(primary_header['TSTOP'] + primary_header['BJDREFI'], format='jd').iso
-            primary_header.update({
-                'DATE-OBS': (date_obs, 'TSTART as Julian Date of first FFI'),
-                'DATE-END': (date_end, 'TSTOP as Julian Date of last FFI'),
-            })
+            date_obs = Time(primary_header["TSTART"] + primary_header["BJDREFI"], format="jd").iso
+            date_end = Time(primary_header["TSTOP"] + primary_header["BJDREFI"], format="jd").iso
+            primary_header.update(
+                {
+                    "DATE-OBS": (date_obs, "TSTART as Julian Date of first FFI"),
+                    "DATE-END": (date_end, "TSTOP as Julian Date of last FFI"),
+                }
+            )
 
         # Remove unnecessary keywords
         # Bulk removal with wildcards. Most of these should only live in EXT 1 header.
-        delete_kwds_wildcards = ['SC_*', 'RMS*', 'A_*', 'AP_*', 'B_*', 'BP*', 'GAIN*', 'TESS_*', 'CD*',
-                                 'CT*', 'CRPIX*', 'CRVAL*', 'MJD*']
+        delete_kwds_wildcards = [
+            "SC_*",
+            "RMS*",
+            "A_*",
+            "AP_*",
+            "B_*",
+            "BP*",
+            "GAIN*",
+            "TESS_*",
+            "CD*",
+            "CT*",
+            "CRPIX*",
+            "CRVAL*",
+            "MJD*",
+        ]
         # Removal of specific kwds not relevant for cutouts. Most likely these describe a single FFI, and not
-        # the whole cube, which is misleading because we are working with entire stacks of FFIs. Other keywords 
+        # the whole cube, which is misleading because we are working with entire stacks of FFIs. Other keywords
         # are analogs to ones that have already been added to the primary header in the lines above.
-        delete_kwds = ['COMMENT', 'FILTER', 'TIME', 'EXPTIME', 'ACS_MODE', 'DEC_TARG', 'FLXWIN', 'RA_TARG',
-                       'CCDNUM', 'CAMNUM', 'WCSGDF', 'UNITS', 'CADENCE', 'SCIPIXS', 'INT_TIME', 'PIX_CAT',
-                       'REQUANT', 'DIFF_HUF', 'PRIM_HUF', 'QUAL_BIT', 'SPM', 'STARTTJD', 'ENDTJD', 'CRM',
-                       'TJD_ZERO', 'CRM_N', 'ORBIT_ID', 'MIDTJD']
-        
+        delete_kwds = [
+            "COMMENT",
+            "FILTER",
+            "TIME",
+            "EXPTIME",
+            "ACS_MODE",
+            "DEC_TARG",
+            "FLXWIN",
+            "RA_TARG",
+            "CCDNUM",
+            "CAMNUM",
+            "WCSGDF",
+            "UNITS",
+            "CADENCE",
+            "SCIPIXS",
+            "INT_TIME",
+            "PIX_CAT",
+            "REQUANT",
+            "DIFF_HUF",
+            "PRIM_HUF",
+            "QUAL_BIT",
+            "SPM",
+            "STARTTJD",
+            "ENDTJD",
+            "CRM",
+            "TJD_ZERO",
+            "CRM_N",
+            "ORBIT_ID",
+            "MIDTJD",
+        ]
+
         for kwd in delete_kwds_wildcards + delete_kwds:
             primary_header.pop(kwd, None)
 
         # Compute and update TELAPSE keyword
-        telapse = primary_header.get('TSTOP', 0) - primary_header.get('TSTART', 0)
-        primary_header['TELAPSE '] = (telapse, '[d] TSTOP - TSTART')
+        telapse = primary_header.get("TSTOP", 0) - primary_header.get("TSTART", 0)
+        primary_header["TELAPSE "] = (telapse, "[d] TSTOP - TSTART")
 
         # Update DATE comment to be more explicit
-        primary_header['DATE'] = (primary_header['DATE'], 'FFI cube creation date')
+        primary_header["DATE"] = (primary_header["DATE"], "FFI cube creation date")
 
         # Specifying that some of these headers keyword values are inherited from the first FFI
-        if self._product == 'SPOC':
-            primary_header.update({
-                'TSTART': (primary_header['TSTART'], 'observation start time in TJD of first FFI'),
-                'TSTOP': (primary_header['TSTOP'], 'observation stop time in TJD of last FFI'),
-                'DATE-OBS': (primary_header['DATE-OBS'], 'TSTART as UTC calendar date of first FFI'),
-                'DATE-END': (primary_header['DATE-END'], 'TSTOP as UTC calendar date of last FFI'),
-                'FFIINDEX': (primary_header['FFIINDEX'], 'number of FFI cadence interval of first FFI')
-            })
+        if self._product == "SPOC":
+            primary_header.update(
+                {
+                    "TSTART": (primary_header["TSTART"], "observation start time in TJD of first FFI"),
+                    "TSTOP": (primary_header["TSTOP"], "observation stop time in TJD of last FFI"),
+                    "DATE-OBS": (primary_header["DATE-OBS"], "TSTART as UTC calendar date of first FFI"),
+                    "DATE-END": (primary_header["DATE-END"], "TSTOP as UTC calendar date of last FFI"),
+                    "FFIINDEX": (primary_header["FFIINDEX"], "number of FFI cadence interval of first FFI"),
+                }
+            )
 
         # Add missing target-specific metadata
-        primary_header.update({
-            'OBJECT': ('', 'string version of target ID'),
-            'TCID': (0, 'unique TESS target identifier'),
-            'PXTABLE': (0, 'pixel table ID'),
-            'PMRA': (0.0, '[mas/yr] RA proper motion'),
-            'PMDEC': (0.0, '[mas/yr] Dec proper motion'),
-            'PMTOTAL': (0.0, '[mas/yr] Total proper motion'),
-            'TESSMAG': (0.0, '[mag] TESS magnitude'),
-            'TEFF': (0.0, '[K] Effective temperature'),
-            'LOGG': (0.0, '[cm/s2] log10 surface gravity'),
-            'MH': (0.0, '[log10([M/H])] Metallicity'),
-            'RADIUS': (0.0, '[solar radii] Stellar radius'),
-            'TICVER': (0, 'TIC version'),
-            'TICID': (None, 'unique TESS target identifier')
-        })
+        primary_header.update(
+            {
+                "OBJECT": ("", "string version of target ID"),
+                "TCID": (0, "unique TESS target identifier"),
+                "PXTABLE": (0, "pixel table ID"),
+                "PMRA": (0.0, "[mas/yr] RA proper motion"),
+                "PMDEC": (0.0, "[mas/yr] Dec proper motion"),
+                "PMTOTAL": (0.0, "[mas/yr] Total proper motion"),
+                "TESSMAG": (0.0, "[mag] TESS magnitude"),
+                "TEFF": (0.0, "[K] Effective temperature"),
+                "LOGG": (0.0, "[cm/s2] log10 surface gravity"),
+                "MH": (0.0, "[log10([M/H])] Metallicity"),
+                "RADIUS": (0.0, "[solar radii] Stellar radius"),
+                "TICVER": (0, "TIC version"),
+                "TICID": (None, "unique TESS target identifier"),
+            }
+        )
 
     def _build_tpf(self, cube_fits: fits.HDUList, cutout: CubeCutout.CubeCutoutInstance) -> fits.HDUList:
         """
@@ -339,57 +401,88 @@ class TessCubeCutout(CubeCutout):
         empty_single = empty_arr[:, 0, 0]  # extract single-value empty array for time & position
 
         # Define FITS column format and dimension
-        pixel_format = f'{img_cube[0].size}E'
-        pixel_dim = f'{img_cube[0].shape[::-1]}'
+        pixel_format = f"{img_cube[0].size}E"
+        pixel_dim = f"{img_cube[0].shape[::-1]}"
 
         # Definte time-related keywords based on product type
         start, stop = ("TSTART", "TSTOP") if self._product == "SPOC" else ("STARTTJD", "ENDTJD")
-        cols.append(fits.Column(name='TIME', format='D', unit='BJD - 2457000, days', disp='D14.7',
-                                array=(cube_fits[2].columns[start].array + cube_fits[2].columns[stop].array) / 2))
+        cols.append(
+            fits.Column(
+                name="TIME",
+                format="D",
+                unit="BJD - 2457000, days",
+                disp="D14.7",
+                array=(cube_fits[2].columns[start].array + cube_fits[2].columns[stop].array) / 2,
+            )
+        )
 
-        if self._product == 'SPOC':
-            cols.append(fits.Column(name='TIMECORR', format='E', unit='d', disp='E14.7',
-                                    array=cube_fits[2].columns['BARYCORR'].array))
+        if self._product == "SPOC":
+            cols.append(
+                fits.Column(
+                    name="TIMECORR", format="E", unit="d", disp="E14.7", array=cube_fits[2].columns["BARYCORR"].array
+                )
+            )
 
         # Define cadence number (zero-filled for SPOC)
-        cadence_array = empty_single if self._product == 'SPOC' else cube_fits[2].columns['CADENCE'].array
-        cols.append(fits.Column(name='CADENCENO', format='J', disp='I10', array=cadence_array))
+        cadence_array = empty_single if self._product == "SPOC" else cube_fits[2].columns["CADENCE"].array
+        cols.append(fits.Column(name="CADENCENO", format="J", disp="I10", array=cadence_array))
 
         # Define flux-related columns
-        pixel_unit = 'e-/s' if self._product == 'SPOC' else 'e-'
-        flux_err_array = cutout.uncertainty if self._product == 'SPOC' else empty_arr
-        cols.extend([
-            fits.Column(name='RAW_CNTS', format=pixel_format.replace('E', 'J'), unit='count',
-                        dim=pixel_dim, disp='I8', array=empty_arr - 1, null=-1),
-            fits.Column(name='FLUX', format=pixel_format, dim=pixel_dim, unit=pixel_unit,
-                        disp='E14.7', array=img_cube),
-            fits.Column(name='FLUX_ERR', format=pixel_format, dim=pixel_dim, unit=pixel_unit,
-                        disp='E14.7', array=flux_err_array)
-        ])
-   
+        pixel_unit = "e-/s" if self._product == "SPOC" else "e-"
+        flux_err_array = cutout.uncertainty if self._product == "SPOC" else empty_arr
+        cols.extend(
+            [
+                fits.Column(
+                    name="RAW_CNTS",
+                    format=pixel_format.replace("E", "J"),
+                    unit="count",
+                    dim=pixel_dim,
+                    disp="I8",
+                    array=empty_arr - 1,
+                    null=-1,
+                ),
+                fits.Column(
+                    name="FLUX", format=pixel_format, dim=pixel_dim, unit=pixel_unit, disp="E14.7", array=img_cube
+                ),
+                fits.Column(
+                    name="FLUX_ERR",
+                    format=pixel_format,
+                    dim=pixel_dim,
+                    unit=pixel_unit,
+                    disp="E14.7",
+                    array=flux_err_array,
+                ),
+            ]
+        )
+
         # Add background columns (identical zero arrays)
-        for col_name in ['FLUX_BKG', 'FLUX_BKG_ERR']:
-            cols.append(fits.Column(name=col_name, format=pixel_format, dim=pixel_dim,
-                                    unit=pixel_unit, disp='E14.7', array=empty_arr))
+        for col_name in ["FLUX_BKG", "FLUX_BKG_ERR"]:
+            cols.append(
+                fits.Column(
+                    name=col_name, format=pixel_format, dim=pixel_dim, unit=pixel_unit, disp="E14.7", array=empty_arr
+                )
+            )
 
         # Add the quality flags
-        data_quality = 'DQUALITY' if self._product == 'SPOC' else 'QUAL_BIT'
-        cols.append(fits.Column(name='QUALITY', format='J', disp='B16.16',
-                                array=cube_fits[2].columns[data_quality].array))
+        data_quality = "DQUALITY" if self._product == "SPOC" else "QUAL_BIT"
+        cols.append(
+            fits.Column(name="QUALITY", format="J", disp="B16.16", array=cube_fits[2].columns[data_quality].array)
+        )
 
         # Add position correction info (zero-filled)
-        for col_name in ['POS_CORR1', 'POS_CORR2']:
-            cols.append(fits.Column(name=col_name, format='E', unit='pixel', disp='E14.7', array=empty_single))
+        for col_name in ["POS_CORR1", "POS_CORR2"]:
+            cols.append(fits.Column(name=col_name, format="E", unit="pixel", disp="E14.7", array=empty_single))
 
         # Add the FFI_FILE column (not in the pipeline tpfs)
-        cols.append(fits.Column(name='FFI_FILE', format='38A', unit='pixel',
-                                array=cube_fits[2].columns['FFI_FILE'].array))
-        
+        cols.append(
+            fits.Column(name="FFI_FILE", format="38A", unit="pixel", array=cube_fits[2].columns["FFI_FILE"].array)
+        )
+
         # Create the table HDU
         table_hdu = fits.BinTableHDU.from_columns(cols)
-        table_hdu.header['EXTNAME'] = 'PIXELS'
-        table_hdu.header['INHERIT'] = True
-    
+        table_hdu.header["EXTNAME"] = "PIXELS"
+        table_hdu.header["INHERIT"] = True
+
         # Add the WCS keywords to the columns and remove from the header
         self._add_column_wcs(table_hdu.header, self._get_cutout_wcs_dict(cutout.wcs, cutout.cutout_lims))
 
@@ -398,21 +491,21 @@ class TessCubeCutout(CubeCutout):
 
         # Build the aperture HDU
         aperture_hdu = fits.ImageHDU(data=cutout.aperture)
-        aperture_hdu.header['EXTNAME'] = 'APERTURE'
+        aperture_hdu.header["EXTNAME"] = "APERTURE"
         # Copy WCS headers
         for kwd, val, cmt in cutout.wcs.to_header().cards:
             aperture_hdu.header.set(kwd, val, cmt)
         # Add extra aperture keywords (TESS specific)
-        aperture_hdu.header.set('NPIXMISS', None, 'Number of op. aperture pixels not collected')
-        aperture_hdu.header.set('NPIXSAP', None, 'Number of pixels in optimal aperture')
+        aperture_hdu.header.set("NPIXMISS", None, "Number of op. aperture pixels not collected")
+        aperture_hdu.header.set("NPIXSAP", None, "Number of pixels in optimal aperture")
         # Add goodness-of-fit keywords
         for key, val in cutout.wcs_fit.items():
             aperture_hdu.header[key] = tuple(val)
-        aperture_hdu.header['INHERIT'] = True
-    
+        aperture_hdu.header["INHERIT"] = True
+
         # Assemble the HDUList
         cutout_hdu_list = fits.HDUList([primary_hdu, table_hdu, aperture_hdu])
-        
+
         # Apply header inheritance
         self._apply_header_inherit(cutout_hdu_list)
 
@@ -420,7 +513,7 @@ class TessCubeCutout(CubeCutout):
         self.tpf_cutouts_by_file[cutout.cube_filename] = cutout_hdu_list
 
         return cutout_hdu_list
-    
+
     def _cutout_file(self, file: Union[str, Path, S3Path]):
         """
         Make a cutout from a single cube file.
@@ -440,7 +533,7 @@ class TessCubeCutout(CubeCutout):
         try:
             cutout = self.CubeCutoutInstance(cube, file, cube_wcs, self._has_uncertainty, self)
         except InvalidQueryError:
-            warnings.warn(f'Cutout footprint does not overlap with data in {file}, skipping...', DataWarning)
+            warnings.warn(f"Cutout footprint does not overlap with data in {file}, skipping...", DataWarning)
             cube.close()
             return
 
@@ -449,17 +542,17 @@ class TessCubeCutout(CubeCutout):
         cube.close()
 
         # Log coordinates
-        log.debug('Cutout center coordinate: %s, %s', self._coordinates.ra.deg, self._coordinates.dec.deg)
+        log.debug("Cutout center coordinate: %s, %s", self._coordinates.ra.deg, self._coordinates.dec.deg)
 
         # Get cutout WCS info
-        max_dist, sigma = cutout.wcs_fit['WCS_MSEP'][0], cutout.wcs_fit['WCS_SIG'][0]
-        log.debug('Maximum distance between approximate and true location: %s', max_dist)
-        log.debug('Error in approximate WCS (sigma): %.4f', sigma)
+        max_dist, sigma = cutout.wcs_fit["WCS_MSEP"][0], cutout.wcs_fit["WCS_SIG"][0]
+        log.debug("Maximum distance between approximate and true location: %s", max_dist)
+        log.debug("Error in approximate WCS (sigma): %.4f", sigma)
 
         # Store cutouts with filename
         self.cutouts_by_file[file] = cutout
-    
-    def write_as_tpf(self, output_dir: Union[str, Path] = '.', output_file: str = None):
+
+    def write_as_tpf(self, output_dir: Union[str, Path] = ".", output_file: str = None):
         """
         Write the cutouts to disk as target pixel files.
 
@@ -468,7 +561,7 @@ class TessCubeCutout(CubeCutout):
         output_dir : str | Path
             The output directory where the cutout files will be saved.
         output_file : str
-            The output filename. If not provided or more than one cutout is created, the filename 
+            The output filename. If not provided or more than one cutout is created, the filename
             will be generated based on the input filename. This parameter is included so that
             ``CubeCutout`` is backwards compatible with ``CutoutFactory.cube_cut``.
 
@@ -482,12 +575,12 @@ class TessCubeCutout(CubeCutout):
 
         # Ensure that output directory exists
         Path(output_dir).mkdir(parents=True, exist_ok=True)
-        
+
         cutout_paths = []
         for file, cutout in self.cutouts_by_file.items():
             # Determine file name
             if not output_file or len(self._input_files) > 1:
-                filename = self._make_cutout_filename(Path(file).stem.rstrip('-cube'))
+                filename = self._make_cutout_filename(Path(file).stem.rstrip("-cube"))
             else:
                 filename = output_file
 
@@ -499,18 +592,18 @@ class TessCubeCutout(CubeCutout):
 
             with warnings.catch_warnings():
                 # Suppress FITS verification warnings
-                warnings.simplefilter('ignore', fits.verify.VerifyWarning)
+                warnings.simplefilter("ignore", fits.verify.VerifyWarning)
                 tpf.writeto(cutout_path, overwrite=True, checksum=True)
-            
+
             # Log file path
-            log.debug('Target pixel file path: %s', cutout_path)
+            log.debug("Target pixel file path: %s", cutout_path)
             # Append file path or memory object
             cutout_paths.append(cutout_path.as_posix())
 
-        log.debug('Write time: %.2f sec', (monotonic() - write_time))
+        log.debug("Write time: %.2f sec", (monotonic() - write_time))
         return cutout_paths
 
-    def write_as_zip(self, output_dir: Union[str, Path] = '.', filename: Union[str, Path, None] = None) -> str:
+    def write_as_zip(self, output_dir: Union[str, Path] = ".", filename: Union[str, Path, None] = None) -> str:
         """
         Package the cutout TPF files into a zip archive without writing intermediate files.
 
@@ -528,13 +621,14 @@ class TessCubeCutout(CubeCutout):
         str
             Path to the created zip file.
         """
+
         def build_entries():
             for file, tpf in self.tpf_cutouts_by_file.items():
-                arcname = self._make_cutout_filename(Path(file).stem.rstrip('-cube'))
+                arcname = self._make_cutout_filename(Path(file).stem.rstrip("-cube"))
                 yield arcname, tpf
 
         return self._write_cutouts_to_zip(output_dir=output_dir, filename=filename, build_entries=build_entries)
-    
+
     class CubeCutoutInstance(CubeCutout.CubeCutoutInstance):
         """
         Represents an individual cutout with its own data, uncertainty, and aperture arrays.
@@ -568,23 +662,23 @@ class TessCubeCutout(CubeCutout):
                     wcs_header.comments[kwd] = cube_table_header[kwd]
 
             # Adjusting the CRPIX values based on cutout limits
-            wcs_header['CRPIX1'] -= self.cutout_lims[0, 0]
-            wcs_header['CRPIX2'] -= self.cutout_lims[1, 0]
+            wcs_header["CRPIX1"] -= self.cutout_lims[0, 0]
+            wcs_header["CRPIX2"] -= self.cutout_lims[1, 0]
 
             # Add physical WCS keywords
             physical_wcs_keys = {
-                'WCSNAMEP': ('PHYSICAL', 'name of world coordinate system alternate P'),
-                'WCSAXESP': (2, 'mumber of WCS physical axes'),
-                'CTYPE1P': ('RAWX', 'physical WCS axis 1 type (CCD column)'),
-                'CUNIT1P': ('PIXEL', 'physical WCS axis 1 unit'),
-                'CRPIX1P': (1, 'reference CCD column'),
-                'CRVAL1P': (self.cutout_lims[0, 0] + 1, 'value at reference CCD column'),
-                'CDELT1P': (1.0, 'physical WCS axis 1 step'),
-                'CTYPE2P': ('RAWY', 'physical WCS axis 2 type (CCD row)'),
-                'CUNIT2P': ('PIXEL', 'physical WCS axis 2 unit'),
-                'CRPIX2P': (1, 'reference CCD row'),
-                'CRVAL2P': (self.cutout_lims[1, 0] + 1, 'value at reference CCD row'),
-                'CDELT2P': (1.0, 'physical WCS axis 2 step'),
+                "WCSNAMEP": ("PHYSICAL", "name of world coordinate system alternate P"),
+                "WCSAXESP": (2, "mumber of WCS physical axes"),
+                "CTYPE1P": ("RAWX", "physical WCS axis 1 type (CCD column)"),
+                "CUNIT1P": ("PIXEL", "physical WCS axis 1 unit"),
+                "CRPIX1P": (1, "reference CCD column"),
+                "CRVAL1P": (self.cutout_lims[0, 0] + 1, "value at reference CCD column"),
+                "CDELT1P": (1.0, "physical WCS axis 1 step"),
+                "CTYPE2P": ("RAWY", "physical WCS axis 2 type (CCD row)"),
+                "CUNIT2P": ("PIXEL", "physical WCS axis 2 unit"),
+                "CRPIX2P": (1, "reference CCD row"),
+                "CRVAL2P": (self.cutout_lims[1, 0] + 1, "value at reference CCD row"),
+                "CDELT2P": (1.0, "physical WCS axis 2 step"),
             }
 
             for key, (value, comment) in physical_wcs_keys.items():

--- a/astrocut/tess_footprint_cutout.py
+++ b/astrocut/tess_footprint_cutout.py
@@ -1,23 +1,23 @@
 import re
 from pathlib import Path
-from typing import Union, List, Tuple
+from typing import List, Tuple, Union
 
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.io.fits import HDUList
-from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.table import Table
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from . import log
-from .exceptions import InvalidQueryError, InvalidInputError
+from .exceptions import InvalidInputError, InvalidQueryError
 from .footprint_cutout import FootprintCutout, get_ffis, ra_dec_crossmatch
 from .tess_cube_cutout import TessCubeCutout
 
 
 class TessFootprintCutout(FootprintCutout):
     """
-    Class for generating cutouts from TESS Full Frame Images (FFIs) hosted on the cloud 
+    Class for generating cutouts from TESS Full Frame Images (FFIs) hosted on the cloud
     based on the footprint of the cutout.
 
     Parameters
@@ -32,7 +32,7 @@ class TessFootprintCutout(FootprintCutout):
         Method to use for rounding the cutout limits. Options are 'round', 'ceil', and 'floor'.
     sequence : int | list | None
         Default None. Sequence(s) from which to generate cutouts. Can provide a single
-        sequence number as an int or a list of sequence numbers. If not specified, 
+        sequence number as an int or a list of sequence numbers. If not specified,
         cutouts will be generated from all sequences that contain the cutout.
         For the TESS mission, this parameter corresponds to sectors.
     product : str, optional
@@ -47,7 +47,7 @@ class TessFootprintCutout(FootprintCutout):
     tess_cube_cutout : `~astrocut.TessCubeCutout`
         Object containing the cutouts from the TESS cubes.
     cutouts_by_file : dict
-        Dictionary where each key is an input cube S3 URI and its corresponding value is the resulting cutout as a 
+        Dictionary where each key is an input cube S3 URI and its corresponding value is the resulting cutout as a
         ``CubeCutoutInstance`` object.
     cutouts : list
         List of cutout objects.
@@ -67,23 +67,33 @@ class TessFootprintCutout(FootprintCutout):
 
     # Mission-specific defaults
     ARCSEC_PER_PX = 21  # Number of arcseconds per pixel in a TESS image
-    S3_FOOTPRINT_CACHE = 's3://stpubdata/tess/public/footprints/tess_ffi_footprint_cache.json'
-    S3_BASE_FILE_PATH = 's3://stpubdata/tess/public/mast/'
+    S3_FOOTPRINT_CACHE = "s3://stpubdata/tess/public/footprints/tess_ffi_footprint_cache.json"
+    S3_BASE_FILE_PATH = "s3://stpubdata/tess/public/mast/"
 
-
-    @deprecated_renamed_argument('product', None, since='1.1.0', message='Astrocut no longer supports cutouts from '
-                                 'TESS Image Calibrator (TICA) products. '
-                                 'The `product` argument is deprecated and will be removed in a future version.')
-    def __init__(self, coordinates: Union[SkyCoord, str], 
-                 cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]] = 25,
-                 fill_value: Union[int, float] = np.nan, limit_rounding_method: str = 'round', 
-                 sequence: Union[int, List[int], None] = None, product: str = 'SPOC', verbose: bool = False):
+    @deprecated_renamed_argument(
+        "product",
+        None,
+        since="1.1.0",
+        message="Astrocut no longer supports cutouts from "
+        "TESS Image Calibrator (TICA) products. "
+        "The `product` argument is deprecated and will be removed in a future version.",
+    )
+    def __init__(
+        self,
+        coordinates: Union[SkyCoord, str],
+        cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]] = 25,
+        fill_value: Union[int, float] = np.nan,
+        limit_rounding_method: str = "round",
+        sequence: Union[int, List[int], None] = None,
+        product: str = "SPOC",
+        verbose: bool = False,
+    ):
         super().__init__(coordinates, cutout_size, fill_value, limit_rounding_method, sequence, verbose)
-        
+
         # Validate and set the product
-        if product.upper() != 'SPOC':
+        if product.upper() != "SPOC":
             raise InvalidInputError('Product for TESS cube cutouts must be "SPOC".')
-        self._product = 'SPOC'
+        self._product = "SPOC"
 
         # Make the cutouts upon initialization
         self.cutout()
@@ -100,41 +110,49 @@ class TessFootprintCutout(FootprintCutout):
         """
         # Get footprints from the cloud
         all_ffis = get_ffis(self.S3_FOOTPRINT_CACHE)
-        log.debug('Found %d footprint files.', len(all_ffis))
+        log.debug("Found %d footprint files.", len(all_ffis))
 
         # Filter footprints by sequence
         if self._sequence:
-            all_ffis = all_ffis[np.isin(all_ffis['sequence_number'], self._sequence)]
+            all_ffis = all_ffis[np.isin(all_ffis["sequence_number"], self._sequence)]
 
             if len(all_ffis) == 0:
-                raise InvalidQueryError('No files were found for sequences: ' +
-                                        ', '.join(str(s) for s in self._sequence))
-            
-            log.debug('Filtered to %d footprints for sequences: %s', len(all_ffis), 
-                      ', '.join(str(s) for s in self._sequence))
+                raise InvalidQueryError(
+                    "No files were found for sequences: " + ", ".join(str(s) for s in self._sequence)
+                )
+
+            log.debug(
+                "Filtered to %d footprints for sequences: %s", len(all_ffis), ", ".join(str(s) for s in self._sequence)
+            )
 
         # Get sequence names and files that contain the cutout
         cone_results = ra_dec_crossmatch(all_ffis, self._coordinates, self._cutout_size, self.ARCSEC_PER_PX)
         if not cone_results:
-            raise InvalidQueryError('The given coordinates were not found within the specified sequence(s).')
+            raise InvalidQueryError("The given coordinates were not found within the specified sequence(s).")
         files_mapping = _get_files_from_cone_results(cone_results)
-        log.debug('Found %d matching files.', len(files_mapping))
+        log.debug("Found %d matching files.", len(files_mapping))
 
         # Generate the cube cutouts
-        log.debug('Generating cutouts...')
+        log.debug("Generating cutouts...")
         input_files = [f"{self.S3_BASE_FILE_PATH}{file['cube']}" for file in files_mapping]
-        tess_cube_cutout = TessCubeCutout(input_files, self._coordinates, self._cutout_size, 
-                                          self._fill_value, self._limit_rounding_method, threads=8, 
-                                          verbose=self._verbose)
-        
+        tess_cube_cutout = TessCubeCutout(
+            input_files,
+            self._coordinates,
+            self._cutout_size,
+            self._fill_value,
+            self._limit_rounding_method,
+            threads=8,
+            verbose=self._verbose,
+        )
+
         # Assign attributes from the TessCubeCutout object
         self.tess_cube_cutout = tess_cube_cutout
         self.cutouts_by_file = tess_cube_cutout.cutouts_by_file
         self.cutouts = tess_cube_cutout.cutouts
         self.tpf_cutouts_by_file = tess_cube_cutout.tpf_cutouts_by_file
         self.tpf_cutouts = tess_cube_cutout.tpf_cutouts
-        
-    def write_as_tpf(self, output_dir: Union[str, Path] = '.') -> List[str]:
+
+    def write_as_tpf(self, output_dir: Union[str, Path] = ".") -> List[str]:
         """
         Write the cutouts to disk as target pixel files.
 
@@ -149,8 +167,8 @@ class TessFootprintCutout(FootprintCutout):
             List of file paths to cutout target pixel files.
         """
         return self.tess_cube_cutout.write_as_tpf(output_dir)
-    
-    def write_as_zip(self, output_dir: Union[str, Path] = '.', filename: Union[str, Path, None] = None) -> str:
+
+    def write_as_zip(self, output_dir: Union[str, Path] = ".", filename: Union[str, Path, None] = None) -> str:
         """
         Package the cutout TPF files into a zip archive.
 
@@ -234,7 +252,7 @@ def _create_sequence_list(observations: Table) -> List[dict]:
 
 def _get_files_from_cone_results(cone_results: Table) -> List[dict]:
     """
-    Converts a `~astropy.table.Table` of cone search results to a list of dictionaries containing 
+    Converts a `~astropy.table.Table` of cone search results to a list of dictionaries containing
     information for each cloud cube file that intersects with the cutout.
 
     This is a helper function and should be left private.
@@ -267,13 +285,23 @@ def _get_files_from_cone_results(cone_results: Table) -> List[dict]:
     return cube_files
 
 
-@deprecated_renamed_argument('product', None, since='1.1.0', message='Astrocut no longer supports cutouts from '
-                             'TESS Image Calibrator (TICA) products. '
-                             'The `product` argument is deprecated and will be removed in a future version.')
-def cube_cut_from_footprint(coordinates: Union[str, SkyCoord], cutout_size, 
-                            sequence: Union[int, List[int], None] = None, product: str = 'SPOC',
-                            memory_only=False, output_dir: str = '.', 
-                            verbose: bool = False) -> Union[List[str], List[HDUList]]:
+@deprecated_renamed_argument(
+    "product",
+    None,
+    since="1.1.0",
+    message="Astrocut no longer supports cutouts from "
+    "TESS Image Calibrator (TICA) products. "
+    "The `product` argument is deprecated and will be removed in a future version.",
+)
+def cube_cut_from_footprint(
+    coordinates: Union[str, SkyCoord],
+    cutout_size,
+    sequence: Union[int, List[int], None] = None,
+    product: str = "SPOC",
+    memory_only=False,
+    output_dir: str = ".",
+    verbose: bool = False,
+) -> Union[List[str], List[HDUList]]:
     """
     Generates cutouts around `coordinates` of size `cutout_size` from image cube files hosted on the S3 cloud.
 
@@ -293,7 +321,7 @@ def cube_cut_from_footprint(coordinates: Union[str, SkyCoord], cutout_size,
         angular units.
     sequence : int, List[int], optional
         Default None. Sequence(s) from which to generate cutouts. Can provide a single
-        sequence number as an int or a list of sequence numbers. If not specified, 
+        sequence number as an int or a list of sequence numbers. If not specified,
         cutouts will be generated from all sequences that contain the cutout.
         For the TESS mission, this parameter corresponds to sectors.
     product : str, optional
@@ -331,13 +359,14 @@ def cube_cut_from_footprint(coordinates: Union[str, SkyCoord], cutout_size,
     # Return cutouts as memory objects
     if memory_only:
         return cutouts.tpf_cutouts
-    
+
     # Write cutouts
     return cutouts.write_as_tpf(output_dir)
 
 
-def get_tess_sectors(coordinates: Union[str, SkyCoord],
-                     cutout_size: Union[int, u.Quantity, List[int], Tuple[int]]) -> Table:
+def get_tess_sectors(
+    coordinates: Union[str, SkyCoord], cutout_size: Union[int, u.Quantity, List[int], Tuple[int]]
+) -> Table:
     """
     Return the TESS sectors (sequence, camera, CCD) whose FFI footprints overlap
     the given cutout defined by position and size.
@@ -356,8 +385,8 @@ def get_tess_sectors(coordinates: Union[str, SkyCoord],
         units of pixels. `~astropy.units.Quantity` objects must be in pixel or
         angular units.
 
-        If a cutout size of zero is provided, the function will return sectors that contain 
-        the exact RA and Dec position. If a non-zero cutout size is provided, the function 
+        If a cutout size of zero is provided, the function will return sectors that contain
+        the exact RA and Dec position. If a non-zero cutout size is provided, the function
         will return sectors whose footprints overlap with the cutout area.
 
     Returns
@@ -366,8 +395,8 @@ def get_tess_sectors(coordinates: Union[str, SkyCoord],
         A table containing the sector name, sector number, camera number, and CCD number
         for each sector that contains the specified coordinates within the cutout size.
     """
-    column_names = ['sectorName', 'sector', 'camera', 'ccd']
-    column_dtypes = ['S20', 'i4', 'i4', 'i4']
+    column_names = ["sectorName", "sector", "camera", "ccd"]
+    column_dtypes = ["S20", "i4", "i4", "i4"]
 
     # Get footprints from the cloud
     ffis = get_ffis(TessFootprintCutout.S3_FOOTPRINT_CACHE)
@@ -380,7 +409,11 @@ def get_tess_sectors(coordinates: Union[str, SkyCoord],
     # Create a list of unique sector entries
     sector_list = _create_sequence_list(matched_ffis)
 
-    return Table(rows=[
-        (entry['sectorName'], int(entry['sector']), int(entry['camera']), int(entry['ccd']))
-        for entry in sector_list
-    ], names=column_names, dtype=column_dtypes)
+    return Table(
+        rows=[
+            (entry["sectorName"], int(entry["sector"]), int(entry["camera"]), int(entry["ccd"]))
+            for entry in sector_list
+        ],
+        names=column_names,
+        dtype=column_dtypes,
+    )

--- a/astrocut/tests/setup_package.py
+++ b/astrocut/tests/setup_package.py
@@ -2,11 +2,11 @@
 
 # If this package has tests data in the tests/data directory, add them to
 # the paths here, see commented example
-paths = ['coveragerc',
-         # os.path.join('data', '*fits')
-         ]
+paths = [
+    "coveragerc",
+    # os.path.join('data', '*fits')
+]
 
 
 def get_package_data():
-    return {
-        _ASTROPY_PACKAGE_NAME_ + '.tests': paths}  # noqa
+    return {_ASTROPY_PACKAGE_NAME_ + ".tests": paths}  # noqa

--- a/astrocut/tests/test_asdf_cutout.py
+++ b/astrocut/tests/test_asdf_cutout.py
@@ -1,28 +1,28 @@
-from pathlib import Path
-import numpy as np
-import pytest
-import zipfile
-import io
 import importlib.util
+import io
+import zipfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import asdf
+import numpy as np
+import pytest
 from astropy import coordinates as coord
-from astropy.time import Time
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from astropy.modeling import models
 from astropy.nddata import Cutout2D
-from astropy.io import fits
-from gwcs import wcs, coordinate_frames
+from astropy.time import Time
+from gwcs import coordinate_frames, wcs
 from PIL import Image
 
 from astrocut.asdf_cutout import ASDFCutout, asdf_cut, get_center_pixel
 from astrocut.exceptions import DataWarning, InvalidInputError, InvalidQueryError, ModuleWarning
 
 
-def make_wcs(xsize, ysize, ra=30., dec=45.):
-    """ Create a fake gwcs object """
+def make_wcs(xsize, ysize, ra=30.0, dec=45.0):
+    """Create a fake gwcs object"""
     # todo - refine this to better reflect roman wcs
 
     # create transformations
@@ -31,26 +31,26 @@ def make_wcs(xsize, ysize, ra=30., dec=45.):
     # - project coords onto sky with TAN projection
     # - transform center pixel to the input celestial coordinate
     pixelshift = models.Shift(-xsize) & models.Shift(-ysize)
-    pixelscale = models.Scale(0.1 / 3600.) & models.Scale(0.1 / 3600.)  # 0.1 arcsec/pixel
+    pixelscale = models.Scale(0.1 / 3600.0) & models.Scale(0.1 / 3600.0)  # 0.1 arcsec/pixel
     tangent_projection = models.Pix2Sky_TAN()
-    celestial_rotation = models.RotateNative2Celestial(ra, dec, 180.)
+    celestial_rotation = models.RotateNative2Celestial(ra, dec, 180.0)
 
     # net transforms pixels to sky
     det2sky = pixelshift | pixelscale | tangent_projection | celestial_rotation
 
     # define the wcs object
-    detector_frame = coordinate_frames.Frame2D(name='detector', axes_names=('x', 'y'), unit=(u.pix, u.pix))
-    sky_frame = coordinate_frames.CelestialFrame(reference_frame=coord.ICRS(), name='world', unit=(u.deg, u.deg))
+    detector_frame = coordinate_frames.Frame2D(name="detector", axes_names=("x", "y"), unit=(u.pix, u.pix))
+    sky_frame = coordinate_frames.CelestialFrame(reference_frame=coord.ICRS(), name="world", unit=(u.deg, u.deg))
     return wcs.WCS([(detector_frame, det2sky), (sky_frame, None)])
 
 
 @pytest.fixture()
 def makefake():
-    """ Fixture factory to make a fake gwcs and dataset """
+    """Fixture factory to make a fake gwcs and dataset"""
 
     def _make_fake(nx, ny, ra, dec, zero=False, asint=False):
         # create the wcs
-        wcsobj = make_wcs(nx/2, ny/2, ra=ra, dec=dec)
+        wcsobj = make_wcs(nx / 2, ny / 2, ra=ra, dec=dec)
         wcsobj.bounding_box = ((0, nx), (0, ny))
 
         # create the data
@@ -61,7 +61,7 @@ def makefake():
             data = np.arange(size).reshape(nx, ny)
 
         # make a quantity
-        data *= (u.electron / u.second)
+        data *= u.electron / u.second
 
         # make integer array
         if asint:
@@ -74,43 +74,49 @@ def makefake():
 
 @pytest.fixture()
 def fakedata(makefake):
-    """ Fixture to create fake data and wcs """
+    """Fixture to create fake data and wcs"""
     # set up initial parameters
     nx = 1000
     ny = 1000
-    ra = 30.
-    dec = 45.
+    ra = 30.0
+    dec = 45.0
 
     yield makefake(nx, ny, ra, dec)
 
 
 @pytest.fixture()
 def test_images(tmp_path, fakedata):
-    """ Fixture to create a fake dataset of 3 images """
+    """Fixture to create a fake dataset of 3 images"""
     # get the fake data
     data, wcsobj = fakedata
 
     # create meta
-    meta = {'wcs': wcsobj,
-            'product_type': 'l2',
-            'origin': 'STSCI/SOC',
-            'file_date': Time('2023-10-01T00:00:00', format='isot')}
+    meta = {
+        "wcs": wcsobj,
+        "product_type": "l2",
+        "origin": "STSCI/SOC",
+        "file_date": Time("2023-10-01T00:00:00", format="isot"),
+    }
 
     # create and write the asdf file
-    tree = {'roman': {'meta': meta, 
-                      'data': data, 
-                      'dq': data, 
-                      'err': data,
-                      'context': np.expand_dims(data, axis=0),
-                      'invalid_dims': np.ndarray(shape=(10))}}
+    tree = {
+        "roman": {
+            "meta": meta,
+            "data": data,
+            "dq": data,
+            "err": data,
+            "context": np.expand_dims(data, axis=0),
+            "invalid_dims": np.ndarray(shape=(10)),
+        }
+    }
     af = asdf.AsdfFile(tree)
 
-    path = tmp_path / 'roman'
+    path = tmp_path / "roman"
     path.mkdir(exist_ok=True)
 
     files = []
     for i in range(3):
-        filename = path / f'test_roman_{i}.asdf'
+        filename = path / f"test_roman_{i}.asdf"
         af.write_to(filename)
         files.append(filename)
 
@@ -119,13 +125,13 @@ def test_images(tmp_path, fakedata):
 
 @pytest.fixture
 def center_coord():
-    """ Fixture to return a center coordinate """
-    return SkyCoord('29.99901792 44.99930555', unit='deg')
+    """Fixture to return a center coordinate"""
+    return SkyCoord("29.99901792 44.99930555", unit="deg")
 
 
 @pytest.fixture
 def cutout_size():
-    """ Fixture to return a cutout size """
+    """Fixture to return a cutout size"""
     return 10
 
 
@@ -150,7 +156,7 @@ def test_asdf_cutout(test_images, center_coord, cutout_size):
 
         # Check that data is equal between cutout and original image
         with asdf.open(test_images[i]) as input_af:
-            assert np.all(cutout_data == input_af['roman']['data'].value[470:480, 471:481])
+            assert np.all(cutout_data == input_af["roman"]["data"].value[470:480, 471:481])
 
         # Check WCS and that center coordinate matches input
         s_coord = cutout_wcs.pixel_to_world(cutout_size / 2, cutout_size / 2)
@@ -162,21 +168,21 @@ def test_asdf_cutout(test_images, center_coord, cutout_size):
 def test_asdf_cutout_write_to_file(test_images, center_coord, cutout_size, tmpdir):
     def check_asdf_metadata(af, original_file, cutout_data, meta_only=False):
         """Check that ASDF file contains correct metadata"""
-        assert 'roman' in af
-        assert 'meta' in af['roman']
-        meta = af['roman']['meta']
-        assert meta['wcs'].pixel_shape == (10, 10)
-        assert meta['product_type'] == 'l2'
-        assert meta['file_date'] == Time('2023-10-01T00:00:00', format='isot')
-        assert meta['origin'] == 'STSCI/SOC'
-        assert meta['orig_file'] == original_file.as_posix()
+        assert "roman" in af
+        assert "meta" in af["roman"]
+        meta = af["roman"]["meta"]
+        assert meta["wcs"].pixel_shape == (10, 10)
+        assert meta["product_type"] == "l2"
+        assert meta["file_date"] == Time("2023-10-01T00:00:00", format="isot")
+        assert meta["origin"] == "STSCI/SOC"
+        assert meta["orig_file"] == original_file.as_posix()
 
         if not meta_only:
             # Check cutout data and metadata
-            for key in ['data', 'dq', 'err', 'context']:
-                assert key in af['roman']
-                assert np.all(af['roman'][key] == cutout_data)
-    
+            for key in ["data", "dq", "err", "context"]:
+                assert key in af["roman"]
+                assert np.all(af["roman"][key] == cutout_data)
+
     # Write cutouts to ASDF files on disk
     cutout = ASDFCutout(test_images, center_coord, cutout_size)
     asdf_files = cutout.write_as_asdf(output_dir=tmpdir)
@@ -193,45 +199,46 @@ def test_asdf_cutout_write_to_file(test_images, center_coord, cutout_size, tmpdi
     assert len(fits_files) == 3
     for i, fits_file in enumerate(fits_files):
         with fits.open(fits_file) as hdul:
-            assert hdul[0].name == 'PRIMARY'
-            assert hdul[1].name == 'CUTOUT'
+            assert hdul[0].name == "PRIMARY"
+            assert hdul[1].name == "CUTOUT"
             assert np.all(hdul[1].data == cutout.cutouts[i].data)
-            assert hdul[1].header['NAXIS1'] == 10
-            assert hdul[1].header['NAXIS2'] == 10
-            assert hdul[1].header['ORIG_FLE'] == test_images[i].as_posix()
+            assert hdul[1].header["NAXIS1"] == 10
+            assert hdul[1].header["NAXIS2"] == 10
+            assert hdul[1].header["ORIG_FLE"] == test_images[i].as_posix()
             assert Path(fits_file).stat().st_size < Path(test_images[i]).stat().st_size
 
         # Check ASDF extension contents (stdatamodels optional)
-        if importlib.util.find_spec('stdatamodels') is not None:
+        if importlib.util.find_spec("stdatamodels") is not None:
             from stdatamodels import asdf_in_fits
+
             with asdf_in_fits.open(fits_file) as af:
                 check_asdf_metadata(af, test_images[i], cutout.cutouts[i].data, meta_only=True)
 
 
-@pytest.mark.parametrize('output_format', ['.asdf', '.fits'])
+@pytest.mark.parametrize("output_format", [".asdf", ".fits"])
 def test_asdf_cutout_write_to_zip(tmpdir, test_images, center_coord, cutout_size, output_format):
     # Zip ASDF representations
     cutout = ASDFCutout(test_images, center_coord, cutout_size)
     zip_path = cutout.write_as_zip(output_dir=tmpdir, output_format=output_format)
     assert Path(zip_path).exists()
 
-    with zipfile.ZipFile(zip_path, 'r') as zf:
+    with zipfile.ZipFile(zip_path, "r") as zf:
         names = zf.namelist()
         assert len(names) == len(test_images)
         for name in names:
-            assert name.endswith(f'_astrocut{output_format}')
+            assert name.endswith(f"_astrocut{output_format}")
 
         # Open one file and check contents
         data = zf.read(names[0])
-        if output_format == '.asdf':
+        if output_format == ".asdf":
             with asdf.open(io.BytesIO(data)) as af:
-                assert 'roman' in af
-                assert 'data' in af['roman']
-                assert af['roman']['data'].shape == (cutout_size, cutout_size)
+                assert "roman" in af
+                assert "data" in af["roman"]
+                assert af["roman"]["data"].shape == (cutout_size, cutout_size)
         else:
             with fits.open(io.BytesIO(data)) as hdul:
                 assert isinstance(hdul, fits.HDUList)
-                assert len(hdul) == 3 if importlib.util.find_spec('stdatamodels') is not None else 2
+                assert len(hdul) == 3 if importlib.util.find_spec("stdatamodels") is not None else 2
                 assert hdul[1].data.shape == (cutout_size, cutout_size)
 
 
@@ -239,20 +246,20 @@ def test_asdf_cutout_write_to_zip_invalid_format(tmpdir, test_images, center_coo
     # Invalid output format for zip
     cutout = ASDFCutout(test_images, center_coord, cutout_size)
     with pytest.raises(InvalidInputError, match="File format must be either '.asdf' or '.fits'"):
-        cutout.write_as_zip(output_dir=tmpdir, output_format='.invalid')
+        cutout.write_as_zip(output_dir=tmpdir, output_format=".invalid")
 
 
 def test_asdf_cutout_lite(test_images, center_coord, cutout_size):
     def check_lite_metadata(af, meta_only=False):
         """Check that ASDF file contains only lite metadata"""
-        assert 'roman' in af
-        assert 'meta' in af['roman']
-        assert 'wcs' in af['roman']['meta']
-        assert 'orig_file' in af['roman']['meta']
-        assert len(af['roman']) == (1 if meta_only else 2)
-        assert len(af['roman']['meta']) == 2  # only wcs and original filename
+        assert "roman" in af
+        assert "meta" in af["roman"]
+        assert "wcs" in af["roman"]["meta"]
+        assert "orig_file" in af["roman"]["meta"]
+        assert len(af["roman"]) == (1 if meta_only else 2)
+        assert len(af["roman"]["meta"]) == 2  # only wcs and original filename
         if not meta_only:
-            assert 'data' in af['roman']
+            assert "data" in af["roman"]
 
     # Write cutouts to ASDF objects in lite mode
     cutout = ASDFCutout(test_images, center_coord, cutout_size, lite=True)
@@ -262,48 +269,49 @@ def test_asdf_cutout_lite(test_images, center_coord, cutout_size):
     # Write cutouts to HDUList objects in lite mode
     cutout = ASDFCutout(test_images, center_coord, cutout_size, lite=True)
     for hdul in cutout.fits_cutouts:
-        has_stdatamodels = importlib.util.find_spec('stdatamodels') is not None
+        has_stdatamodels = importlib.util.find_spec("stdatamodels") is not None
         assert len(hdul) == 3 if has_stdatamodels else 2  # primary HDU + cutout HDU + embedded ASDF extension
-        assert hdul[0].name == 'PRIMARY'
-        assert hdul[1].name == 'CUTOUT'
+        assert hdul[0].name == "PRIMARY"
+        assert hdul[1].name == "CUTOUT"
 
         # Check ASDF extension contents (stdatamodels optional)
         if has_stdatamodels:
-            assert hdul[2].name == 'ASDF'
+            assert hdul[2].name == "ASDF"
             from stdatamodels import asdf_in_fits
+
             with asdf_in_fits.open(hdul) as af:
                 check_lite_metadata(af, meta_only=True)
 
 
 def test_asdf_cutout_partial(test_images, center_coord, cutout_size):
     # Off the top
-    center_coord = SkyCoord('29.99901792 44.9861', unit='deg')
+    center_coord = SkyCoord("29.99901792 44.9861", unit="deg")
     cutout = ASDFCutout(test_images[0], center_coord, cutout_size).cutouts[0]
     assert cutout.data.shape == (10, 10)
-    assert np.isnan(cutout.data[:cutout_size//2, :]).all()
+    assert np.isnan(cutout.data[: cutout_size // 2, :]).all()
 
     # Off the bottom
-    center_coord = SkyCoord('29.99901792 45.01387', unit='deg')
+    center_coord = SkyCoord("29.99901792 45.01387", unit="deg")
     cutout = ASDFCutout(test_images[0], center_coord, cutout_size).cutouts[0]
-    assert np.isnan(cutout.data[cutout_size//2:, :]).all()
+    assert np.isnan(cutout.data[cutout_size // 2 :, :]).all()
 
     # Off the left, with integer fill value
-    center_coord = SkyCoord('29.98035835 44.99930555', unit='deg')
+    center_coord = SkyCoord("29.98035835 44.99930555", unit="deg")
     cutout = ASDFCutout(test_images[0], center_coord, cutout_size, fill_value=1).cutouts[0]
-    assert np.all(cutout.data[:, :cutout_size//2] == 1)
+    assert np.all(cutout.data[:, : cutout_size // 2] == 1)
 
     # Off the right, with float fill value
-    center_coord = SkyCoord('30.01961 44.99930555', unit='deg')
+    center_coord = SkyCoord("30.01961 44.99930555", unit="deg")
     cutout = ASDFCutout(test_images[0], center_coord, cutout_size, fill_value=1.5).cutouts[0]
-    assert np.all(cutout.data[:, cutout_size//2:] == 1.5)
+    assert np.all(cutout.data[:, cutout_size // 2 :] == 1.5)
 
     # Error if unexpected fill value
-    with pytest.raises(InvalidInputError, match='Fill value must be an integer or a float.'):
-        ASDFCutout(test_images[0], center_coord, cutout_size, fill_value='invalid')
+    with pytest.raises(InvalidInputError, match="Fill value must be an integer or a float."):
+        ASDFCutout(test_images[0], center_coord, cutout_size, fill_value="invalid")
 
 
 def test_asdf_cutout_poles(cutout_size, makefake, tmp_path):
-    """ Test we can make cutouts around poles """
+    """Test we can make cutouts around poles"""
     # Make fake zero data around the pole
     ra, dec = 315.0, 89.995
     data, gwcs = makefake(1000, 1000, ra, dec, zero=True)
@@ -316,15 +324,15 @@ def test_asdf_cutout_poles(cutout_size, makefake, tmp_path):
     assert ss == (ra, dec)
 
     # Set input cutout coord
-    center_coord = SkyCoord(284.702, 89.986, unit='deg')
+    center_coord = SkyCoord(284.702, 89.986, unit="deg")
 
     # create and write the asdf file
-    meta = {'wcs': gwcs}
-    tree = {'roman': {'data': data, 'meta': meta}}
+    meta = {"wcs": gwcs}
+    tree = {"roman": {"data": data, "meta": meta}}
     af = asdf.AsdfFile(tree)
-    path = tmp_path / 'roman'
+    path = tmp_path / "roman"
     path.mkdir(exist_ok=True)
-    filename = path / 'test_roman_poles.asdf'
+    filename = path / "test_roman_poles.asdf"
     af.write_to(filename)
 
     # Get cutout
@@ -336,29 +344,29 @@ def test_asdf_cutout_poles(cutout_size, makefake, tmp_path):
 
 def test_asdf_cutout_not_in_footprint(test_images, center_coord, cutout_size):
     # Throw error if cutout location is not in image footprint
-    with pytest.warns(DataWarning, match='Cutout footprint does not overlap'):
-        with pytest.raises(InvalidQueryError, match='Cutout contains no data!'):
-            ASDFCutout(test_images[0], SkyCoord('0 0', unit='deg'), cutout_size)
+    with pytest.warns(DataWarning, match="Cutout footprint does not overlap"):
+        with pytest.raises(InvalidQueryError, match="Cutout contains no data!"):
+            ASDFCutout(test_images[0], SkyCoord("0 0", unit="deg"), cutout_size)
 
     # Alter one of the test images to only contain zeros in cutout footprint
-    with asdf.open(test_images[0], mode='rw') as af:
-        af['roman']['data'][470:480, 471:481] = 0
+    with asdf.open(test_images[0], mode="rw") as af:
+        af["roman"]["data"][470:480, 471:481] = 0
         af.update()
 
     # Should warn about first image containing no data, but not fail
-    with pytest.warns(DataWarning, match='contains no data, skipping...'):
+    with pytest.warns(DataWarning, match="contains no data, skipping..."):
         cutouts = ASDFCutout(test_images, center_coord, cutout_size).cutouts
     assert len(cutouts) == 2
 
 
 def test_asdf_cutout_no_gwcs(test_images, center_coord, cutout_size):
     # Remove WCS from test image
-    with asdf.open(test_images[0], mode='rw') as af:
-        del af['roman']['meta']['wcs']
+    with asdf.open(test_images[0], mode="rw") as af:
+        del af["roman"]["meta"]["wcs"]
         af.update()
 
     # Should warn about missing WCS for first image, but not fail
-    with pytest.warns(DataWarning, match='does not contain a GWCS object'):
+    with pytest.warns(DataWarning, match="does not contain a GWCS object"):
         cutouts = ASDFCutout(test_images, center_coord, cutout_size).cutouts
     assert len(cutouts) == 2
 
@@ -366,23 +374,23 @@ def test_asdf_cutout_no_gwcs(test_images, center_coord, cutout_size):
 def test_asdf_cutout_invalid_params(test_images, center_coord, cutout_size, tmpdir):
     # Invalid units for cutout size
     cutout_size = 1 * u.m  # meters are not valid
-    with pytest.raises(InvalidInputError, match='Cutout size unit meter is not supported.'):
+    with pytest.raises(InvalidInputError, match="Cutout size unit meter is not supported."):
         ASDFCutout(test_images, center_coord, cutout_size)
 
 
 def test_asdf_cutout_img_output(test_images, center_coord, cutout_size, tmpdir):
     # Basic JPG image
-    jpg_files = ASDFCutout(test_images, center_coord, cutout_size).write_as_img(output_dir=tmpdir, 
-                                                                                output_format='jpg')
+    jpg_files = ASDFCutout(test_images, center_coord, cutout_size).write_as_img(output_dir=tmpdir, output_format="jpg")
     assert len(jpg_files) == len(test_images)
-    with open(jpg_files[0], 'rb') as IMGFLE:
-        assert IMGFLE.read(3) == b'\xFF\xD8\xFF'  # JPG
+    with open(jpg_files[0], "rb") as IMGFLE:
+        assert IMGFLE.read(3) == b"\xff\xd8\xff"  # JPG
 
     # PNG (single input file, not as list)
-    png_files = ASDFCutout(test_images[0], center_coord, cutout_size).write_as_img(output_dir=tmpdir, 
-                                                                                   output_format='png')
-    with open(png_files[0], 'rb') as IMGFLE:
-        assert IMGFLE.read(8) == b'\x89\x50\x4E\x47\x0D\x0A\x1A\x0A'  # PNG
+    png_files = ASDFCutout(test_images[0], center_coord, cutout_size).write_as_img(
+        output_dir=tmpdir, output_format="png"
+    )
+    with open(png_files[0], "rb") as IMGFLE:
+        assert IMGFLE.read(8) == b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"  # PNG
     assert len(png_files) == 1
 
     # Save to memory only
@@ -394,14 +402,14 @@ def test_asdf_cutout_img_output(test_images, center_coord, cutout_size, tmpdir):
     # Color image
     color_jpg = ASDFCutout(test_images, center_coord, cutout_size).write_as_img(output_dir=tmpdir, colorize=True)
     img = Image.open(color_jpg)
-    assert img.mode == 'RGB'
+    assert img.mode == "RGB"
 
 
 def test_asdf_cutout_gwcs(test_images, center_coord):
-    """ Test creating a rectangular cutout to make sure cutout gwcs is correct """
+    """Test creating a rectangular cutout to make sure cutout gwcs is correct"""
     cutout = ASDFCutout(test_images[0], center_coord, cutout_size=[20, 40])
     asdf_cutouts = cutout.asdf_cutouts
-    gwcs = asdf_cutouts[0]['roman']['meta']['wcs']
+    gwcs = asdf_cutouts[0]["roman"]["meta"]["wcs"]
     assert isinstance(gwcs, wcs.WCS)
     assert gwcs.pixel_shape == (20, 40)
     assert gwcs.array_shape == (40, 20)
@@ -411,19 +419,21 @@ def test_asdf_cutout_gwcs(test_images, center_coord):
     assert gwcs.bounding_box.intervals[1].upper == 39
 
 
-@pytest.mark.parametrize(('is_installed', 'warn_msg'), 
-                         [(True, 'not available in the correct version'), (False, 'package cannot be imported')])
+@pytest.mark.parametrize(
+    ("is_installed", "warn_msg"),
+    [(True, "not available in the correct version"), (False, "package cannot be imported")],
+)
 def test_asdf_cutout_stdatamodels(test_images, center_coord, cutout_size, is_installed, warn_msg):
-    """ Test that warning is emitted about ASDF-in-FITS embedding for stdatamodels issues """
+    """Test that warning is emitted about ASDF-in-FITS embedding for stdatamodels issues"""
     mock_stdatamodels = None
     if is_installed:
         mock_stdatamodels = MagicMock()
-        mock_stdatamodels.__version__ = '1.0.0'
+        mock_stdatamodels.__version__ = "1.0.0"
         mock_stdatamodels.asdf_in_fits = MagicMock()
-    patch_dict = {'stdatamodels': mock_stdatamodels}
+    patch_dict = {"stdatamodels": mock_stdatamodels}
 
-    with patch.dict('sys.modules', patch_dict):
-        with patch('sys.version_info', (3, 11, 0)):
+    with patch.dict("sys.modules", patch_dict):
+        with patch("sys.version_info", (3, 11, 0)):
             with pytest.warns(ModuleWarning, match=warn_msg):
                 cutout = ASDFCutout(test_images, center_coord, cutout_size)
                 fits_cutouts = cutout.fits_cutouts
@@ -432,9 +442,9 @@ def test_asdf_cutout_stdatamodels(test_images, center_coord, cutout_size, is_ins
 
 
 def test_asdf_cutout_python_version(test_images, center_coord, cutout_size):
-    """ Test that warning is emitted about ASDF-in-FITS embedding for Python <3.11 """
-    with patch('sys.version_info', (3, 10, 0)):
-        with pytest.warns(ModuleWarning, match='requires Python 3.11 or higher'):
+    """Test that warning is emitted about ASDF-in-FITS embedding for Python <3.11"""
+    with patch("sys.version_info", (3, 10, 0)):
+        with pytest.warns(ModuleWarning, match="requires Python 3.11 or higher"):
             cutout = ASDFCutout(test_images, center_coord, cutout_size)
             fits_cutouts = cutout.fits_cutouts
         assert cutout._py311_or_higher is False
@@ -443,7 +453,7 @@ def test_asdf_cutout_python_version(test_images, center_coord, cutout_size):
 
 
 def test_get_center_pixel(fakedata):
-    """ Test get_center_pixel function """
+    """Test get_center_pixel function"""
     # Get the fake data
     __, gwcs = fakedata
 
@@ -460,7 +470,8 @@ def test_get_center_pixel(fakedata):
 
 
 def test_asdf_cut(test_images, center_coord, cutout_size, tmpdir):
-    """ Test convenience function to create ASDF cutouts """
+    """Test convenience function to create ASDF cutouts"""
+
     def check_paths(cutout_paths, ext):
         assert isinstance(cutout_paths, list)
         assert isinstance(cutout_paths[0], str)
@@ -471,18 +482,19 @@ def test_asdf_cut(test_images, center_coord, cutout_size, tmpdir):
             assert Path(path).exists()
             assert str(tmpdir) in path
             assert Path(test_images[i]).stem in path
-            assert center_coord.ra.to_string(unit='deg', decimal=True) in path
-            assert center_coord.dec.to_string(unit='deg', decimal=True) in path
-            assert '10-x-10' in path
-    
+            assert center_coord.ra.to_string(unit="deg", decimal=True) in path
+            assert center_coord.dec.to_string(unit="deg", decimal=True) in path
+            assert "10-x-10" in path
+
     # Write files to disk as ASDF files
     asdf_paths = asdf_cut(test_images, center_coord.ra.deg, center_coord.dec.deg, cutout_size, output_dir=tmpdir)
-    check_paths(asdf_paths, '.asdf')
+    check_paths(asdf_paths, ".asdf")
 
     # Write files to disk as FITS files
-    fits_paths = asdf_cut(test_images, center_coord.ra.deg, center_coord.dec.deg, cutout_size, output_dir=tmpdir, 
-                          output_format='fits')
-    check_paths = (fits_paths, '.fits')
+    fits_paths = asdf_cut(
+        test_images, center_coord.ra.deg, center_coord.dec.deg, cutout_size, output_dir=tmpdir, output_format="fits"
+    )
+    check_paths = (fits_paths, ".fits")
 
     # Write cutouts to memory as Cutout2D objects
     cutouts = asdf_cut(test_images, center_coord.ra.deg, center_coord.dec.deg, cutout_size, write_file=False)
@@ -491,5 +503,5 @@ def test_asdf_cut(test_images, center_coord, cutout_size, tmpdir):
     assert len(cutouts) == 3
 
     # Error if output format is not supported
-    with pytest.raises(InvalidInputError, match='Output format .invalid is not recognized.'):
-        asdf_cut(test_images, center_coord.ra.deg, center_coord.dec.deg, cutout_size, output_format='invalid')
+    with pytest.raises(InvalidInputError, match="Output format .invalid is not recognized."):
+        asdf_cut(test_images, center_coord.ra.deg, center_coord.dec.deg, cutout_size, output_format="invalid")

--- a/astrocut/tests/test_cube_cut.py
+++ b/astrocut/tests/test_cube_cut.py
@@ -12,9 +12,9 @@ from astropy.io import fits
 from astropy.time import Time
 from astropy.wcs import FITSFixedWarning
 
+from ..cube_factory import CubeFactory
 from ..cutout_factory import CutoutFactory, cube_cut
 from ..exceptions import InputWarning
-from ..cube_factory import CubeFactory
 from ..tica_cube_factory import TicaCubeFactory
 from .utils_for_test import create_test_ffis
 
@@ -48,12 +48,12 @@ def cube_file(ffi_type: Literal["SPOC", "TICA"], ffi_files: List[str], tmp_path)
     return cube_file
 
 
-def check_cutout(product, hdulist, center_pix, center_world, cutout_size, ecube, eps=1.e-7):
+def check_cutout(product, hdulist, center_pix, center_world, cutout_size, ecube, eps=1.0e-7):
     """Check FITS cutout for correctness
-    
+
     Checks RA_OBJ/DEC_OBJ in primary header, and TIME, FLUX, and
     FLUX_ERR in table.
-    
+
     Inputs:
     cutfile  Name of FITS cutout file
     pixcrd   [2] pixel coordinates for cutout center [cy,cx]
@@ -69,34 +69,34 @@ def check_cutout(product, hdulist, center_pix, center_world, cutout_size, ecube,
     y1, y2 = iy - cutout_size // 2, iy + cutout_size // 2
 
     # Check RA and Dec in primary header
-    ra_obj = hdulist[0].header['RA_OBJ']
-    dec_obj = hdulist[0].header['DEC_OBJ']
-    expected_coords = SkyCoord(center_world[0], center_world[1], frame='icrs', unit='deg')
-    actual_coords = SkyCoord(ra_obj, dec_obj, frame='icrs', unit='deg')
-    
+    ra_obj = hdulist[0].header["RA_OBJ"]
+    dec_obj = hdulist[0].header["DEC_OBJ"]
+    expected_coords = SkyCoord(center_world[0], center_world[1], frame="icrs", unit="deg")
+    actual_coords = SkyCoord(ra_obj, dec_obj, frame="icrs", unit="deg")
+
     dist = expected_coords.separation(actual_coords).degree
     assert dist <= eps, "{} separation in primary header {} too large".format(hdulist, dist)
-        
+
     # Check timeseries data
     ntimes = ecube.shape[2]
     tab = hdulist[1].data
     assert len(tab) == ntimes, f"Expected {ntimes} entries, found {len(tab)}"
-    assert (tab['TIME'] == (np.arange(ntimes)+0.5)).all(), "Some time values are incorrect"
+    assert (tab["TIME"] == (np.arange(ntimes) + 0.5)).all(), "Some time values are incorrect"
 
     # Check flux data if product is SPOC
-    if product == 'SPOC':
+    if product == "SPOC":
         # TODO: Modify check1 to take TICA - adjust for TICA's slightly different WCS
         # solutions (TICA will usually be ~1 pixel off from SPOC for the same cutout)
-        check_flux(tab['FLUX'], x1, x2, y1, y2, ecube[:, :, :, 0], 'FLUX', hdulist)
+        check_flux(tab["FLUX"], x1, x2, y1, y2, ecube[:, :, :, 0], "FLUX", hdulist)
         # Only SPOC propagates errors, so TICA will always have an empty error array
-        check_flux(tab['FLUX_ERR'], x1, x2, y1, y2, ecube[:, :, :, 1], 'FLUX_ERR', hdulist)
-    
+        check_flux(tab["FLUX_ERR"], x1, x2, y1, y2, ecube[:, :, :, 1], "FLUX_ERR", hdulist)
+
     # Ensure correct data type in third HDU
     assert hdulist[2].data.dtype.type == np.int32
 
 
 def check_flux(flux, x1, x2, y1, y2, ecube, label, hdulist):
-    """ Checking to make sure the right corresponding pixels 
+    """Checking to make sure the right corresponding pixels
     are replaced by NaNs when cutout goes off the TESS camera.
     Test one of flux or error
     """
@@ -108,17 +108,17 @@ def check_flux(flux, x1, x2, y1, y2, ecube, label, hdulist):
     if y1 < 0:
         assert np.isnan(flux[:, :, :-y1]).all(), "{} {} y1 NaN failure".format(hdulist, label)
     if x2 >= cx:
-        assert np.isnan(flux[:, -(x2-cx+1):, :]).all(), "{} {} x2 NaN failure".format(hdulist, label)
+        assert np.isnan(flux[:, -(x2 - cx + 1) :, :]).all(), "{} {} x2 NaN failure".format(hdulist, label)
     if y2 >= cy:
-        assert np.isnan(flux[:, :, -(y2-cy+1):]).all(), "{} {} y2 NaN failure".format(hdulist, label)
-        
+        assert np.isnan(flux[:, :, -(y2 - cy + 1) :]).all(), "{} {} y2 NaN failure".format(hdulist, label)
+
     # Compute valid indices within cutout bounds
     x1c, x2c = max(x1, 0), min(x2, cx - 1)
     y1c, y2c = max(y1, 0), min(y2, cy - 1)
 
     # Extract and compare valid data
     expected_flux = ecube[x1c:x2c, y1c:y2c, :]
-    cutout_flux = np.moveaxis(flux[:, x1c-x1:x2c-x1, y1c-y1:y2c-y1], 0, -1)
+    cutout_flux = np.moveaxis(flux[:, x1c - x1 : x2c - x1, y1c - y1 : y2c - y1], 0, -1)
 
     assert np.array_equal(expected_flux, cutout_flux)
 
@@ -134,17 +134,17 @@ def test_cube_cutout(cube_file, ffi_files, ffi_type, use_factory, tmp_path):
     num_im = 100
 
     # Read one of the input images to get the WCS
-    n = 1 if ffi_type == 'SPOC' else 0
+    n = 1 if ffi_type == "SPOC" else 0
     img_header = fits.getheader(ffi_files[0], n)
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore', FITSFixedWarning)
+        warnings.simplefilter("ignore", FITSFixedWarning)
         cube_wcs = wcs.WCS(img_header)
 
     # get pixel positions at edges and center of image
     # somewhat cryptic one-liner to get the grid of points
     pval = np.array([0, img_sz // 2, img_sz - 1], dtype=float)
     pixcrd = pval[np.transpose(np.reshape(np.mgrid[0:3, 0:3], (2, 9)))]
-    
+
     # add one more giant cutout that goes off all 4 edges
     pixcrd = np.append(pixcrd, pixcrd[4].reshape(1, 2), axis=0)
 
@@ -152,28 +152,29 @@ def test_cube_cutout(cube_file, ffi_files, ffi_type, use_factory, tmp_path):
     world_coords = cube_wcs.all_pix2world(pixcrd, 0)
 
     # Getting the cutouts
-    cutbasename = 'make_cube_cutout_{}.fits'
+    cutbasename = "make_cube_cutout_{}.fits"
     cutlist = [path.join(tmpdir, cutbasename.format(i)) for i in range(len(world_coords))]
-    csize = [img_sz//2]*len(world_coords)
-    csize[-1] = img_sz+5
+    csize = [img_sz // 2] * len(world_coords)
+    csize[-1] = img_sz + 5
     for i, v in enumerate(world_coords):
-        coord = SkyCoord(v[0], v[1], frame='icrs', unit='deg')
+        coord = SkyCoord(v[0], v[1], frame="icrs", unit="deg")
         if use_factory:
             cutout_maker = CutoutFactory()
-            cutout_maker.cube_cut(cube_file, coord, csize[i], ffi_type, target_pixel_file=cutlist[i],
-                                  output_path=tmpdir, verbose=False)
+            cutout_maker.cube_cut(
+                cube_file, coord, csize[i], ffi_type, target_pixel_file=cutlist[i], output_path=tmpdir, verbose=False
+            )
         else:
-            cube_cut(cube_file, coord, csize[i], ffi_type, target_pixel_file=cutlist[i],
-                     output_path=tmpdir, verbose=False)
-
+            cube_cut(
+                cube_file, coord, csize[i], ffi_type, target_pixel_file=cutlist[i], output_path=tmpdir, verbose=False
+            )
 
     # expected values for cube
     ecube = np.zeros((img_sz, img_sz, num_im, 2))
-    plane = np.arange(img_sz*img_sz, dtype=np.float32).reshape((img_sz, img_sz))
+    plane = np.arange(img_sz * img_sz, dtype=np.float32).reshape((img_sz, img_sz))
     for i in range(num_im):
         ecube[:, :, i, 0] = -plane
         ecube[:, :, i, 1] = plane
-        plane += img_sz*img_sz
+        plane += img_sz * img_sz
 
     # Doing the actual checking
     for i, cutfile in enumerate(cutlist):
@@ -220,30 +221,29 @@ def test_header_keywords_quality(cube_file, ffi_type, tmp_path):
     )
 
     with fits.open(out_file) as hdulist:
-
         # Primary header checks
         primary_header = hdulist[0].header
-        assert primary_header['FFI_TYPE'] == ffi_type
-        assert primary_header['CREATOR'] == 'astrocut'
-        assert primary_header['BJDREFI'] == 2457000
+        assert primary_header["FFI_TYPE"] == ffi_type
+        assert primary_header["CREATOR"] == "astrocut"
+        assert primary_header["BJDREFI"] == 2457000
 
-        if ffi_type == 'TICA':
+        if ffi_type == "TICA":
             # Verifying DATE-OBS calculation in TICA
-            date_obs = primary_header['DATE-OBS']
-            tstart = Time(date_obs).jd - primary_header['BJDREFI']
-            assert primary_header['TSTART'] == tstart
+            date_obs = primary_header["DATE-OBS"]
+            tstart = Time(date_obs).jd - primary_header["BJDREFI"]
+            assert primary_header["TSTART"] == tstart
 
             # Verifying DATE-END calculation in TICA
-            date_end = primary_header['DATE-END']
-            tstop = Time(date_end).jd - primary_header['BJDREFI']
-            assert primary_header['TSTOP'] == tstop
+            date_end = primary_header["DATE-END"]
+            tstop = Time(date_end).jd - primary_header["BJDREFI"]
+            assert primary_header["TSTOP"] == tstop
 
         # Checking for header keyword propagation in EXT 1 and 2
         ext1_header = hdulist[1].header
         ext2_header = hdulist[2].header
-        assert ext1_header['FFI_TYPE'] == ext2_header['FFI_TYPE'] == primary_header['FFI_TYPE']
-        assert ext1_header['CREATOR'] == ext2_header['CREATOR'] == primary_header['CREATOR']
-        assert ext1_header['BJDREFI'] == ext2_header['BJDREFI'] == primary_header['BJDREFI']
+        assert ext1_header["FFI_TYPE"] == ext2_header["FFI_TYPE"] == primary_header["FFI_TYPE"]
+        assert ext1_header["CREATOR"] == ext2_header["CREATOR"] == primary_header["CREATOR"]
+        assert ext1_header["BJDREFI"] == ext2_header["BJDREFI"] == primary_header["BJDREFI"]
 
 
 @pytest.mark.parametrize("ffi_type", ["SPOC", "TICA"])
@@ -260,26 +260,25 @@ def test_header_keywords_diffs(cube_file, ffi_type, tmp_path):
     )
 
     with fits.open(out_file) as hdulist:
-
         # Get units from BinTableHDU
-        cols = hdulist[1].columns.info('name, unit', output=False)
+        cols = hdulist[1].columns.info("name, unit", output=False)
         cols_dict = dict(zip(*cols.values()))
 
-        ncols = 12 if ffi_type == 'SPOC' else 11
+        ncols = 12 if ffi_type == "SPOC" else 11
         assert len(cols_dict) == ncols
 
         # Checking for known keyword differences
-        if ffi_type == 'SPOC':
-            assert hdulist[0].header['TIMEREF'] == 'SOLARSYSTEM', 'TIMEREF keyword does not match expected'
-            assert hdulist[0].header['TASSIGN'] == 'SPACECRAFT', 'TASSIGN keyword does not match expected'
-            assert cols_dict['FLUX'] == 'e-/s', f'Expected `FLUX` units of "e-/s", got units of "{cols_dict["FLUX"]}"'
-            assert hdulist[1].data.field('CADENCENO').all() == 0.0
+        if ffi_type == "SPOC":
+            assert hdulist[0].header["TIMEREF"] == "SOLARSYSTEM", "TIMEREF keyword does not match expected"
+            assert hdulist[0].header["TASSIGN"] == "SPACECRAFT", "TASSIGN keyword does not match expected"
+            assert cols_dict["FLUX"] == "e-/s", f'Expected `FLUX` units of "e-/s", got units of "{cols_dict["FLUX"]}"'
+            assert hdulist[1].data.field("CADENCENO").all() == 0.0
 
-        if ffi_type == 'TICA':
-            assert hdulist[0].header['TIMEREF'] is None, 'TIMEREF keyword does not match expected'
-            assert hdulist[0].header['TASSIGN'] is None, 'TASSIGN keyword does not match expected'
-            assert cols_dict['FLUX'] == 'e-', f'Expected `FLUX` units of "e-", got units of "{cols_dict["FLUX"]}"'
-            assert hdulist[1].data.field('CADENCENO').all() != 0.0
+        if ffi_type == "TICA":
+            assert hdulist[0].header["TIMEREF"] is None, "TIMEREF keyword does not match expected"
+            assert hdulist[0].header["TASSIGN"] is None, "TASSIGN keyword does not match expected"
+            assert cols_dict["FLUX"] == "e-", f'Expected `FLUX` units of "e-", got units of "{cols_dict["FLUX"]}"'
+            assert hdulist[1].data.field("CADENCENO").all() != 0.0
 
 
 @pytest.mark.parametrize("ffi_type", ["SPOC", "TICA"])
@@ -300,20 +299,20 @@ def test_get_cutout_limits(cube_file, ffi_type, tmp_path):
     xmin, xmax = cutout_maker.cutout_lims[0]
     ymin, ymax = cutout_maker.cutout_lims[1]
 
-    assert (xmax-xmin) == cutout_size[0]
-    assert (ymax-ymin) == cutout_size[1]
+    assert (xmax - xmin) == cutout_size[0]
+    assert (ymax - ymin) == cutout_size[1]
 
-    cutout_size = [5*u.pixel, 7*u.pixel]
+    cutout_size = [5 * u.pixel, 7 * u.pixel]
     out_file = cutout_maker.cube_cut(cube_file, coord, cutout_size, ffi_type, verbose=False, output_path=tmpdir)
     assert "256.8800000_6.3800000_5.0pix-x-7.0pix_astrocut.fits" in out_file
 
     xmin, xmax = cutout_maker.cutout_lims[0]
     ymin, ymax = cutout_maker.cutout_lims[1]
 
-    assert (xmax-xmin) == cutout_size[0].value
-    assert (ymax-ymin) == cutout_size[1].value
+    assert (xmax - xmin) == cutout_size[0].value
+    assert (ymax - ymin) == cutout_size[1].value
 
-    cutout_size = [3*u.arcmin, 5*u.arcmin]
+    cutout_size = [3 * u.arcmin, 5 * u.arcmin]
     out_file = cutout_maker.cube_cut(cube_file, coord, cutout_size, ffi_type, verbose=False, output_path=tmpdir)
     assert "256.8800000_6.3800000_3.0arcmin-x-5.0arcmin_astrocut.fits" in out_file
 
@@ -326,7 +325,6 @@ def test_get_cutout_limits(cube_file, ffi_type, tmp_path):
 
 @pytest.mark.parametrize("ffi_type", ["SPOC", "TICA"])
 def test_small_cutout(cube_file, ffi_type, tmp_path):
-
     tmpdir = str(tmp_path)
 
     cutout_maker = CutoutFactory()
@@ -375,7 +373,7 @@ def test_fit_cutout_wcs(cube_file, ffi_type, tmp_path):
 @pytest.mark.parametrize("ffi_type", ["SPOC", "TICA"])
 def test_target_pixel_file(cube_file, ffi_type, tmp_path):
     """Test target pixel file"""
-    
+
     tmpdir = str(tmp_path)
 
     cutout_maker = CutoutFactory()
@@ -388,11 +386,11 @@ def test_target_pixel_file(cube_file, ffi_type, tmp_path):
     # this tests that the format of the tpf is what it should be
     tpf = fits.open(out_file)
 
-    assert tpf[0].header["ORIGIN"] == 'STScI/MAST'
+    assert tpf[0].header["ORIGIN"] == "STScI/MAST"
 
     tpf_table = tpf[1].data
     # SPOC cutouts have 1 extra columns in EXT 1
-    ncols = 12 if ffi_type == 'SPOC' else 11
+    ncols = 12 if ffi_type == "SPOC" else 11
     assert len(tpf_table.columns) == ncols
     assert "TIME" in tpf_table.columns.names
     assert "FLUX" in tpf_table.columns.names
@@ -400,21 +398,21 @@ def test_target_pixel_file(cube_file, ffi_type, tmp_path):
     assert "FFI_FILE" in tpf_table.columns.names
 
     # Check img cutout shape and data type
-    cutout_img = tpf_table[0]['FLUX']
+    cutout_img = tpf_table[0]["FLUX"]
     assert cutout_img.shape == (3, 5)
-    assert cutout_img.dtype.name == 'float32'
+    assert cutout_img.dtype.name == "float32"
 
     # Check error cutout shape, contents, and data type
-    cutout_err = tpf_table[0]['FLUX_ERR']
+    cutout_err = tpf_table[0]["FLUX_ERR"]
     assert cutout_err.shape == (3, 5)
     if ffi_type == "TICA":
         assert np.mean(cutout_err) == 0
-    assert cutout_err.dtype.name == 'float32'
+    assert cutout_err.dtype.name == "float32"
 
     # Check aperture shape and data type
     aperture = tpf[2].data
     assert aperture.shape == (3, 5)
-    assert aperture.dtype.name == 'int32'
+    assert aperture.dtype.name == "int32"
 
     tpf.close()
 
@@ -427,7 +425,7 @@ def test_tica_cutout_error(tmp_path):
     Write test to check that cutouts can be made from *both* the TICA
     cubes that still have the error array, as well as cubes that
     *have* been updated and no longer have the error array. Needed to
-    verify that CutoutFactory will work on the cubes that have not 
+    verify that CutoutFactory will work on the cubes that have not
     been remade yet.
     """
 
@@ -438,22 +436,21 @@ def test_tica_cutout_error(tmp_path):
 
     # Create a mock TICA cube that still has the error array
     # Cube with TICA headers to copy to cube with error array
-    spoc_cube_error = CubeFactory() 
+    spoc_cube_error = CubeFactory()
     spoc_ffi_files = create_test_ffis(img_sz, num_im, dir_name=tmpdir)
-    cube_error_file = spoc_cube_error.make_cube(spoc_ffi_files, 
-                                                path.join(tmpdir, "out_dir", "test_error_cube.fits"), 
-                                                verbose=False)
+    cube_error_file = spoc_cube_error.make_cube(
+        spoc_ffi_files, path.join(tmpdir, "out_dir", "test_error_cube.fits"), verbose=False
+    )
 
     # Cube with error array
     tica_cube_no_error = TicaCubeFactory()
-    tica_ffi_files = create_test_ffis(img_sz, num_im, dir_name=tmpdir, product='TICA')
-    tica_cube_no_error_file = tica_cube_no_error.make_cube(tica_ffi_files, 
-                                                           path.join(tmpdir, "out_dir", "test_add_error_cube.fits"), 
-                                                           verbose=False)
+    tica_ffi_files = create_test_ffis(img_sz, num_im, dir_name=tmpdir, product="TICA")
+    tica_cube_no_error_file = tica_cube_no_error.make_cube(
+        tica_ffi_files, path.join(tmpdir, "out_dir", "test_add_error_cube.fits"), verbose=False
+    )
 
     # Take ImageHDU from the cube with the error array, write into cube with TICA headers
-    with fits.open(tica_cube_no_error_file, mode='update') as hdulist:
-
+    with fits.open(tica_cube_no_error_file, mode="update") as hdulist:
         tica_hdr = hdulist[1].header
         error_hdr = fits.getheader(cube_error_file, 1)
 
@@ -473,7 +470,7 @@ def test_tica_cutout_error(tmp_path):
     # Verify dimensions of new TICA cube with added error array
     assert np.shape(fits.getdata(tica_cube_error_file, 1)) == (img_sz, img_sz, num_im, 2)
 
-    ffi_type = 'TICA'
+    ffi_type = "TICA"
     # Test cutouts from TICA cube with error array
     test_cube_cutout(tica_cube_error_file, tica_ffi_files, ffi_type, True, tmp_path)
     test_header_keywords_quality(tica_cube_error_file, ffi_type, tmp_path)
@@ -489,17 +486,17 @@ def test_ffi_cube_header(cube_file, ffi_files, ffi_type):
     cube_header_keys = list(fits.getheader(cube_file, 0).keys())
 
     # Lists of expected keys for each product type
-    if ffi_type == 'SPOC':
+    if ffi_type == "SPOC":
         # CHECKSUM in FFI header, not in cube header
         # SECTOR, DATE, ORIGIN in cube header, not in FFI header
-        effi_keys = ['CHECKSUM']
-        ecube_keys = ['SECTOR', 'DATE', 'ORIGIN']
+        effi_keys = ["CHECKSUM"]
+        ecube_keys = ["SECTOR", "DATE", "ORIGIN"]
 
     else:
         # CHECKSUM, and image dimensions (NAXIS1, NAXIS2) in FFI header, not in cube header
         # SECTOR, DATE, EXTNAME, ORIGIN in cube header, not in FFI header
-        effi_keys = ['CHECKSUM', 'NAXIS1', 'NAXIS2']
-        ecube_keys = ['SECTOR', 'DATE', 'EXTNAME', 'ORIGIN']
+        effi_keys = ["CHECKSUM", "NAXIS1", "NAXIS2"]
+        ecube_keys = ["SECTOR", "DATE", "EXTNAME", "ORIGIN"]
 
     for k in effi_keys:
         assert k in ffi_header_keys
@@ -523,7 +520,7 @@ def test_inputs(cube_file, ffi_type, tmp_path, caplog):
     # Setting up
     coord = "256.88 6.38"
 
-    cutout_size = [5, 3]*u.pixel
+    cutout_size = [5, 3] * u.pixel
     cutout_file = cutout_maker.cube_cut(cube_file, coord, cutout_size, ffi_type, output_path=tmpdir, verbose=True)
     captured = caplog.text
     assert "Image cutout cube shape: (100, 3, 5)" in captured
@@ -531,11 +528,11 @@ def test_inputs(cube_file, ffi_type, tmp_path, caplog):
     assert "Cutout center coordinate: 256.88, 6.38" in captured
     assert "5.0pix-x-3.0pix" in cutout_file
 
-    cutout_size = [5, 3]*u.arcmin
+    cutout_size = [5, 3] * u.arcmin
     cutout_file = cutout_maker.cube_cut(cube_file, coord, cutout_size, ffi_type, output_path=tmpdir, verbose=False)
     assert "5.0arcmin-x-3.0arcmin" in cutout_file
-    
-    cutout_size = [5, 3, 9]*u.pixel
+
+    cutout_size = [5, 3, 9] * u.pixel
     with pytest.warns(InputWarning):
         cutout_file = cutout_maker.cube_cut(cube_file, coord, cutout_size, ffi_type, output_path=tmpdir, verbose=False)
     assert "5.0pix-x-3.0pix" in cutout_file

--- a/astrocut/tests/test_cube_factory.py
+++ b/astrocut/tests/test_cube_factory.py
@@ -1,41 +1,41 @@
 from pathlib import Path
+from re import findall
+
 import numpy as np
 import pytest
-
 from astropy.io import fits
 from astropy.table import Table
-from re import findall
 
 from astrocut.exceptions import DataWarning, InvalidInputError
 
-from .utils_for_test import create_test_ffis
 from ..cube_factory import CubeFactory
 from ..tica_cube_factory import TicaCubeFactory
+from .utils_for_test import create_test_ffis
 
 
 @pytest.fixture
 def img_size():
-    """ Fixture for the size of the test images to be created. """
+    """Fixture for the size of the test images to be created."""
     return 10
 
 
 @pytest.fixture
 def num_images():
-    """ Fixture for the number of test images to be created. """
+    """Fixture for the number of test images to be created."""
     return 100
 
 
 def test_make_cube(tmpdir, img_size, num_images, tmp_path):
     """
-    Testing the make cube functionality by making a bunch of test FFIs, 
+    Testing the make cube functionality by making a bunch of test FFIs,
     making the cube, and checking the results.
     """
     cube_maker = CubeFactory()
     tmp_path = Path(tmpdir)
-    
+
     # Create test FFIs
     ffi_files = create_test_ffis(img_size, num_images, dir_name=tmpdir)
-    cube_path = tmp_path / 'out_dir' / 'test_cube.fits'
+    cube_path = tmp_path / "out_dir" / "test_cube.fits"
 
     # Generate cube
     cube_file = cube_maker.make_cube(ffi_files, cube_path, verbose=False)
@@ -45,47 +45,47 @@ def test_make_cube(tmpdir, img_size, num_images, tmp_path):
         cube = hdu[1].data
         tab = Table(hdu[2].data)
         filenames = np.array([Path(x).name for x in ffi_files])
-    
+
         # Expected cube shape and values
         ecube = np.zeros((img_size, img_size, num_images, 2))
-        plane = np.arange(img_size*img_size, dtype=np.float32).reshape((img_size, img_size))
-        assert cube.shape == ecube.shape, 'Mismatch between cube shape and expected shape'
+        plane = np.arange(img_size * img_size, dtype=np.float32).reshape((img_size, img_size))
+        assert cube.shape == ecube.shape, "Mismatch between cube shape and expected shape"
 
         for i in range(num_images):
             ecube[:, :, i, 0] = -plane
             ecube[:, :, i, 1] = plane
             plane += img_size * img_size
-        assert np.all(cube == ecube), 'Cube values do not match expected values'
-        
-        assert np.all(tab['TSTART'] == np.arange(num_images)), 'TSTART mismatch in table'
-        assert np.all(tab['TSTOP'] == np.arange(num_images)+1), 'TSTOP mismatch in table'
-        assert np.all(tab['FFI_FILE'] == np.array(filenames)), 'FFI_FILE mismatch in table'
-    
+        assert np.all(cube == ecube), "Cube values do not match expected values"
+
+        assert np.all(tab["TSTART"] == np.arange(num_images)), "TSTART mismatch in table"
+        assert np.all(tab["TSTOP"] == np.arange(num_images) + 1), "TSTOP mismatch in table"
+        assert np.all(tab["FFI_FILE"] == np.array(filenames)), "FFI_FILE mismatch in table"
+
 
 def test_make_and_update_cube(tmpdir, img_size, num_images):
     """
-    Testing the make cube and update cube functionality for TICACubeFactory by making a bunch of test FFIs, 
+    Testing the make cube and update cube functionality for TICACubeFactory by making a bunch of test FFIs,
     making the cube with first half of the FFIs, updating the same cube with the second half,
     and checking the results.
     """
     cube_maker = TicaCubeFactory()
     tmp_path = Path(tmpdir)
-    
+
     # Create test FFIs
-    ffi_files = create_test_ffis(img_size, num_images, product='TICA', dir_name=tmpdir)
-    cube_path = tmp_path / 'out_dir' / 'test_update_cube.fits'
+    ffi_files = create_test_ffis(img_size, num_images, product="TICA", dir_name=tmpdir)
+    cube_path = tmp_path / "out_dir" / "test_update_cube.fits"
 
     # Generate cube
-    cube_file = cube_maker.make_cube(ffi_files[:num_images // 2], cube_path, verbose=False)
+    cube_file = cube_maker.make_cube(ffi_files[: num_images // 2], cube_path, verbose=False)
 
     with fits.open(cube_file) as hdu:
         cube = hdu[1].data
 
         # Expected values for cube before update_cube
         ecube = np.zeros((img_size, img_size, num_images // 2, 1))
-        plane = np.arange(img_size*img_size, dtype=np.float32).reshape((img_size, img_size))
+        plane = np.arange(img_size * img_size, dtype=np.float32).reshape((img_size, img_size))
 
-        assert cube.shape == ecube.shape, 'Mismatch between cube shape and expected shape'
+        assert cube.shape == ecube.shape, "Mismatch between cube shape and expected shape"
 
         for i in range(num_images // 2):
             ecube[:, :, i, 0] = -plane
@@ -94,21 +94,21 @@ def test_make_and_update_cube(tmpdir, img_size, num_images):
             # ecube[:, :, i, 1] = plane
             plane += img_size * img_size
 
-        assert np.all(cube == ecube), 'Cube values do not match expected values'
+        assert np.all(cube == ecube), "Cube values do not match expected values"
 
     # Update cube
-    cube_file = cube_maker.update_cube(ffi_files[num_images // 2:], cube_file, verbose=False)
+    cube_file = cube_maker.update_cube(ffi_files[num_images // 2 :], cube_file, verbose=False)
 
     with fits.open(cube_file) as hdu:
         cube = hdu[1].data
         tab = Table(hdu[2].data)
         filenames = np.array([Path(x).name for x in ffi_files])
-    
+
         # Expected values for cube after update_cube
         ecube = np.zeros((img_size, img_size, num_images, 1))
-        plane = np.arange(img_size*img_size, dtype=np.float32).reshape((img_size, img_size))
+        plane = np.arange(img_size * img_size, dtype=np.float32).reshape((img_size, img_size))
 
-        assert cube.shape == ecube.shape, 'Mismatch between cube shape and expected shape'
+        assert cube.shape == ecube.shape, "Mismatch between cube shape and expected shape"
 
         for i in range(num_images):
             ecube[:, :, i, 0] = -plane
@@ -117,16 +117,16 @@ def test_make_and_update_cube(tmpdir, img_size, num_images):
             # ecube[:, :, i, 1] = plane
             plane += img_size * img_size
 
-        assert np.all(cube == ecube), 'Cube values do not match expected values'
-        assert np.all(tab['STARTTJD'] == np.arange(num_images)), 'STARTTJD mismatch in table'
-        assert np.all(tab['ENDTJD'] == np.arange(num_images)+1), 'ENDTJD mismatch in table'
-        assert np.all(tab['FFI_FILE'] == np.array(filenames)), 'FFI_FILE mismatch in table'
+        assert np.all(cube == ecube), "Cube values do not match expected values"
+        assert np.all(tab["STARTTJD"] == np.arange(num_images)), "STARTTJD mismatch in table"
+        assert np.all(tab["ENDTJD"] == np.arange(num_images) + 1), "ENDTJD mismatch in table"
+        assert np.all(tab["FFI_FILE"] == np.array(filenames)), "FFI_FILE mismatch in table"
 
     # Fail if trying to update a cube with no new files
-    with pytest.raises(InvalidInputError, match='No new images were found'):
-        with pytest.warns(DataWarning, match='Removed duplicate file'):
+    with pytest.raises(InvalidInputError, match="No new images were found"):
+        with pytest.warns(DataWarning, match="Removed duplicate file"):
             cube_maker.update_cube(ffi_files[:1], cube_file)
-    
+
 
 def test_iteration(tmpdir, caplog):
     """
@@ -141,66 +141,58 @@ def test_iteration(tmpdir, caplog):
     ffi_files = create_test_ffis(img_size, num_images, dir_name=tmpdir)
 
     # Single iteration (higher memory usage)
-    cube_file_1 = cube_maker.make_cube(ffi_files, tmp_path / 'iterated_cube_1.fits',
-                                       max_memory=0.5, verbose=True)
-    assert len(findall('Completed block', caplog.text)) == 1, 'Incorrect number of iterations'
-    assert len(findall('Completed file', caplog.text)) == num_images, 'Incorrect number of complete files'
+    cube_file_1 = cube_maker.make_cube(ffi_files, tmp_path / "iterated_cube_1.fits", max_memory=0.5, verbose=True)
+    assert len(findall("Completed block", caplog.text)) == 1, "Incorrect number of iterations"
+    assert len(findall("Completed file", caplog.text)) == num_images, "Incorrect number of complete files"
     caplog.clear()
 
     # Multiple iterations (lower memory usage)
-    cube_file_2 = cube_maker.make_cube(ffi_files, tmp_path / 'iterated_cube_2.fits',
-                                       max_memory=0.05, verbose=True)
-    print(len(findall('Completed block', caplog.text)))
-    assert len(findall('Completed block', caplog.text)) == 2, 'Incorrect number of iterations'
-    assert len(findall('Completed file', caplog.text)) == num_images * 2, 'Incorrect number of complete files'
+    cube_file_2 = cube_maker.make_cube(ffi_files, tmp_path / "iterated_cube_2.fits", max_memory=0.05, verbose=True)
+    print(len(findall("Completed block", caplog.text)))
+    assert len(findall("Completed block", caplog.text)) == 2, "Incorrect number of iterations"
+    assert len(findall("Completed file", caplog.text)) == num_images * 2, "Incorrect number of complete files"
 
     # Open FITS files and compare cubes
     with fits.open(cube_file_1) as hdu_1, fits.open(cube_file_2) as hdu_2:
         cube_1 = hdu_1[1].data
         cube_2 = hdu_2[1].data
 
-        assert cube_1.shape == cube_2.shape, 'Mismatch between cube shape for 1 vs 2 iterations'
-        assert np.all(cube_1 == cube_2), 'Cubes made in 1 vs 2 iterations do not match'
+        assert cube_1.shape == cube_2.shape, "Mismatch between cube shape for 1 vs 2 iterations"
+        assert np.all(cube_1 == cube_2), "Cubes made in 1 vs 2 iterations do not match"
 
         # Expected values for cube
         ecube = np.zeros((img_size, img_size, num_images, 2))
         plane = np.arange(img_size * img_size, dtype=np.float32).reshape((img_size, img_size))
-        assert cube_1.shape == ecube.shape, 'Mismatch between cube shape and expected shape'
+        assert cube_1.shape == ecube.shape, "Mismatch between cube shape and expected shape"
 
         for i in range(num_images):
             ecube[:, :, i, 0] = -plane
             ecube[:, :, i, 1] = plane
             plane += img_size * img_size
 
-        assert np.all(cube_1 == ecube), 'Cube values do not match expected values'
+        assert np.all(cube_1 == ecube), "Cube values do not match expected values"
 
 
-@pytest.mark.parametrize('ffi_type', ['TICA', 'SPOC'])
+@pytest.mark.parametrize("ffi_type", ["TICA", "SPOC"])
 def test_invalid_inputs(tmpdir, ffi_type, img_size, num_images):
     """
     Test that an error is raised when users attempt to make cubes with an invalid file type.
     """
     # Assigning some variables
-    product = 'TICA' if ffi_type == 'TICA' else 'SPOC'
-    value_error = ('One or more incorrect file types were input.')
-    
+    product = "TICA" if ffi_type == "TICA" else "SPOC"
+    value_error = "One or more incorrect file types were input."
+
     # Create test FFI files
-    ffi_files = create_test_ffis(img_size=img_size, 
-                                 num_images=num_images,
-                                 dir_name=tmpdir, 
-                                 product=product)
-    
+    ffi_files = create_test_ffis(img_size=img_size, num_images=num_images, dir_name=tmpdir, product=product)
+
     # Create opposite cube factory of input
-    cube_maker = CubeFactory() if ffi_type == 'TICA' else TicaCubeFactory()
+    cube_maker = CubeFactory() if ffi_type == "TICA" else TicaCubeFactory()
 
     # Should raise a Value Error due to incorrect file type
     with pytest.raises(ValueError, match=value_error):
         cube_maker.make_cube(ffi_files)
 
     # Fail if trying to update a cube file that doesn't exist
-    new_ffi_files = create_test_ffis(img_size=10, 
-                                     num_images=10,
-                                     dir_name=tmpdir, 
-                                     product=product)
-    with pytest.raises(InvalidInputError, match='Cube file was not found'):
-        cube_maker.update_cube(new_ffi_files, 'non_existent_file.fits')
+    new_ffi_files = create_test_ffis(img_size=10, num_images=10, dir_name=tmpdir, product=product)
+    with pytest.raises(InvalidInputError, match="Cube file was not found"):
+        cube_maker.update_cube(new_ffi_files, "non_existent_file.fits")

--- a/astrocut/tests/test_cutout_processing.py
+++ b/astrocut/tests/test_cutout_processing.py
@@ -1,62 +1,66 @@
-import os 
-import pytest
+import os
 
 import numpy as np
-
-from astropy.io import fits
-from astropy.utils.data import get_pkg_data_filename
-from astropy.wcs import WCS
+import pytest
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from astropy.table import Table
 from astropy.time import Time
+from astropy.utils.data import get_pkg_data_filename
+from astropy.wcs import WCS
 
+from .. import CubeFactory, CutoutFactory, cutout_processing, fits_cut
 from .utils_for_test import create_test_ffis, create_test_imgs
-from .. import cutout_processing, CubeFactory, CutoutFactory, fits_cut
-
 
 # Example FFI WCS for testing
-with open(get_pkg_data_filename('data/ex_ffi_wcs.txt'), "r") as FLE:
+with open(get_pkg_data_filename("data/ex_ffi_wcs.txt"), "r") as FLE:
     WCS_STR = FLE.read()
 
 
 def test_combine_headers():
-
-    header_1 = fits.Header(cards=[('KWD_SHR', 20, 'Shared keyword'),
-                                  ('KWD_DIF', 'one', 'Different keyword'),
-                                  ('CHECKSUM', 1283726182378, "Keyword to drop")])
-    header_2 = fits.Header(cards=[('KWD_SHR', 20, 'Shared keyword'),
-                                  ('KWD_DIF', 'two', 'Different keyword'),
-                                  ('CHECKSUM', 1248721378218, "Keyword to drop")])
+    header_1 = fits.Header(
+        cards=[
+            ("KWD_SHR", 20, "Shared keyword"),
+            ("KWD_DIF", "one", "Different keyword"),
+            ("CHECKSUM", 1283726182378, "Keyword to drop"),
+        ]
+    )
+    header_2 = fits.Header(
+        cards=[
+            ("KWD_SHR", 20, "Shared keyword"),
+            ("KWD_DIF", "two", "Different keyword"),
+            ("CHECKSUM", 1248721378218, "Keyword to drop"),
+        ]
+    )
 
     combined_header = cutout_processing._combine_headers([header_1, header_2])
 
-    assert len(combined_header) == 7 
-    assert 'KWD_SHR' in combined_header
-    assert 'KWD_DIF' not in combined_header
-    assert 'CHECKSUM' not in combined_header
-    assert combined_header['F01_K01'] == combined_header['F02_K01']
-    assert combined_header['F01_V01'] != combined_header['F02_V01']
-    assert combined_header['F01_V01'] == header_1[combined_header['F01_K01']]
-    assert 'F01_K02' not in combined_header
+    assert len(combined_header) == 7
+    assert "KWD_SHR" in combined_header
+    assert "KWD_DIF" not in combined_header
+    assert "CHECKSUM" not in combined_header
+    assert combined_header["F01_K01"] == combined_header["F02_K01"]
+    assert combined_header["F01_V01"] != combined_header["F02_V01"]
+    assert combined_header["F01_V01"] == header_1[combined_header["F01_K01"]]
+    assert "F01_K02" not in combined_header
 
     combined_header = cutout_processing._combine_headers([header_1, header_2], constant_only=True)
     assert len(combined_header) == 1
-    assert 'KWD_SHR' in combined_header
-    assert 'KWD_DIF' not in combined_header
-    assert 'F01_K01' not in combined_header
+    assert "KWD_SHR" in combined_header
+    assert "KWD_DIF" not in combined_header
+    assert "F01_K01" not in combined_header
 
 
 def test_get_bounds():
-
     x = [5, 10]
     y = [2, 20]
     size = [3, 5]
     bounds = cutout_processing._get_bounds(x, y, size)
     assert (bounds == np.array([[[4, 7], [0, 5]], [[8, 11], [18, 23]]])).all()
-    
+
     for nx, ny in bounds:
-        assert nx[1]-nx[0] == size[0]
-        assert ny[1]-ny[0] == size[1]
+        assert nx[1] - nx[0] == size[0]
+        assert ny[1] - ny[0] == size[1]
 
     # test that if we move the center a small amount, we still get the same integer bounds
     x = [5.9, 9.8]
@@ -65,14 +69,13 @@ def test_get_bounds():
 
 
 def test_combine_bounds():
-
     x = [5, 10]
     y = [2, 20]
     size = [3, 5]
     bounds = cutout_processing._get_bounds(x, y, size)
 
     big_bounds = cutout_processing._combine_bounds(bounds[0], bounds[1])
-    
+
     assert big_bounds.dtype == int
     for bx, by in bounds:
         assert big_bounds[0, 0] <= bx[0]
@@ -82,12 +85,11 @@ def test_combine_bounds():
 
 
 def test_area():
-
     x = [5, 10]
     y = [2, 20]
     size = [3, 5]
     area = np.multiply(*size)
-    
+
     bounds = cutout_processing._get_bounds(x, y, size)
     area_0 = cutout_processing._area(bounds[0])
     area_1 = cutout_processing._area(bounds[1])
@@ -97,7 +99,6 @@ def test_area():
 
 
 def test_get_args():
-
     wcs_obj = WCS(WCS_STR, relax=True)
     bounds = np.array([[0, 4], [0, 6]])
 
@@ -107,37 +108,41 @@ def test_get_args():
 
 
 def test_moving_target_focus(tmpdir):
-
     # Making the test cube/cutout
     cube_maker = CubeFactory()
-    
+
     img_sz = 1000
     num_im = 10
-    
+
     ffi_files = create_test_ffis(img_size=img_sz, num_images=num_im, dir_name=tmpdir)
     cube_file = cube_maker.make_cube(ffi_files, os.path.join(tmpdir, "test_cube.fits"), verbose=False)
 
-    cutout_file = CutoutFactory().cube_cut(cube_file, "250.3497414839765  2.280925599609063", 100, 
-                                           target_pixel_file="cutout_file.fits", output_path=tmpdir,
-                                           verbose=False)
+    cutout_file = CutoutFactory().cube_cut(
+        cube_file,
+        "250.3497414839765  2.280925599609063",
+        100,
+        target_pixel_file="cutout_file.fits",
+        output_path=tmpdir,
+        verbose=False,
+    )
 
     cutout_wcs = WCS(fits.getheader(cutout_file, 2))
     cutout_data = Table(fits.getdata(cutout_file, 1))
 
     # Focusing on a path where the time points line up with cutout times
     coords = cutout_wcs.pixel_to_world([4, 5, 10, 20], [10, 10, 11, 12])
-    times = Time(Table(fits.getdata(cutout_file, 1))["TIME"].data[:len(coords)] + 2457000, format="jd")
+    times = Time(Table(fits.getdata(cutout_file, 1))["TIME"].data[: len(coords)] + 2457000, format="jd")
     path = Table({"time": times, "position": coords})
     size = [4, 4]
 
     mt_cutout_table = cutout_processing._moving_target_focus(path, size, [cutout_file])
     assert np.allclose(coords.ra.deg, mt_cutout_table["TGT_RA"])
     assert np.allclose(coords.dec.deg, mt_cutout_table["TGT_DEC"])
-    assert (mt_cutout_table["TIME"] == cutout_data["TIME"][:len(coords)]).all()
-    assert (mt_cutout_table["FFI_FILE"] == cutout_data["FFI_FILE"][:len(coords)]).all()
+    assert (mt_cutout_table["TIME"] == cutout_data["TIME"][: len(coords)]).all()
+    assert (mt_cutout_table["FFI_FILE"] == cutout_data["FFI_FILE"][: len(coords)]).all()
 
     # Focusing on a path where interpolation will actually have to be used
-    times = Time(Table(fits.getdata(cutout_file, 1))["TIME"].data[:len(coords)*2:2] + 2457000, format="jd")
+    times = Time(Table(fits.getdata(cutout_file, 1))["TIME"].data[: len(coords) * 2 : 2] + 2457000, format="jd")
     path = Table({"time": times, "position": coords})
 
     mt_cutout_table = cutout_processing._moving_target_focus(path, size, [cutout_file])
@@ -146,7 +151,6 @@ def test_moving_target_focus(tmpdir):
 
 
 def test_path_to_footprints():
-
     img_wcs = WCS(WCS_STR, relax=True)
     size = [4, 5]
 
@@ -160,8 +164,8 @@ def test_path_to_footprints():
     assert (np.max(xs) - np.min(xs) + size[0]) == footprints[0]["size"][1]
     assert (np.max(ys) - np.min(ys) + size[1]) == footprints[0]["size"][0]
 
-    cent_x = (np.max(xs) - np.min(xs) + size[0])//2 + np.min(xs) - size[0]/2 
-    cent_y = (np.max(ys) - np.min(ys) + size[1])//2 + np.min(ys) - size[1]/2 
+    cent_x = (np.max(xs) - np.min(xs) + size[0]) // 2 + np.min(xs) - size[0] / 2
+    cent_y = (np.max(ys) - np.min(ys) + size[1]) // 2 + np.min(ys) - size[1] / 2
     assert (img_wcs.pixel_to_world([cent_x], [cent_y]) == footprints[0]["coordinates"]).all()
 
     # Lowering the max pixels so we force >1 footprint
@@ -172,32 +176,35 @@ def test_path_to_footprints():
     for fp in footprints:
         assert np.multiply(*fp["size"]) <= max_pixels
 
-    
-def test_configure_bintable_header(tmpdir):
-    
 
+def test_configure_bintable_header(tmpdir):
     # Making the test cube/cutout/table we need
     cube_maker = CubeFactory()
-    
+
     img_sz = 1000
     num_im = 10
-    
+
     ffi_files = create_test_ffis(img_sz, num_im, dir_name=tmpdir)
     cube_file = cube_maker.make_cube(ffi_files, os.path.join(tmpdir, "test_cube.fits"), verbose=False)
 
-    cutout_file = CutoutFactory().cube_cut(cube_file, "250.3497414839765  2.280925599609063", 100, 
-                                           target_pixel_file="cutout_file.fits", output_path=tmpdir,
-                                           verbose=False)
+    cutout_file = CutoutFactory().cube_cut(
+        cube_file,
+        "250.3497414839765  2.280925599609063",
+        100,
+        target_pixel_file="cutout_file.fits",
+        output_path=tmpdir,
+        verbose=False,
+    )
 
     cutout_wcs = WCS(fits.getheader(cutout_file, 2))
     coords = cutout_wcs.pixel_to_world([4, 5, 10, 20], [10, 10, 11, 12])
-    times = Time(Table(fits.getdata(cutout_file, 1))["TIME"].data[:len(coords)] + 2457000, format="jd")
+    times = Time(Table(fits.getdata(cutout_file, 1))["TIME"].data[: len(coords)] + 2457000, format="jd")
     path = Table({"time": times, "position": coords})
     size = [4, 4]
 
     mt_cutout_table = cutout_processing._moving_target_focus(path, size, [cutout_file])
     mt_cutout_fits_table = fits.table_to_hdu(mt_cutout_table)
-    
+
     new_header = mt_cutout_fits_table.header
     orig_header = new_header.copy()
     cutout_header = fits.getheader(cutout_file, 1)
@@ -214,86 +221,94 @@ def test_configure_bintable_header(tmpdir):
 
 @pytest.mark.parametrize("in_target, out_file", [(None, "path_"), ("C/ Targetname", "C-_Targetname")])
 def test_center_on_path(tmpdir, in_target, out_file):
-    
     # Making the test cube/cutout
     cube_maker = CubeFactory()
-    
+
     img_sz = 1000
     num_im = 10
-    
+
     ffi_files = create_test_ffis(img_sz, num_im, dir_name=tmpdir)
     cube_file = cube_maker.make_cube(ffi_files, os.path.join(tmpdir, "test_cube.fits"), verbose=False)
 
     cutout_maker = CutoutFactory()
-    cutout_file = cutout_maker.cube_cut(cube_file, "250.3497414839765  2.280925599609063", 100, 
-                                        target_pixel_file="cutout_file.fits", output_path=tmpdir,
-                                        verbose=False)
+    cutout_file = cutout_maker.cube_cut(
+        cube_file,
+        "250.3497414839765  2.280925599609063",
+        100,
+        target_pixel_file="cutout_file.fits",
+        output_path=tmpdir,
+        verbose=False,
+    )
 
     cutout_wcs = WCS(fits.getheader(cutout_file, 2))
 
     coords = cutout_wcs.pixel_to_world([4, 5, 10, 20], [10, 10, 11, 12])
-    times = Time(Table(fits.getdata(cutout_file, 1))["TIME"].data[:len(coords)] + 2457000, format="jd")
+    times = Time(Table(fits.getdata(cutout_file, 1))["TIME"].data[: len(coords)] + 2457000, format="jd")
     path = Table({"time": times, "position": coords})
     size = [4, 4]
 
     # Parametrization of 2 tests
     # Test 1: Using the default output filename and not giving an image wcs
     # Test 2: Using target name with special characters and not giving an image wcs
-    output = cutout_processing.center_on_path(path, size, 
-                                              cutout_fles=[cutout_file], 
-                                              target=in_target, 
-                                              output_path=tmpdir, 
-                                              verbose=False)
+    output = cutout_processing.center_on_path(
+        path, size, cutout_fles=[cutout_file], target=in_target, output_path=tmpdir, verbose=False
+    )
     output_file = os.path.basename(output)
     assert output_file.startswith(out_file)
 
     hdu = fits.open(output)
     assert len(hdu) == 2
-    assert hdu[0].header["DATE"] == Time.now().to_value('iso', subfmt='date')
-    assert hdu[0].header["OBJECT"] == '' if in_target is None else in_target
+    assert hdu[0].header["DATE"] == Time.now().to_value("iso", subfmt="date")
+    assert hdu[0].header["OBJECT"] == "" if in_target is None else in_target
     hdu.close()
 
 
 def test_center_on_path_input_tpf(tmpdir):
-    
     # Making the test cube/cutout
     cube_maker = CubeFactory()
-    
+
     img_sz = 1000
     num_im = 10
-    
+
     ffi_files = create_test_ffis(img_sz, num_im, dir_name=tmpdir)
     cube_file = cube_maker.make_cube(ffi_files, os.path.join(tmpdir, "test_cube.fits"), verbose=False)
 
     cutout_maker = CutoutFactory()
-    cutout_file = cutout_maker.cube_cut(cube_file, "250.3497414839765  2.280925599609063", 100, 
-                                        target_pixel_file="cutout_file.fits", output_path=tmpdir,
-                                        verbose=False)
+    cutout_file = cutout_maker.cube_cut(
+        cube_file,
+        "250.3497414839765  2.280925599609063",
+        100,
+        target_pixel_file="cutout_file.fits",
+        output_path=tmpdir,
+        verbose=False,
+    )
 
     cutout_wcs = WCS(fits.getheader(cutout_file, 2))
 
     coords = cutout_wcs.pixel_to_world([4, 5, 10, 20], [10, 10, 11, 12])
-    times = Time(Table(fits.getdata(cutout_file, 1))["TIME"].data[:len(coords)] + 2457000, format="jd")
+    times = Time(Table(fits.getdata(cutout_file, 1))["TIME"].data[: len(coords)] + 2457000, format="jd")
     path = Table({"time": times, "position": coords})
     size = [4, 4]
 
     # Giving both a target name and a specific output filename
     img_wcs = cutout_maker.cube_wcs
-    output = cutout_processing.center_on_path(path, 
-                                              size, 
-                                              cutout_fles=[cutout_file], 
-                                              target="Target Name", 
-                                              img_wcs=img_wcs, 
-                                              target_pixel_file="mt_cutout.fits", 
-                                              output_path=tmpdir, 
-                                              verbose=False)
+    output = cutout_processing.center_on_path(
+        path,
+        size,
+        cutout_fles=[cutout_file],
+        target="Target Name",
+        img_wcs=img_wcs,
+        target_pixel_file="mt_cutout.fits",
+        output_path=tmpdir,
+        verbose=False,
+    )
     assert "mt_cutout.fits" in output
-    
+
     mt_wcs = WCS(fits.getheader(output, 2))
     assert img_wcs.to_header(relax=True) == mt_wcs.to_header(relax=True)
 
     primary_header = fits.getheader(output)
-    assert primary_header["DATE"] == Time.now().to_value('iso', subfmt='date')
+    assert primary_header["DATE"] == Time.now().to_value("iso", subfmt="date")
     assert primary_header["OBJECT"] == "Target Name"
 
 
@@ -337,17 +352,14 @@ def test_default_combine():
     assert np.allclose(combine_func([hdu_1, hdu_2]), [[1, np.nan], [1, 1]], equal_nan=True)
 
 
-@pytest.mark.parametrize('ffi_type', ['SPOC', 'TICA'])
+@pytest.mark.parametrize("ffi_type", ["SPOC", "TICA"])
 def test_combiner(tmpdir, ffi_type):
-
     test_images = create_test_imgs(ffi_type, 50, 6, dir_name=tmpdir)
-    center_coord = SkyCoord("150.1163213 2.200973097", unit='deg')
+    center_coord = SkyCoord("150.1163213 2.200973097", unit="deg")
     cutout_size = 2
 
-    cutout_file_1 = fits_cut(test_images[:3], center_coord, cutout_size, 
-                             cutout_prefix="cutout_1", output_dir=tmpdir)
-    cutout_file_2 = fits_cut(test_images[3:], center_coord, cutout_size, 
-                             cutout_prefix="cutout_2", output_dir=tmpdir)
+    cutout_file_1 = fits_cut(test_images[:3], center_coord, cutout_size, cutout_prefix="cutout_1", output_dir=tmpdir)
+    cutout_file_2 = fits_cut(test_images[3:], center_coord, cutout_size, cutout_prefix="cutout_2", output_dir=tmpdir)
 
     combiner = cutout_processing.CutoutsCombiner([cutout_file_1, cutout_file_2])
 
@@ -366,8 +378,8 @@ def test_combiner(tmpdir, ffi_type):
     comb_hdu = fits.open(out_fle)
     assert len(comb_hdu) == 4
     assert (comb_hdu[1].data == comb_1).all()
-    assert np.isclose(comb_hdu[0].header['RA_OBJ'], center_coord.ra.deg)
-    assert np.isclose(comb_hdu[0].header['DEC_OBJ'], center_coord.dec.deg)
+    assert np.isclose(comb_hdu[0].header["RA_OBJ"], center_coord.ra.deg)
+    assert np.isclose(comb_hdu[0].header["DEC_OBJ"], center_coord.dec.deg)
     comb_hdu.close()
 
     # Checking memory only input and output

--- a/astrocut/tests/test_cutouts.py
+++ b/astrocut/tests/test_cutouts.py
@@ -1,32 +1,29 @@
-import pytest
-
-import numpy as np
 from os import path
 from re import findall
 
-from astropy.io import fits
+import numpy as np
+import pytest
+from astropy import units as u
 from astropy import wcs
 from astropy.coordinates import SkyCoord
-from astropy import units as u
-
+from astropy.io import fits
 from PIL import Image
 
-from .utils_for_test import create_test_imgs
 from .. import fits_cut, img_cut, normalize_img
-from ..exceptions import DataWarning, InputWarning, InvalidInputError, InvalidQueryError 
+from ..exceptions import DataWarning, InputWarning, InvalidInputError, InvalidQueryError
+from .utils_for_test import create_test_imgs
 
 
-@pytest.mark.parametrize('ffi_type', ['SPOC', 'TICA'])
+@pytest.mark.parametrize("ffi_type", ["SPOC", "TICA"])
 def test_fits_cut(tmpdir, caplog, ffi_type):
-
     test_images = create_test_imgs(ffi_type, 50, 6, dir_name=tmpdir)
 
     # Single file
-    center_coord = SkyCoord("150.1163213 2.200973097", unit='deg')
+    center_coord = SkyCoord("150.1163213 2.200973097", unit="deg")
     cutout_size = 10
     cutout_file = fits_cut(test_images, center_coord, cutout_size, single_outfile=True, output_dir=tmpdir)
     assert isinstance(cutout_file, str)
-    
+
     cutout_hdulist = fits.open(cutout_file)
     assert len(cutout_hdulist) == len(test_images) + 1  # num imgs + primary header
 
@@ -37,9 +34,9 @@ def test_fits_cut(tmpdir, caplog, ffi_type):
     assert cutout_hdulist[3].data.shape == cutout_hdulist[4].data.shape
     assert cutout_hdulist[4].data.shape == cutout_hdulist[5].data.shape
     assert cutout_hdulist[5].data.shape == cutout_hdulist[6].data.shape
-    
+
     cut_wcs = wcs.WCS(cutout_hdulist[1].header)
-    sra, sdec = cut_wcs.all_pix2world(cutout_size/2, cutout_size/2, 0)
+    sra, sdec = cut_wcs.all_pix2world(cutout_size / 2, cutout_size / 2, 0)
     assert round(float(sra), 4) == round(center_coord.ra.deg, 4)
     assert round(float(sdec), 4) == round(center_coord.dec.deg, 4)
 
@@ -53,12 +50,12 @@ def test_fits_cut(tmpdir, caplog, ffi_type):
 
     cutout_hdulist = fits.open(cutout_files[0])
     assert len(cutout_hdulist) == 2
-    
+
     cut1 = cutout_hdulist[1].data
     assert cut1.shape == (cutout_size, cutout_size)
-    
+
     cut_wcs = wcs.WCS(cutout_hdulist[1].header)
-    sra, sdec = cut_wcs.all_pix2world(cutout_size/2, cutout_size/2, 0)
+    sra, sdec = cut_wcs.all_pix2world(cutout_size / 2, cutout_size / 2, 0)
     assert round(float(sra), 4) == round(center_coord.ra.deg, 4)
     assert round(float(sdec), 4) == round(center_coord.dec.deg, 4)
 
@@ -66,16 +63,18 @@ def test_fits_cut(tmpdir, caplog, ffi_type):
 
     # Memory only, single file
     nonexisting_dir = "nonexisting"  # non-existing directory to check that no files are written
-    cutout_list = fits_cut(test_images, center_coord, cutout_size, 
-                           output_dir=nonexisting_dir, single_outfile=True, memory_only=True)
+    cutout_list = fits_cut(
+        test_images, center_coord, cutout_size, output_dir=nonexisting_dir, single_outfile=True, memory_only=True
+    )
     assert isinstance(cutout_list, list)
     assert len(cutout_list) == 1
     assert isinstance(cutout_list[0], fits.HDUList)
     assert not path.exists(nonexisting_dir)  # no files should be written
 
     # Memory only, multiple files
-    cutout_list = fits_cut(test_images, center_coord, cutout_size, 
-                           output_dir=nonexisting_dir, single_outfile=False, memory_only=True)
+    cutout_list = fits_cut(
+        test_images, center_coord, cutout_size, output_dir=nonexisting_dir, single_outfile=False, memory_only=True
+    )
     assert isinstance(cutout_list, list)
     assert len(cutout_list) == len(test_images)
     assert isinstance(cutout_list[0], fits.HDUList)
@@ -83,41 +82,39 @@ def test_fits_cut(tmpdir, caplog, ffi_type):
 
     # Output directory that has to be created
     new_dir = path.join(tmpdir, "cutout_files")  # non-existing directory to write files to
-    cutout_files = fits_cut(test_images, center_coord, cutout_size,
-                            output_dir=new_dir, single_outfile=False)
+    cutout_files = fits_cut(test_images, center_coord, cutout_size, output_dir=new_dir, single_outfile=False)
 
     assert isinstance(cutout_files, list)
     assert len(cutout_files) == len(test_images)
     assert new_dir in cutout_files[0]
     assert path.exists(new_dir)  # new directory should now exist
-    
+
     # Do an off the edge test
-    center_coord = SkyCoord("150.1163213 2.2005731", unit='deg')
+    center_coord = SkyCoord("150.1163213 2.2005731", unit="deg")
     cutout_file = fits_cut(test_images, center_coord, cutout_size, single_outfile=True, output_dir=tmpdir)
     assert isinstance(cutout_file, str)
-    
+
     cutout_hdulist = fits.open(cutout_file)
     assert len(cutout_hdulist) == len(test_images) + 1  # num imgs + primary header
 
     cut1 = cutout_hdulist[1].data
     assert cut1.shape == (cutout_size, cutout_size)
-    assert np.isnan(cut1[:cutout_size//2, :]).all()
+    assert np.isnan(cut1[: cutout_size // 2, :]).all()
 
     cutout_hdulist.close()
 
     # Test when the requested cutout is not on the image
-    center_coord = SkyCoord("140.1163213 2.2005731", unit='deg')
-    with pytest.warns(DataWarning, match='does not overlap'):
-        with pytest.warns(DataWarning, match='contains no data, skipping...'):
-            with pytest.raises(InvalidQueryError, match='Cutout contains no data!'):
+    center_coord = SkyCoord("140.1163213 2.2005731", unit="deg")
+    with pytest.warns(DataWarning, match="does not overlap"):
+        with pytest.warns(DataWarning, match="contains no data, skipping..."):
+            with pytest.raises(InvalidQueryError, match="Cutout contains no data!"):
                 cutout_file = fits_cut(test_images, center_coord, cutout_size, single_outfile=True)
 
-    center_coord = SkyCoord("15.1163213 2.2005731", unit='deg')
-    with pytest.warns(DataWarning, match='does not overlap'):
-        with pytest.warns(DataWarning, match='contains no data, skipping...'):
-            with pytest.raises(InvalidQueryError, match='Cutout contains no data!'):
+    center_coord = SkyCoord("15.1163213 2.2005731", unit="deg")
+    with pytest.warns(DataWarning, match="does not overlap"):
+        with pytest.warns(DataWarning, match="contains no data, skipping..."):
+            with pytest.raises(InvalidQueryError, match="Cutout contains no data!"):
                 cutout_file = fits_cut(test_images, center_coord, cutout_size, single_outfile=True)
-    
 
     # Test when cutout is in some images not others
     # Putting zeros into 2 images
@@ -126,11 +123,11 @@ def test_fits_cut(tmpdir, caplog, ffi_type):
         hdu[0].data[:20, :] = 0
         hdu.flush()
         hdu.close()
-        
-    center_coord = SkyCoord("150.1163213 2.2007", unit='deg')
-    with pytest.warns(DataWarning, match='contains no data, skipping...'):
+
+    center_coord = SkyCoord("150.1163213 2.2007", unit="deg")
+    with pytest.warns(DataWarning, match="contains no data, skipping..."):
         cutout_file = fits_cut(test_images, center_coord, cutout_size, single_outfile=True, output_dir=tmpdir)
-    
+
     cutout_hdulist = fits.open(cutout_file)
     assert len(cutout_hdulist) == len(test_images) - 1  # 6 images - 2 empty + 1 primary header
     assert ~(cutout_hdulist[1].data == 0).any()
@@ -138,7 +135,7 @@ def test_fits_cut(tmpdir, caplog, ffi_type):
     assert ~(cutout_hdulist[3].data == 0).any()
     assert ~(cutout_hdulist[4].data == 0).any()
 
-    with pytest.warns(DataWarning, match='contains no data'):
+    with pytest.warns(DataWarning, match="contains no data"):
         cutout_files = fits_cut(test_images, center_coord, cutout_size, single_outfile=False, output_dir=tmpdir)
     assert isinstance(cutout_files, list)
     assert len(cutout_files) == len(test_images) - 2
@@ -150,16 +147,16 @@ def test_fits_cut(tmpdir, caplog, ffi_type):
         hdu.flush()
         hdu.close()
 
-    with pytest.warns(DataWarning, match='contains no data, skipping...'):
-        with pytest.raises(InvalidQueryError, match='Cutout contains no data!'):
-            cutout_file = fits_cut(test_images, center_coord, cutout_size, single_outfile=True, 
-                                   output_dir=tmpdir)
+    with pytest.warns(DataWarning, match="contains no data, skipping..."):
+        with pytest.raises(InvalidQueryError, match="Cutout contains no data!"):
+            cutout_file = fits_cut(test_images, center_coord, cutout_size, single_outfile=True, output_dir=tmpdir)
 
     # test single image and also conflicting sip keywords
-    test_image = create_test_imgs(ffi_type, 50, 1, dir_name=tmpdir,
-                                  basename="img_badsip_{:04d}.fits", bad_sip_keywords=True)[0]
+    test_image = create_test_imgs(
+        ffi_type, 50, 1, dir_name=tmpdir, basename="img_badsip_{:04d}.fits", bad_sip_keywords=True
+    )[0]
 
-    center_coord = SkyCoord("150.1163213 2.2007", unit='deg')
+    center_coord = SkyCoord("150.1163213 2.2007", unit="deg")
     cutout_size = [10, 15]
     cutout_file = fits_cut(test_image, center_coord, cutout_size, output_dir=tmpdir)
     assert isinstance(cutout_file, str)
@@ -167,15 +164,15 @@ def test_fits_cut(tmpdir, caplog, ffi_type):
     cutout_hdulist = fits.open(cutout_file)
     assert cutout_hdulist[1].data.shape == (15, 10)
 
-    center_coord = SkyCoord("150.1159 2.2006", unit='deg')
-    cutout_size = [10, 15]*u.pixel
+    center_coord = SkyCoord("150.1159 2.2006", unit="deg")
+    cutout_size = [10, 15] * u.pixel
     cutout_file = fits_cut(test_image, center_coord, cutout_size, output_dir=tmpdir)
     assert isinstance(cutout_file, str)
     assert "10.0pix-x-15.0pix" in cutout_file
     cutout_hdulist = fits.open(cutout_file)
     assert cutout_hdulist[1].data.shape == (15, 10)
 
-    cutout_size = [1, 2]*u.arcsec
+    cutout_size = [1, 2] * u.arcsec
     cutout_file = fits_cut(test_image, center_coord, cutout_size, output_dir=tmpdir, verbose=True)
     assert isinstance(cutout_file, str)
     assert "1.0arcsec-x-2.0arcsec" in cutout_file
@@ -196,107 +193,105 @@ def test_fits_cut(tmpdir, caplog, ffi_type):
 
     # Test single cloud image
     test_s3_uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
-    center_coord = SkyCoord("150.4275416667 2.42155", unit='deg')
+    center_coord = SkyCoord("150.4275416667 2.42155", unit="deg")
     cutout_size = [10, 15]
     cutout_file = fits_cut(test_s3_uri, center_coord, cutout_size, output_dir=tmpdir)
     assert isinstance(cutout_file, str)
     assert "10-x-15" in cutout_file
-    
+
     with fits.open(cutout_file) as cutout_hdulist:
         assert cutout_hdulist[1].data.shape == (15, 10)
 
 
 def test_normalize_img():
-
     # basic linear stretch
-    img_arr = np.array([[1, 0], [.25, .75]])
-    assert ((img_arr*255).astype(int) == normalize_img(img_arr, stretch='linear')).all()
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
+    assert ((img_arr * 255).astype(int) == normalize_img(img_arr, stretch="linear")).all()
 
     # invert
-    assert (255-(img_arr*255).astype(int) == normalize_img(img_arr, stretch='linear', invert=True)).all()
+    assert (255 - (img_arr * 255).astype(int) == normalize_img(img_arr, stretch="linear", invert=True)).all()
 
-    # linear stretch where input image must be scaled 
+    # linear stretch where input image must be scaled
     img_arr = np.array([[10, 5], [2.5, 7.5]])
-    norm_img = ((img_arr - img_arr.min())/(img_arr.max()-img_arr.min())*255).astype(int)
-    assert (norm_img == normalize_img(img_arr, stretch='linear')).all()
+    norm_img = ((img_arr - img_arr.min()) / (img_arr.max() - img_arr.min()) * 255).astype(int)
+    assert (norm_img == normalize_img(img_arr, stretch="linear")).all()
 
     # min_max val
     minval, maxval = 0, 1
     img_arr = np.array([[1, 0], [-1, 2]])
-    norm_img = normalize_img(img_arr, stretch='linear', minmax_value=[minval, maxval])
+    norm_img = normalize_img(img_arr, stretch="linear", minmax_value=[minval, maxval])
     img_arr[img_arr < minval] = minval
     img_arr[img_arr > maxval] = maxval
-    assert ((img_arr*255).astype(int) == norm_img).all()
+    assert ((img_arr * 255).astype(int) == norm_img).all()
 
     minval, maxval = 0, 1
-    img_arr = np.array([[1, 0], [.1, .2]])
-    norm_img = normalize_img(img_arr, stretch='linear', minmax_value=[minval, maxval])
+    img_arr = np.array([[1, 0], [0.1, 0.2]])
+    norm_img = normalize_img(img_arr, stretch="linear", minmax_value=[minval, maxval])
     img_arr[img_arr < minval] = minval
     img_arr[img_arr > maxval] = maxval
-    ((img_arr*255).astype(int) == norm_img).all()
+    ((img_arr * 255).astype(int) == norm_img).all()
 
     # min_max percent
-    img_arr = np.array([[1, 0], [0.1, 0.9], [.25, .75]])
-    norm_img = normalize_img(img_arr, stretch='linear', minmax_percent=[25, 75])
+    img_arr = np.array([[1, 0], [0.1, 0.9], [0.25, 0.75]])
+    norm_img = normalize_img(img_arr, stretch="linear", minmax_percent=[25, 75])
     assert (norm_img == [[255, 0], [0, 255], [39, 215]]).all()
 
     # asinh
-    img_arr = np.array([[1, 0], [.25, .75]])
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
     norm_img = normalize_img(img_arr)
-    assert ((np.arcsinh(img_arr*10)/np.arcsinh(10)*255).astype(int) == norm_img).all()
+    assert ((np.arcsinh(img_arr * 10) / np.arcsinh(10) * 255).astype(int) == norm_img).all()
 
     # sinh
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = normalize_img(img_arr, stretch='sinh')
-    assert ((np.sinh(img_arr*3)/np.sinh(3)*255).astype(int) == norm_img).all()
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
+    norm_img = normalize_img(img_arr, stretch="sinh")
+    assert ((np.sinh(img_arr * 3) / np.sinh(3) * 255).astype(int) == norm_img).all()
 
     # sqrt
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = normalize_img(img_arr, stretch='sqrt')
-    assert ((np.sqrt(img_arr)*255).astype(int) == norm_img).all()
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
+    norm_img = normalize_img(img_arr, stretch="sqrt")
+    assert ((np.sqrt(img_arr) * 255).astype(int) == norm_img).all()
 
     # log
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = normalize_img(img_arr, stretch='log')
-    assert ((np.log(img_arr*1000+1)/np.log(1000)*255).astype(int) == norm_img).all()
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
+    norm_img = normalize_img(img_arr, stretch="log")
+    assert ((np.log(img_arr * 1000 + 1) / np.log(1000) * 255).astype(int) == norm_img).all()
 
     # Bad stretch
     with pytest.raises(InvalidInputError):
-        img_arr = np.array([[1, 0], [.25, .75]])
-        normalize_img(img_arr, stretch='lin')
+        img_arr = np.array([[1, 0], [0.25, 0.75]])
+        normalize_img(img_arr, stretch="lin")
 
     # Giving both minmax percent and cut
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = normalize_img(img_arr, stretch='asinh', minmax_percent=[0.7, 99.3])
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
+    norm_img = normalize_img(img_arr, stretch="asinh", minmax_percent=[0.7, 99.3])
     with pytest.warns(InputWarning):
-        test_img = normalize_img(img_arr, stretch='asinh', minmax_value=[5, 2000], minmax_percent=[0.7, 99.3])
+        test_img = normalize_img(img_arr, stretch="asinh", minmax_value=[5, 2000], minmax_percent=[0.7, 99.3])
     assert (test_img == norm_img).all()
 
 
-@pytest.mark.parametrize('ffi_type', ['SPOC', 'TICA'])
+@pytest.mark.parametrize("ffi_type", ["SPOC", "TICA"])
 def test_img_cut(tmpdir, caplog, ffi_type):
-
     test_images = create_test_imgs(ffi_type, 50, 6, dir_name=tmpdir)
-    center_coord = SkyCoord("150.1163213 2.200973097", unit='deg')
+    center_coord = SkyCoord("150.1163213 2.200973097", unit="deg")
     cutout_size = 10
 
     # Basic jpg image
     jpg_files = img_cut(test_images, center_coord, cutout_size, output_dir=tmpdir)
-    
+
     assert len(jpg_files) == len(test_images)
-    with open(jpg_files[0], 'rb') as IMGFLE:
-        assert IMGFLE.read(3) == b'\xFF\xD8\xFF'  # JPG
+    with open(jpg_files[0], "rb") as IMGFLE:
+        assert IMGFLE.read(3) == b"\xff\xd8\xff"  # JPG
 
     # Png (single input file, not as list)
-    img_files = img_cut(test_images[0], center_coord, cutout_size, img_format='png', output_dir=tmpdir)
-    with open(img_files[0], 'rb') as IMGFLE:
-        assert IMGFLE.read(8) == b'\x89\x50\x4E\x47\x0D\x0A\x1A\x0A'  # PNG
+    img_files = img_cut(test_images[0], center_coord, cutout_size, img_format="png", output_dir=tmpdir)
+    with open(img_files[0], "rb") as IMGFLE:
+        assert IMGFLE.read(8) == b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"  # PNG
     assert len(img_files) == 1
 
     # Color image
     color_jpg = img_cut(test_images[:3], center_coord, cutout_size, colorize=True, output_dir=tmpdir)
     img = Image.open(color_jpg)
-    assert img.mode == 'RGB'
+    assert img.mode == "RGB"
 
     # Too few input images
     with pytest.raises(InvalidInputError):
@@ -306,24 +301,24 @@ def test_img_cut(tmpdir, caplog, ffi_type):
     with pytest.warns(InputWarning):
         color_jpg = img_cut(test_images, center_coord, cutout_size, colorize=True, output_dir=tmpdir)
     img = Image.open(color_jpg)
-    assert img.mode == 'RGB'
+    assert img.mode == "RGB"
 
     # string coordinates and verbose
     center_coord = "150.1163213 2.200973097"
-    jpg_files = img_cut(test_images, center_coord, cutout_size,
-                        output_dir=path.join(tmpdir, "image_path"), verbose=True)
+    jpg_files = img_cut(
+        test_images, center_coord, cutout_size, output_dir=path.join(tmpdir, "image_path"), verbose=True
+    )
     captured = caplog.text
     assert len(findall("Original image shape", captured)) == 6
     assert "Cutout filepaths:" in captured
     assert "Total time" in captured
 
     # test color image where one of the images is all zeros
-    hdu = fits.open(test_images[0], mode='update')
+    hdu = fits.open(test_images[0], mode="update")
     hdu[0].data[:, :] = 0
     hdu.flush()
     hdu.close()
 
-    with pytest.warns(DataWarning, match='contains no data, skipping...'):
+    with pytest.warns(DataWarning, match="contains no data, skipping..."):
         with pytest.raises(InvalidInputError):
-            img_cut(test_images[:3], center_coord, cutout_size,
-                    colorize=True, img_format='png', output_dir=tmpdir)
+            img_cut(test_images[:3], center_coord, cutout_size, colorize=True, img_format="png", output_dir=tmpdir)

--- a/astrocut/tests/test_fits_cutout.py
+++ b/astrocut/tests/test_fits_cutout.py
@@ -1,44 +1,43 @@
-from pathlib import Path
-from unittest.mock import patch
-import pytest
-import zipfile
 import io
+import zipfile
+from os import path
+from pathlib import Path
+from re import findall
+from unittest.mock import patch
 
 import numpy as np
-from os import path
-from re import findall
-
+import pytest
 from astropy import units as u
 from astropy import wcs
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Table
-
 from PIL import Image
 
 from astrocut.fits_cutout import FITSCutout
 
-from .utils_for_test import create_test_imgs
 from ..exceptions import DataWarning, InputWarning, InvalidInputError, InvalidQueryError
+from .utils_for_test import create_test_imgs
 
 
 # Fixture to create test images for both SPOC and TICA
-@pytest.fixture(params=['SPOC', 'TICA'])
+@pytest.fixture(params=["SPOC", "TICA"])
 def test_images(request, tmpdir):
     return create_test_imgs(request.param, 50, 6, dir_name=tmpdir)
 
 
 # Fixture to create a test image with bad SIP keywords
-@pytest.fixture(params=['SPOC', 'TICA'])
+@pytest.fixture(params=["SPOC", "TICA"])
 def test_image_bad_sip(request, tmpdir):
-    return create_test_imgs(request.param, 50, 1, dir_name=tmpdir,
-                            basename="img_badsip_{:04d}.fits", bad_sip_keywords=True)[0]
+    return create_test_imgs(
+        request.param, 50, 1, dir_name=tmpdir, basename="img_badsip_{:04d}.fits", bad_sip_keywords=True
+    )[0]
 
 
 # Fixture to return a center coordinate
 @pytest.fixture
 def center_coord():
-    return SkyCoord('150.1163213 2.200973097', unit='deg')
+    return SkyCoord("150.1163213 2.200973097", unit="deg")
 
 
 # Fixture to return a cutout size
@@ -73,7 +72,7 @@ def test_fits_cutout_single_outfile(test_images, center_coord, cutout_size, tmpd
 
     # Check WCS and position of center
     cut_wcs = wcs.WCS(cutout[1].header)
-    sra, sdec = cut_wcs.all_pix2world(cutout_size/2, cutout_size/2, 0)
+    sra, sdec = cut_wcs.all_pix2world(cutout_size / 2, cutout_size / 2, 0)
     assert round(float(sra), 4) == round(center_coord.ra.deg, 4)
     assert round(float(sdec), 4) == round(center_coord.dec.deg, 4)
 
@@ -100,12 +99,12 @@ def test_fits_cutout_multiple_files(tmpdir, test_images, center_coord, cutout_si
 
         # Check WCS and position of center
         cut_wcs = wcs.WCS(cutout[1].header)
-        sra, sdec = cut_wcs.all_pix2world(cutout_size/2, cutout_size/2, 0)
+        sra, sdec = cut_wcs.all_pix2world(cutout_size / 2, cutout_size / 2, 0)
         assert round(float(sra), 4) == round(center_coord.ra.deg, 4)
         assert round(float(sdec), 4) == round(center_coord.dec.deg, 4)
 
     # Test case where output directory does not exist
-    new_dir = path.join(tmpdir, 'cutout_files')  # non-existing directory to write files to
+    new_dir = path.join(tmpdir, "cutout_files")  # non-existing directory to write files to
     cutouts = FITSCutout(test_images[0], center_coord, cutout_size, single_outfile=False)
     paths = cutouts.write_as_fits(output_dir=new_dir)
 
@@ -117,7 +116,7 @@ def test_fits_cutout_multiple_files(tmpdir, test_images, center_coord, cutout_si
 
 def test_fits_cutout_memory_only(test_images, center_coord, cutout_size):
     # Memory only, single file
-    nonexisting_dir = 'nonexisting'  # non-existing directory to check that no files are written
+    nonexisting_dir = "nonexisting"  # non-existing directory to check that no files are written
     cutout_list = FITSCutout(test_images, center_coord, cutout_size, single_outfile=True).fits_cutouts
     assert isinstance(cutout_list, list)
     assert len(cutout_list) == 1
@@ -134,19 +133,21 @@ def test_fits_cutout_memory_only(test_images, center_coord, cutout_size):
 
 def test_fits_cutout_return_paths(test_images, center_coord, cutout_size, tmpdir):
     # Return filepath for single output file
-    cutout_file = FITSCutout(test_images, center_coord, cutout_size).write_as_fits(output_dir=tmpdir,
-                                                                                   cutout_prefix='prefix')[0]
+    cutout_file = FITSCutout(test_images, center_coord, cutout_size).write_as_fits(
+        output_dir=tmpdir, cutout_prefix="prefix"
+    )[0]
     assert isinstance(cutout_file, str)
     assert path.exists(cutout_file)
     assert str(tmpdir) in cutout_file
-    assert 'prefix' in cutout_file
-    assert center_coord.ra.to_string(unit='deg', decimal=True) in cutout_file
-    assert center_coord.dec.to_string(unit='deg', decimal=True) in cutout_file
-    assert '10-x-10' in cutout_file
+    assert "prefix" in cutout_file
+    assert center_coord.ra.to_string(unit="deg", decimal=True) in cutout_file
+    assert center_coord.dec.to_string(unit="deg", decimal=True) in cutout_file
+    assert "10-x-10" in cutout_file
 
     # Return list of filepaths for multiple output files
-    cutout_files = FITSCutout(test_images, center_coord, cutout_size,
-                              single_outfile=False).write_as_fits(output_dir=tmpdir)
+    cutout_files = FITSCutout(test_images, center_coord, cutout_size, single_outfile=False).write_as_fits(
+        output_dir=tmpdir
+    )
     assert isinstance(cutout_files, list)
     assert len(cutout_files) == len(test_images)
     for i, cutout_file in enumerate(cutout_files):
@@ -161,13 +162,13 @@ def test_fits_cutout_write_to_zip_single(tmpdir, test_images, center_coord, cuto
     zip_path = cutout.write_as_zip(output_dir=tmpdir)
     assert Path(zip_path).exists()
 
-    with zipfile.ZipFile(zip_path, 'r') as zf:
+    with zipfile.ZipFile(zip_path, "r") as zf:
         # Expect exactly one FITS entry inside
         names = zf.namelist()
         assert len(names) == 1
         arcname = names[0]
-        assert arcname.endswith('_astrocut.fits')
-        assert '10-x-10' in arcname
+        assert arcname.endswith("_astrocut.fits")
+        assert "10-x-10" in arcname
         # Open the FITS from the zip bytes
         data = zf.read(arcname)
         with fits.open(io.BytesIO(data)) as hdul:
@@ -183,14 +184,14 @@ def test_fits_cutout_write_to_zip_multiple(tmpdir, test_images, center_coord, cu
     zip_path = cutout.write_as_zip(output_dir=tmpdir)
     assert Path(zip_path).exists()
 
-    with zipfile.ZipFile(zip_path, 'r') as zf:
+    with zipfile.ZipFile(zip_path, "r") as zf:
         names = zf.namelist()
         # One entry per input file
         assert len(names) == len(test_images)
         # Names should include each input stem and suffix
         stems = [Path(p).stem for p in test_images]
         for name in names:
-            assert name.endswith('_astrocut.fits')
+            assert name.endswith("_astrocut.fits")
             assert any(stem in name for stem in stems)
         # Spot-check opening one member
         data = zf.read(names[0])
@@ -201,7 +202,7 @@ def test_fits_cutout_write_to_zip_multiple(tmpdir, test_images, center_coord, cu
 
 def test_fits_cutout_off_edge(test_images, cutout_size):
     #  Off the top
-    center_coord = SkyCoord("150.1163213 2.2005731", unit='deg')
+    center_coord = SkyCoord("150.1163213 2.2005731", unit="deg")
     cutout = FITSCutout(test_images, center_coord, cutout_size, single_outfile=True).fits_cutouts[0]
     assert isinstance(cutout, fits.HDUList)
 
@@ -209,80 +210,80 @@ def test_fits_cutout_off_edge(test_images, cutout_size):
 
     cut1 = cutout[1].data
     assert cut1.shape == (cutout_size, cutout_size)
-    assert np.isnan(cut1[:cutout_size//2, :]).all()
+    assert np.isnan(cut1[: cutout_size // 2, :]).all()
 
     # Off the bottom
-    center_coord = SkyCoord("150.1163213 2.2014", unit='deg')
+    center_coord = SkyCoord("150.1163213 2.2014", unit="deg")
     cutout = FITSCutout(test_images[0], center_coord, cutout_size).fits_cutouts[0]
-    assert np.isnan(cutout[1].data[cutout_size//2:, :]).all()
+    assert np.isnan(cutout[1].data[cutout_size // 2 :, :]).all()
 
     # Off the left, with integer fill value
-    center_coord = SkyCoord('150.11672 2.200973097', unit='deg')
+    center_coord = SkyCoord("150.11672 2.200973097", unit="deg")
     cutout = FITSCutout(test_images[0], center_coord, cutout_size, fill_value=1).fits_cutouts[0]
-    assert np.all(cutout[1].data[:, :cutout_size//2] == 1)
+    assert np.all(cutout[1].data[:, : cutout_size // 2] == 1)
 
     # Off the right, with float fill value
-    center_coord = SkyCoord('150.11588 2.200973097', unit='deg')
+    center_coord = SkyCoord("150.11588 2.200973097", unit="deg")
     cutout = FITSCutout(test_images[0], center_coord, cutout_size, fill_value=1.5).fits_cutouts[0]
-    assert np.all(cutout[1].data[:, cutout_size//2:] == 1.5)
+    assert np.all(cutout[1].data[:, cutout_size // 2 :] == 1.5)
 
     # Error if unexpected fill value
-    with pytest.raises(InvalidInputError, match='Fill value must be an integer or a float.'):
-        FITSCutout(test_images[0], center_coord, cutout_size, fill_value='invalid')
+    with pytest.raises(InvalidInputError, match="Fill value must be an integer or a float."):
+        FITSCutout(test_images[0], center_coord, cutout_size, fill_value="invalid")
 
 
 def test_fits_cutout_cloud():
     # Test single cloud image
     test_s3_uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
-    center_coord = SkyCoord("150.4275416667 2.42155", unit='deg')
+    center_coord = SkyCoord("150.4275416667 2.42155", unit="deg")
     cutout_size = [10, 15]
-    with patch('astrocut.fits_cutout.fits.open', wraps=fits.open) as mock_open:
+    with patch("astrocut.fits_cutout.fits.open", wraps=fits.open) as mock_open:
         cutout = FITSCutout(test_s3_uri, center_coord, cutout_size).fits_cutouts[0]
         assert cutout[1].data.shape == (15, 10)
         # Verify fsspec_kwargs was passed with anonymous access
-        call_fsspec_kwargs = mock_open.call_args.kwargs['fsspec_kwargs']
-        assert call_fsspec_kwargs['anon'] is True
+        call_fsspec_kwargs = mock_open.call_args.kwargs["fsspec_kwargs"]
+        assert call_fsspec_kwargs["anon"] is True
 
 
 def test_fits_cutout_cloud_fsspec_kwargs():
     # Test single cloud image with fsspec_kwargs passed through to fits.open
     test_s3_uri = "s3://stpubdata/hst/public/j8pu/j8pu0y010/j8pu0y010_drc.fits"
-    center_coord = SkyCoord("150.4275416667 2.42155", unit='deg')
+    center_coord = SkyCoord("150.4275416667 2.42155", unit="deg")
     cutout_size = [10, 15]
     new_default_block_size = 1 * 1024 * 1024
-    fsspec_kwargs = {'default_block_size': new_default_block_size}
-    with patch('astrocut.fits_cutout.fits.open', wraps=fits.open) as mock_open:
+    fsspec_kwargs = {"default_block_size": new_default_block_size}
+    with patch("astrocut.fits_cutout.fits.open", wraps=fits.open) as mock_open:
         FITSCutout(test_s3_uri, center_coord, cutout_size, fsspec_kwargs=fsspec_kwargs).fits_cutouts[0]
         # Verify fsspec_kwargs was passed with user's kwargs merged in
-        call_fsspec_kwargs = mock_open.call_args.kwargs['fsspec_kwargs']
-        assert call_fsspec_kwargs['anon'] is True
-        assert call_fsspec_kwargs['default_block_size'] == new_default_block_size
+        call_fsspec_kwargs = mock_open.call_args.kwargs["fsspec_kwargs"]
+        assert call_fsspec_kwargs["anon"] is True
+        assert call_fsspec_kwargs["default_block_size"] == new_default_block_size
 
 
 def test_fits_cutout_rounding(test_images, cutout_size):
     # Rounding normally
-    center_coord = SkyCoord("150.1163117 2.200973097", unit='deg')
+    center_coord = SkyCoord("150.1163117 2.200973097", unit="deg")
     cutout = FITSCutout(test_images[0], center_coord, cutout_size).fits_cutouts[0]
     with fits.open(test_images[0]) as test_hdu:
         assert np.all(cutout[1].data == test_hdu[0].data[19:29, 20:30])
 
         # Rounding to ceiling
-        cutout = FITSCutout(test_images[0], center_coord, cutout_size, limit_rounding_method='ceil').fits_cutouts[0]
+        cutout = FITSCutout(test_images[0], center_coord, cutout_size, limit_rounding_method="ceil").fits_cutouts[0]
         assert np.all(cutout[1].data == test_hdu[0].data[20:30, 20:30])
 
         # Rounding to floor
-        cutout = FITSCutout(test_images[0], center_coord, cutout_size, limit_rounding_method='floor').fits_cutouts[0]
+        cutout = FITSCutout(test_images[0], center_coord, cutout_size, limit_rounding_method="floor").fits_cutouts[0]
         assert np.all(cutout[1].data == test_hdu[0].data[19:29, 19:29])
 
         # Case that the cutout rounds to zero
         cutout_size = 0.57557495
-        cutout = FITSCutout(test_images[0], center_coord, cutout_size, limit_rounding_method='round').fits_cutouts[0]
+        cutout = FITSCutout(test_images[0], center_coord, cutout_size, limit_rounding_method="round").fits_cutouts[0]
         assert np.all(cutout[1].data == test_hdu[0].data[24:25, 24:25])
 
 
 def test_fits_cutout_extension(test_images, center_coord, cutout_size):
     # Add additional extensions to one of the input files
-    with fits.open(test_images[0], mode='update') as hdul:
+    with fits.open(test_images[0], mode="update") as hdul:
         # Create a copy of first extension
         source_hdu = hdul[0]
         new_hdu = source_hdu.copy()
@@ -291,7 +292,7 @@ def test_fits_cutout_extension(test_images, center_coord, cutout_size):
         hdul.flush()  # save changes
 
     # Cutout all extensions
-    cutout_list = FITSCutout(test_images[0], center_coord, cutout_size, extension='all').fits_cutouts
+    cutout_list = FITSCutout(test_images[0], center_coord, cutout_size, extension="all").fits_cutouts
     assert len(cutout_list[0]) == 4  # primary header + 3 images
 
     # Specify a single extension
@@ -303,36 +304,36 @@ def test_fits_cutout_extension(test_images, center_coord, cutout_size):
     assert len(cutout_list[0]) == 3  # primary header + 2 images
 
     # Warning if a non-existing extension is specified
-    with pytest.warns(DataWarning, match=r'extension\(s\) 3 will be skipped.'):
+    with pytest.warns(DataWarning, match=r"extension\(s\) 3 will be skipped."):
         cutout_list = FITSCutout(test_images[0], center_coord, cutout_size, extension=[1, 3]).fits_cutouts
         assert len(cutout_list[0]) == 2  # primary header + 1 image
 
     # Remove image data from one of the input files
-    with fits.open(test_images[1], mode='update') as hdul:
+    with fits.open(test_images[1], mode="update") as hdul:
         primary = hdul[0]
         primary.data = None
-        table_data = Table({'col1': [1, 2, 3], 'col2': ['a', 'b', 'c']})
-        table_hdu = fits.BinTableHDU(data=table_data, name='TABLE')
+        table_data = Table({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
+        table_hdu = fits.BinTableHDU(data=table_data, name="TABLE")
         hdul.append(table_hdu)
         hdul.flush()
 
-    with pytest.warns(DataWarning, match='No image extensions with data found.'):
-        with pytest.raises(InvalidQueryError, match='Cutout contains no data!'):
+    with pytest.warns(DataWarning, match="No image extensions with data found."):
+        with pytest.raises(InvalidQueryError, match="Cutout contains no data!"):
             FITSCutout(test_images[1], center_coord, cutout_size)
 
 
 def test_fits_cutout_not_in_footprint(test_images, cutout_size):
     # Test when the requested cutout is not on the image
-    center_coord = SkyCoord("140.1163213 2.2005731", unit='deg')
-    with pytest.warns(DataWarning, match='does not overlap'):
-        with pytest.warns(DataWarning, match='contains no data, skipping...'):
-            with pytest.raises(InvalidQueryError, match='Cutout contains no data!'):
+    center_coord = SkyCoord("140.1163213 2.2005731", unit="deg")
+    with pytest.warns(DataWarning, match="does not overlap"):
+        with pytest.warns(DataWarning, match="contains no data, skipping..."):
+            with pytest.raises(InvalidQueryError, match="Cutout contains no data!"):
                 FITSCutout(test_images, center_coord, cutout_size, single_outfile=True)
 
-    center_coord = SkyCoord("15.1163213 2.2005731", unit='deg')
-    with pytest.warns(DataWarning, match='does not overlap'):
-        with pytest.warns(DataWarning, match='contains no data, skipping...'):
-            with pytest.raises(InvalidQueryError, match='Cutout contains no data!'):
+    center_coord = SkyCoord("15.1163213 2.2005731", unit="deg")
+    with pytest.warns(DataWarning, match="does not overlap"):
+        with pytest.warns(DataWarning, match="contains no data, skipping..."):
+            with pytest.raises(InvalidQueryError, match="Cutout contains no data!"):
                 FITSCutout(test_images, center_coord, cutout_size, single_outfile=True)
 
 
@@ -345,8 +346,8 @@ def test_fits_cutout_no_data(tmpdir, test_images, cutout_size):
             hdu.flush()
 
     # Single outfile should include empty files as extensions
-    center_coord = SkyCoord("150.1163213 2.2007", unit='deg')
-    with pytest.warns(DataWarning, match='contains no data, skipping...'):
+    center_coord = SkyCoord("150.1163213 2.2007", unit="deg")
+    with pytest.warns(DataWarning, match="contains no data, skipping..."):
         cutout = FITSCutout(test_images, center_coord, cutout_size, single_outfile=True).fits_cutouts[0]
     assert len(cutout) == len(test_images) - 1  # 6 images - 2 empty + 1 primary header
     assert ~(cutout[1].data == 0).any()
@@ -355,9 +356,10 @@ def test_fits_cutout_no_data(tmpdir, test_images, cutout_size):
     assert ~(cutout[4].data == 0).any()
 
     # Empty files should not be written to their own file
-    with pytest.warns(DataWarning, match='contains no data, skipping...'):
-        cutout_files = FITSCutout(test_images, center_coord, cutout_size,
-                                  single_outfile=False).write_as_fits(output_dir=tmpdir)
+    with pytest.warns(DataWarning, match="contains no data, skipping..."):
+        cutout_files = FITSCutout(test_images, center_coord, cutout_size, single_outfile=False).write_as_fits(
+            output_dir=tmpdir
+        )
     assert isinstance(cutout_files, list)
     assert len(cutout_files) == len(test_images) - 2
 
@@ -368,14 +370,14 @@ def test_fits_cutout_no_data(tmpdir, test_images, cutout_size):
             hdu[0].data[:20, :] = 0
             hdu.flush()
 
-    with pytest.warns(DataWarning, match='contains no data, skipping...'):
-        with pytest.raises(InvalidQueryError, match='Cutout contains no data!'):
+    with pytest.warns(DataWarning, match="contains no data, skipping..."):
+        with pytest.raises(InvalidQueryError, match="Cutout contains no data!"):
             FITSCutout(test_images, center_coord, cutout_size, single_outfile=True)
 
 
 def test_fits_cutout_bad_sip(tmpdir, caplog, test_image_bad_sip):
     # Test single image and also conflicting sip keywords
-    center_coord = SkyCoord("150.1163213 2.2007", unit='deg')
+    center_coord = SkyCoord("150.1163213 2.2007", unit="deg")
     cutout_size = [10, 15]
     cutout_file = FITSCutout(test_image_bad_sip, center_coord, cutout_size).write_as_fits(output_dir=tmpdir)[0]
     assert isinstance(cutout_file, str)
@@ -383,17 +385,18 @@ def test_fits_cutout_bad_sip(tmpdir, caplog, test_image_bad_sip):
     with fits.open(cutout_file) as cutout_hdulist:
         assert cutout_hdulist[1].data.shape == (15, 10)
 
-    center_coord = SkyCoord("150.1159 2.2006", unit='deg')
-    cutout_size = [10, 15]*u.pixel
+    center_coord = SkyCoord("150.1159 2.2006", unit="deg")
+    cutout_size = [10, 15] * u.pixel
     cutout_file = FITSCutout(test_image_bad_sip, center_coord, cutout_size).write_as_fits(output_dir=tmpdir)[0]
     assert isinstance(cutout_file, str)
     assert "10.0pix-x-15.0pix" in cutout_file
     with fits.open(cutout_file) as cutout_hdulist:
         assert cutout_hdulist[1].data.shape == (15, 10)
 
-    cutout_size = [1, 2]*u.arcsec
-    cutout_file = FITSCutout(test_image_bad_sip, center_coord, cutout_size,
-                             verbose=True).write_as_fits(output_dir=tmpdir)[0]
+    cutout_size = [1, 2] * u.arcsec
+    cutout_file = FITSCutout(test_image_bad_sip, center_coord, cutout_size, verbose=True).write_as_fits(
+        output_dir=tmpdir
+    )[0]
     assert isinstance(cutout_file, str)
     assert "1.0arcsec-x-2.0arcsec" in cutout_file
     with fits.open(cutout_file) as cutout_hdulist:
@@ -405,7 +408,7 @@ def test_fits_cutout_bad_sip(tmpdir, caplog, test_image_bad_sip):
 
     center_coord = "150.1159 2.2006"
     cutout_size = [10, 15, 20]
-    with pytest.warns(InputWarning, match='Too many dimensions in cutout size, only the first two will be used.'):
+    with pytest.warns(InputWarning, match="Too many dimensions in cutout size, only the first two will be used."):
         cutout_file = FITSCutout(test_image_bad_sip, center_coord, cutout_size).write_as_fits(output_dir=tmpdir)[0]
     assert isinstance(cutout_file, str)
     assert "10-x-15" in cutout_file
@@ -414,44 +417,47 @@ def test_fits_cutout_bad_sip(tmpdir, caplog, test_image_bad_sip):
 
 def test_fits_cutout_invalid_params(tmpdir, test_images, center_coord, cutout_size):
     # Invalid limit rounding method
-    with pytest.raises(InvalidInputError, match='Limit rounding method invalid is not recognized.'):
-        FITSCutout(test_images, center_coord, cutout_size, limit_rounding_method='invalid')
+    with pytest.raises(InvalidInputError, match="Limit rounding method invalid is not recognized."):
+        FITSCutout(test_images, center_coord, cutout_size, limit_rounding_method="invalid")
 
     # Invalid units for cutout size
     cutout_size = 1 * u.m  # meters are not valid
-    with pytest.raises(InvalidInputError, match='Cutout size unit meter is not supported.'):
+    with pytest.raises(InvalidInputError, match="Cutout size unit meter is not supported."):
         FITSCutout(test_images, center_coord, cutout_size)
 
 
 def test_fits_cutout_img_output(tmpdir, test_images, caplog, center_coord, cutout_size):
     # Basic jpg image
-    jpg_files = FITSCutout(test_images, center_coord, cutout_size).write_as_img(output_format='jpg', output_dir=tmpdir)
+    jpg_files = FITSCutout(test_images, center_coord, cutout_size).write_as_img(output_format="jpg", output_dir=tmpdir)
     assert len(jpg_files) == len(test_images)
-    with open(jpg_files[0], 'rb') as IMGFLE:
-        assert IMGFLE.read(3) == b'\xFF\xD8\xFF'  # JPG
+    with open(jpg_files[0], "rb") as IMGFLE:
+        assert IMGFLE.read(3) == b"\xff\xd8\xff"  # JPG
 
     # Png (single input file, not as list)
-    img_files = FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(output_format='png',
-                                                                                   output_dir=tmpdir)
-    with open(img_files[0], 'rb') as IMGFLE:
-        assert IMGFLE.read(8) == b'\x89\x50\x4E\x47\x0D\x0A\x1A\x0A'  # PNG
+    img_files = FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(
+        output_format="png", output_dir=tmpdir
+    )
+    with open(img_files[0], "rb") as IMGFLE:
+        assert IMGFLE.read(8) == b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"  # PNG
     assert len(img_files) == 1
 
     # String coordinates and verbose
     center_coord = "150.1163213 2.200973097"
-    jpg_files = FITSCutout(test_images, center_coord, cutout_size, verbose=True).write_as_img(output_format='jpg',
-                                                                                              output_dir=tmpdir)
+    jpg_files = FITSCutout(test_images, center_coord, cutout_size, verbose=True).write_as_img(
+        output_format="jpg", output_dir=tmpdir
+    )
     captured = caplog.text
-    assert len(findall('Original image shape', captured)) == 6
-    assert 'Total time' in captured
+    assert len(findall("Original image shape", captured)) == 6
+    assert "Total time" in captured
 
 
 def test_fits_cutout_img_color(tmpdir, test_images, center_coord, cutout_size):
     # Color image
-    color_jpg = FITSCutout(test_images[:3], center_coord, cutout_size).write_as_img(output_format='jpg', colorize=True,
-                                                                                    output_dir=tmpdir)
+    color_jpg = FITSCutout(test_images[:3], center_coord, cutout_size).write_as_img(
+        output_format="jpg", colorize=True, output_dir=tmpdir
+    )
     img = Image.open(color_jpg)
-    assert img.mode == 'RGB'
+    assert img.mode == "RGB"
 
 
 def test_fits_cutout_img_memory_only(test_images, center_coord, cutout_size):
@@ -466,7 +472,7 @@ def test_fits_cutout_img_memory_only(test_images, center_coord, cutout_size):
     assert isinstance(color_imgs, list)
     assert len(color_imgs) == 1
     assert isinstance(color_imgs[0], Image.Image)
-    assert color_imgs[0].mode == 'RGB'
+    assert color_imgs[0].mode == "RGB"
 
 
 def test_fits_cutout_img_errors(tmpdir, test_images, center_coord, cutout_size):
@@ -475,40 +481,43 @@ def test_fits_cutout_img_errors(tmpdir, test_images, center_coord, cutout_size):
         FITSCutout(test_images[0], center_coord, cutout_size).get_image_cutouts(colorize=True)
 
     # Warning when too many input images
-    with pytest.warns(InputWarning, match='Too many inputs for a color cutout, only the first three will be used.'):
+    with pytest.warns(InputWarning, match="Too many inputs for a color cutout, only the first three will be used."):
         color_jpg = FITSCutout(test_images, center_coord, cutout_size).write_as_img(colorize=True, output_dir=tmpdir)
     img = Image.open(color_jpg)
-    assert img.mode == 'RGB'
+    assert img.mode == "RGB"
 
     # Warning when saving image to unsupported image formats
-    with pytest.warns(DataWarning, match='Cutout could not be saved in .blp format'):
-        FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(output_format='blp', output_dir=tmpdir)
+    with pytest.warns(DataWarning, match="Cutout could not be saved in .blp format"):
+        FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(output_format="blp", output_dir=tmpdir)
 
-    with pytest.warns(DataWarning, match='Cutout could not be saved in .mpg format'):
-        FITSCutout(test_images[:3], center_coord, cutout_size).write_as_img(output_format='mpg', output_dir=tmpdir,
-                                                                            colorize=True)
+    with pytest.warns(DataWarning, match="Cutout could not be saved in .mpg format"):
+        FITSCutout(test_images[:3], center_coord, cutout_size).write_as_img(
+            output_format="mpg", output_dir=tmpdir, colorize=True
+        )
 
     # Invalid stretch error
-    with pytest.raises(InvalidInputError, match='Stretch invalid is not recognized.'):
-        FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(stretch='invalid', output_format='png',
-                                                                           output_dir=tmpdir)
+    with pytest.raises(InvalidInputError, match="Stretch invalid is not recognized."):
+        FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(
+            stretch="invalid", output_format="png", output_dir=tmpdir
+        )
 
     # Invalid output format
-    with pytest.raises(InvalidInputError, match='Output format .invalid is not supported'):
-        FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(output_format='invalid', output_dir=tmpdir)
+    with pytest.raises(InvalidInputError, match="Output format .invalid is not supported"):
+        FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(output_format="invalid", output_dir=tmpdir)
 
     # Change first input file to be all zeros
-    with fits.open(test_images[0], mode='update') as hdu:
+    with fits.open(test_images[0], mode="update") as hdu:
         hdu[0].data[:, :] = 0
         hdu.flush()
 
     # Warning when outputting non-color images
-    with pytest.warns(DataWarning, match='contains no data, skipping...'):
-        with pytest.raises(InvalidQueryError, match='Cutout contains no data'):
-            FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(output_format='png', output_dir=tmpdir)
+    with pytest.warns(DataWarning, match="contains no data, skipping..."):
+        with pytest.raises(InvalidQueryError, match="Cutout contains no data"):
+            FITSCutout(test_images[0], center_coord, cutout_size).write_as_img(output_format="png", output_dir=tmpdir)
 
     # Error when outputting color image
-    with pytest.warns(DataWarning, match='contains no data, skipping...'):
+    with pytest.warns(DataWarning, match="contains no data, skipping..."):
         with pytest.raises(InvalidInputError):
-            FITSCutout(test_images[:3], center_coord, cutout_size).write_as_img(colorize=True, output_format='png',
-                                                                                output_dir=tmpdir)
+            FITSCutout(test_images[:3], center_coord, cutout_size).write_as_img(
+                colorize=True, output_format="png", output_dir=tmpdir
+            )

--- a/astrocut/tests/test_image_cutout.py
+++ b/astrocut/tests/test_image_cutout.py
@@ -1,6 +1,5 @@
-import pytest
-
 import numpy as np
+import pytest
 
 from astrocut.image_cutout import ImageCutout
 
@@ -9,71 +8,75 @@ from ..exceptions import InputWarning, InvalidInputError
 
 def test_normalize_img():
     # basic linear stretch
-    img_arr = np.array([[1, 0], [.25, .75]])
-    assert ((img_arr*255).astype(int) == ImageCutout.normalize_img(img_arr, stretch='linear')).all()
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
+    assert ((img_arr * 255).astype(int) == ImageCutout.normalize_img(img_arr, stretch="linear")).all()
 
     # invert
-    assert (255-(img_arr*255).astype(int) == ImageCutout.normalize_img(img_arr, stretch='linear', invert=True)).all()
+    assert (
+        255 - (img_arr * 255).astype(int) == ImageCutout.normalize_img(img_arr, stretch="linear", invert=True)
+    ).all()
 
-    # linear stretch where input image must be scaled 
+    # linear stretch where input image must be scaled
     img_arr = np.array([[10, 5], [2.5, 7.5]])
-    norm_img = ((img_arr - img_arr.min())/(img_arr.max()-img_arr.min())*255).astype(int)
-    assert (norm_img == ImageCutout.normalize_img(img_arr, stretch='linear')).all()
+    norm_img = ((img_arr - img_arr.min()) / (img_arr.max() - img_arr.min()) * 255).astype(int)
+    assert (norm_img == ImageCutout.normalize_img(img_arr, stretch="linear")).all()
 
     # min_max val
     minval, maxval = 0, 1
     img_arr = np.array([[1, 0], [-1, 2]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_value=[minval, maxval])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch="linear", minmax_value=[minval, maxval])
     img_arr[img_arr < minval] = minval
     img_arr[img_arr > maxval] = maxval
-    assert ((img_arr*255).astype(int) == norm_img).all()
+    assert ((img_arr * 255).astype(int) == norm_img).all()
 
     minval, maxval = 0, 1
-    img_arr = np.array([[1, 0], [.1, .2]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_value=[minval, maxval])
+    img_arr = np.array([[1, 0], [0.1, 0.2]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch="linear", minmax_value=[minval, maxval])
     img_arr[img_arr < minval] = minval
     img_arr[img_arr > maxval] = maxval
-    ((img_arr*255).astype(int) == norm_img).all()
+    ((img_arr * 255).astype(int) == norm_img).all()
 
     # min_max percent
-    img_arr = np.array([[1, 0], [0.1, 0.9], [.25, .75]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='linear', minmax_percent=[25, 75])
+    img_arr = np.array([[1, 0], [0.1, 0.9], [0.25, 0.75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch="linear", minmax_percent=[25, 75])
     assert (norm_img == [[255, 0], [0, 255], [39, 215]]).all()
 
     # asinh
-    img_arr = np.array([[1, 0], [.25, .75]])
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
     norm_img = ImageCutout.normalize_img(img_arr)
-    assert ((np.arcsinh(img_arr*10)/np.arcsinh(10)*255).astype(int) == norm_img).all()
+    assert ((np.arcsinh(img_arr * 10) / np.arcsinh(10) * 255).astype(int) == norm_img).all()
 
     # sinh
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='sinh')
-    assert ((np.sinh(img_arr*3)/np.sinh(3)*255).astype(int) == norm_img).all()
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch="sinh")
+    assert ((np.sinh(img_arr * 3) / np.sinh(3) * 255).astype(int) == norm_img).all()
 
     # sqrt
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='sqrt')
-    assert ((np.sqrt(img_arr)*255).astype(int) == norm_img).all()
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch="sqrt")
+    assert ((np.sqrt(img_arr) * 255).astype(int) == norm_img).all()
 
     # log
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='log')
-    assert ((np.log(img_arr*1000+1)/np.log(1000)*255).astype(int) == norm_img).all()
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch="log")
+    assert ((np.log(img_arr * 1000 + 1) / np.log(1000) * 255).astype(int) == norm_img).all()
 
 
 def test_normalize_img_errors():
     # Bad stretch
     with pytest.raises(InvalidInputError):
-        img_arr = np.array([[1, 0], [.25, .75]])
-        ImageCutout.normalize_img(img_arr, stretch='lin')
+        img_arr = np.array([[1, 0], [0.25, 0.75]])
+        ImageCutout.normalize_img(img_arr, stretch="lin")
 
     # Giving both minmax percent and cut
-    img_arr = np.array([[1, 0], [.25, .75]])
-    norm_img = ImageCutout.normalize_img(img_arr, stretch='asinh', minmax_percent=[0.7, 99.3])
-    with pytest.warns(InputWarning, 
-                      match='Both minmax_percent and minmax_value are set, minmax_value will be ignored.'):
-        test_img = ImageCutout.normalize_img(img_arr, stretch='asinh', minmax_value=[5, 2000], 
-                                             minmax_percent=[0.7, 99.3])
+    img_arr = np.array([[1, 0], [0.25, 0.75]])
+    norm_img = ImageCutout.normalize_img(img_arr, stretch="asinh", minmax_percent=[0.7, 99.3])
+    with pytest.warns(
+        InputWarning, match="Both minmax_percent and minmax_value are set, minmax_value will be ignored."
+    ):
+        test_img = ImageCutout.normalize_img(
+            img_arr, stretch="asinh", minmax_value=[5, 2000], minmax_percent=[0.7, 99.3]
+        )
     assert (test_img == norm_img).all()
 
     # Raise error if image array is empty

--- a/astrocut/tests/test_roman_spectral_subset.py
+++ b/astrocut/tests/test_roman_spectral_subset.py
@@ -338,7 +338,7 @@ def test_roman_spectral_subset_asdf_subsets_source_file(spectral_files, lite):
         # Check that history entry is added to the subset ASDF file
         assert "history" in subset_af.tree
         history_entry = subset_af.tree["history"]["entries"][-1]  # Get the last history entry
-        expected_entry = f"Spectral subset created for source ID {subset_source_id} " f"from file {subset_file}."
+        expected_entry = f"Spectral subset created for source ID {subset_source_id} from file {subset_file}."
         assert history_entry["description"] == expected_entry
 
     # Only select certain source files
@@ -397,7 +397,7 @@ def test_roman_spectral_subset_asdf_subsets_file(spectral_files, lite):
         # Check that history entry is added to the subset ASDF file
         assert "history" in subset_af.tree
         history_entry = subset_af.tree["history"]["entries"][-1]  # Get the last history entry
-        expected_entry = f"Spectral subset created for source IDs ['420007', '420008'] " f"from file {subset_file}."
+        expected_entry = f"Spectral subset created for source IDs ['420007', '420008'] from file {subset_file}."
         assert history_entry["description"] == expected_entry
 
 

--- a/astrocut/tests/test_tess_cube_cutout.py
+++ b/astrocut/tests/test_tess_cube_cutout.py
@@ -1,24 +1,23 @@
-
+import io
 import shutil
-import numpy as np
-import pytest
 import warnings
 import zipfile
-import io
 from pathlib import Path
 from typing import List, Literal
 
+import numpy as np
+import pytest
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.time import Time
 from astropy.wcs import WCS, FITSFixedWarning
 
-from .utils_for_test import create_test_ffis
-from ..exceptions import DataWarning, InvalidInputError, InvalidQueryError
-from ..cube_factory import CubeFactory
-from ..tica_cube_factory import TicaCubeFactory
 from ..cube_cutout import CubeCutout
+from ..cube_factory import CubeFactory
+from ..exceptions import DataWarning, InvalidInputError, InvalidQueryError
 from ..tess_cube_cutout import TessCubeCutout
+from ..tica_cube_factory import TicaCubeFactory
+from .utils_for_test import create_test_ffis
 
 
 @pytest.fixture
@@ -48,8 +47,12 @@ def coordinates(cube_wcs, img_size):
 @pytest.fixture
 def cutout_lims(img_size, cutout_size):
     """Fixture to return the expected cutout limits"""
-    return np.array([[img_size // 2 - cutout_size // 2, img_size // 2 + cutout_size // 2],
-                     [img_size // 2 - cutout_size // 2, img_size // 2 + cutout_size // 2]])
+    return np.array(
+        [
+            [img_size // 2 - cutout_size // 2, img_size // 2 + cutout_size // 2],
+            [img_size // 2 - cutout_size // 2, img_size // 2 + cutout_size // 2],
+        ]
+    )
 
 
 @pytest.fixture
@@ -59,7 +62,7 @@ def ffi_files(tmpdir, img_size, num_images, ffi_type: Literal["SPOC", "TICA"]):
 
 
 @pytest.fixture
-def cube_file(ffi_files: List[str], tmpdir, ffi_type: Literal['SPOC', "TICA"]):
+def cube_file(ffi_files: List[str], tmpdir, ffi_type: Literal["SPOC", "TICA"]):
     """Fixture for creating a cube file"""
     # Making the test cube
     if ffi_type == "SPOC":
@@ -76,9 +79,9 @@ def cube_file(ffi_files: List[str], tmpdir, ffi_type: Literal['SPOC', "TICA"]):
 def cube_wcs(ffi_files: List[str], tmpdir, ffi_type: Literal["SPOC", "TICA"]):
     """Fixture to return the WCS of the cube"""
     # Read one of the input images to get the WCS
-    n = 1 if ffi_type == 'SPOC' else 0
+    n = 1 if ffi_type == "SPOC" else 0
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore', FITSFixedWarning)
+        warnings.simplefilter("ignore", FITSFixedWarning)
         return WCS(fits.getheader(ffi_files[0], n))
 
 
@@ -100,19 +103,22 @@ def test_tess_cube_cutout(cube_file, num_images, ffi_type, cutout_size, coordina
     # Compare data with input cube file
     with fits.open(cube_file) as hdul:
         data = np.transpose(hdul[1].data, (3, 2, 0, 1))
-        assert np.all(data[0, :, cutout_lims[0, 0]:cutout_lims[0, 1], cutout_lims[1, 0]:cutout_lims[1, 1]] == 
-                      cutout.data)
-        if ffi_type == 'SPOC':
-            assert np.all(data[1, :, cutout_lims[0, 0]:cutout_lims[0, 1], cutout_lims[1, 0]:cutout_lims[1, 1]] == 
-                          cutout.uncertainty)
+        assert np.all(
+            data[0, :, cutout_lims[0, 0] : cutout_lims[0, 1], cutout_lims[1, 0] : cutout_lims[1, 1]] == cutout.data
+        )
+        if ffi_type == "SPOC":
+            assert np.all(
+                data[1, :, cutout_lims[0, 0] : cutout_lims[0, 1], cutout_lims[1, 0] : cutout_lims[1, 1]]
+                == cutout.uncertainty
+            )
 
     # Check the cutout WCS
     cutout_wcs = cutout.wcs
     assert isinstance(cutout_wcs, WCS)
     assert np.all(np.round(cutout_wcs.world_to_pixel(coordinates)) == (cutout_size // 2, cutout_size // 2))
     assert cutout_wcs.pixel_shape == (cutout_size, cutout_size)
-    assert cutout.wcs_fit['WCS_MSEP'][0] == 0
-    assert cutout.wcs_fit['WCS_SIG'][0] == 0
+    assert cutout.wcs_fit["WCS_MSEP"][0] == 0
+    assert cutout.wcs_fit["WCS_SIG"][0] == 0
 
 
 @pytest.mark.parametrize("ffi_type", ["SPOC", "TICA"])
@@ -127,78 +133,80 @@ def test_tess_cube_cutout_tpf(cube_file, num_images, ffi_type, cutout_size, coor
 
     # Check primary header values
     primary_header = tpf[0].header
-    assert primary_header['RA_OBJ'] == coordinates.ra.deg
-    assert primary_header['DEC_OBJ'] == coordinates.dec.deg
-    assert primary_header['FFI_TYPE'] == ffi_type
-    assert primary_header['CREATOR'] == 'astrocut'
-    assert primary_header['ORIGIN'] == 'STScI/MAST'
-    assert primary_header['TELAPSE'] == primary_header['TSTOP'] - primary_header['TSTART']
+    assert primary_header["RA_OBJ"] == coordinates.ra.deg
+    assert primary_header["DEC_OBJ"] == coordinates.dec.deg
+    assert primary_header["FFI_TYPE"] == ffi_type
+    assert primary_header["CREATOR"] == "astrocut"
+    assert primary_header["ORIGIN"] == "STScI/MAST"
+    assert primary_header["TELAPSE"] == primary_header["TSTOP"] - primary_header["TSTART"]
 
     # Get units from BinTableHDU
-    cols = tpf[1].columns.info('name, unit', output=False)
+    cols = tpf[1].columns.info("name, unit", output=False)
     cols_dict = dict(zip(*cols.values()))
 
     # Check differences in primary header values and units for SPOC and TICA
-    if ffi_type == 'SPOC':
-        assert primary_header['TIMEREF'] == 'SOLARSYSTEM'
-        assert primary_header['TASSIGN'] == 'SPACECRAFT'
-        assert cols_dict['FLUX'] == 'e-/s'
-        assert tpf[1].data.field('CADENCENO').all() == 0.0
+    if ffi_type == "SPOC":
+        assert primary_header["TIMEREF"] == "SOLARSYSTEM"
+        assert primary_header["TASSIGN"] == "SPACECRAFT"
+        assert cols_dict["FLUX"] == "e-/s"
+        assert tpf[1].data.field("CADENCENO").all() == 0.0
 
-    if ffi_type == 'TICA':
-        assert primary_header['TIMEREF'] is None
-        assert primary_header['TASSIGN'] is None
-        assert cols_dict['FLUX'] == 'e-'
-        assert tpf[1].data.field('CADENCENO').all() != 0.0
+    if ffi_type == "TICA":
+        assert primary_header["TIMEREF"] is None
+        assert primary_header["TASSIGN"] is None
+        assert cols_dict["FLUX"] == "e-"
+        assert tpf[1].data.field("CADENCENO").all() != 0.0
 
         # Verifying DATE-OBS calculation in TICA
-        date_obs = primary_header['DATE-OBS']
-        tstart = Time(date_obs).jd - primary_header['BJDREFI']
-        assert primary_header['TSTART'] == tstart
+        date_obs = primary_header["DATE-OBS"]
+        tstart = Time(date_obs).jd - primary_header["BJDREFI"]
+        assert primary_header["TSTART"] == tstart
 
         # Verifying DATE-END calculation in TICA
-        date_end = primary_header['DATE-END']
-        tstop = Time(date_end).jd - primary_header['BJDREFI']
-        assert primary_header['TSTOP'] == tstop
+        date_end = primary_header["DATE-END"]
+        tstop = Time(date_end).jd - primary_header["BJDREFI"]
+        assert primary_header["TSTOP"] == tstop
 
     # Check for header keyword propagation in EXT 1 and 2
     ext1_header = tpf[1].header
     ext2_header = tpf[2].header
-    assert ext1_header['FFI_TYPE'] == ext2_header['FFI_TYPE'] == primary_header['FFI_TYPE']
-    assert ext1_header['CREATOR'] == ext2_header['CREATOR'] == primary_header['CREATOR']
-    assert ext1_header['BJDREFI'] == ext2_header['BJDREFI'] == primary_header['BJDREFI']
+    assert ext1_header["FFI_TYPE"] == ext2_header["FFI_TYPE"] == primary_header["FFI_TYPE"]
+    assert ext1_header["CREATOR"] == ext2_header["CREATOR"] == primary_header["CREATOR"]
+    assert ext1_header["BJDREFI"] == ext2_header["BJDREFI"] == primary_header["BJDREFI"]
 
     # Check timeseries data
     table = tpf[1].data
     assert tpf[1].data.shape[0] == num_images
-    assert np.all(table['TIME'] == (np.arange(num_images) + 0.5))
+    assert np.all(table["TIME"] == (np.arange(num_images) + 0.5))
 
     # Check data table columns
-    num_cols = 12 if ffi_type == 'SPOC' else 11
+    num_cols = 12 if ffi_type == "SPOC" else 11
     assert len(table.columns) == num_cols
-    assert 'TIME' in table.columns.names
-    assert 'FLUX' in table.columns.names
-    assert 'FLUX_ERR' in table.columns.names
-    assert 'FFI_FILE' in table.columns.names
+    assert "TIME" in table.columns.names
+    assert "FLUX" in table.columns.names
+    assert "FLUX_ERR" in table.columns.names
+    assert "FFI_FILE" in table.columns.names
 
     # Check flux data
-    flux = table['FLUX']
+    flux = table["FLUX"]
     assert flux.shape == (num_images, cutout_size, cutout_size)
     assert flux.dtype.type == np.float32
 
     # Check flux error data
-    err = table['FLUX_ERR']
+    err = table["FLUX_ERR"]
     assert err.shape == (num_images, cutout_size, cutout_size)
-    if ffi_type == 'TICA':
+    if ffi_type == "TICA":
         assert np.mean(err) == 0
     assert err.dtype.type == np.float32
 
     # Compare data with input cube file
     with fits.open(cube_file) as hdul:
         data = np.transpose(hdul[1].data, (3, 2, 0, 1))
-        assert np.all(data[0, :, cutout_lims[0, 0]:cutout_lims[0, 1], cutout_lims[1, 0]:cutout_lims[1, 1]] == flux)
-        if ffi_type == 'SPOC':
-            assert np.all(data[1, :, cutout_lims[0, 0]:cutout_lims[0, 1], cutout_lims[1, 0]:cutout_lims[1, 1]] == err)
+        assert np.all(data[0, :, cutout_lims[0, 0] : cutout_lims[0, 1], cutout_lims[1, 0] : cutout_lims[1, 1]] == flux)
+        if ffi_type == "SPOC":
+            assert np.all(
+                data[1, :, cutout_lims[0, 0] : cutout_lims[0, 1], cutout_lims[1, 0] : cutout_lims[1, 1]] == err
+            )
 
     # Check aperture HDU
     aper = tpf[2].data
@@ -217,7 +225,7 @@ def test_tess_cutout_partial(cube_file, cutout_size, ffi_type, cube_wcs, img_siz
     offset = cutout_size // 2
     assert np.all(np.isnan(cutout.data[:, :, :offset]))
     assert np.all(cutout.aperture[:, :offset] == 0)
-    if ffi_type == 'SPOC':
+    if ffi_type == "SPOC":
         assert np.all(np.isnan(cutout.uncertainty[:, :, :offset]))
 
     # Off the bottom
@@ -225,7 +233,7 @@ def test_tess_cutout_partial(cube_file, cutout_size, ffi_type, cube_wcs, img_siz
     cutout = TessCubeCutout(cube_file, coord, cutout_size, product=ffi_type).cutouts[0]
     assert np.all(np.isnan(cutout.data[:, :, offset:]))
     assert np.all(cutout.aperture[:, offset:] == 0)
-    if ffi_type == 'SPOC':
+    if ffi_type == "SPOC":
         assert np.all(np.isnan(cutout.uncertainty[:, :, offset:]))
 
     # Off the left, integer fill value
@@ -233,7 +241,7 @@ def test_tess_cutout_partial(cube_file, cutout_size, ffi_type, cube_wcs, img_siz
     cutout = TessCubeCutout(cube_file, coord, cutout_size, product=ffi_type, fill_value=0).cutouts[0]
     assert np.all(cutout.data[:, :offset, :] == 0)
     assert np.all(cutout.aperture[:offset, :] == 0)
-    if ffi_type == 'SPOC':
+    if ffi_type == "SPOC":
         assert np.all(cutout.uncertainty[:, :offset, :] == 0)
 
     # Off the right, float fill value
@@ -241,7 +249,7 @@ def test_tess_cutout_partial(cube_file, cutout_size, ffi_type, cube_wcs, img_siz
     cutout = TessCubeCutout(cube_file, coord, cutout_size, product=ffi_type, fill_value=1.5).cutouts[0]
     assert np.all(cutout.data[:, offset:, :] == 1.5)
     assert np.all(cutout.aperture[offset:, :] == 0)
-    if ffi_type == 'SPOC':
+    if ffi_type == "SPOC":
         assert np.all(cutout.uncertainty[:, offset:, :] == 1.5)
 
     # Large cutout that goes off all sides. Use center coordinate
@@ -250,12 +258,12 @@ def test_tess_cutout_partial(cube_file, cutout_size, ffi_type, cube_wcs, img_siz
     diff_height = (cutout_size[1] - img_size) // 2
     cutout = TessCubeCutout(cube_file, coordinates, cutout_size, product=ffi_type).cutouts[0]
     cutout_mask = np.zeros((num_images, cutout_size[1], cutout_size[0]), dtype=bool)
-    cutout_mask[:, diff_height:diff_height + img_size, diff_width:diff_width + img_size] = True
+    cutout_mask[:, diff_height : diff_height + img_size, diff_width : diff_width + img_size] = True
     aper_mask = np.zeros((cutout_size[1], cutout_size[0]), dtype=bool)
-    aper_mask[diff_height:diff_height + img_size, diff_width:diff_width + img_size] = True
+    aper_mask[diff_height : diff_height + img_size, diff_width : diff_width + img_size] = True
     assert np.all(np.isnan(cutout.data[~cutout_mask]))
     assert np.all(cutout.aperture[~aper_mask] == 0)
-    if ffi_type == 'SPOC':
+    if ffi_type == "SPOC":
         assert np.all(np.isnan(cutout.uncertainty[~cutout_mask]))
 
 
@@ -282,12 +290,17 @@ def test_tess_cube_cutout_batching(cube_file, tmpdir, cutout_size, coordinates, 
     assert cutouts[0].shape == cutouts[1].shape == cutouts[2].shape == expected_shape
     assert np.all(cutouts[0].data == cutouts[1].data)
     assert np.all(cutouts[0].data == cutouts[2].data)
-    assert (cutouts[0].uncertainty.shape == cutouts[1].uncertainty.shape == cutouts[2].uncertainty.shape ==
-            expected_shape)
+    assert (
+        cutouts[0].uncertainty.shape == cutouts[1].uncertainty.shape == cutouts[2].uncertainty.shape == expected_shape
+    )
     assert np.all(cutouts[0].uncertainty == cutouts[1].uncertainty)
     assert np.all(cutouts[0].uncertainty == cutouts[2].uncertainty)
-    assert (cutouts[0].aperture.shape == cutouts[1].aperture.shape == cutouts[2].aperture.shape ==
-            (cutout_size[1], cutout_size[0]))
+    assert (
+        cutouts[0].aperture.shape
+        == cutouts[1].aperture.shape
+        == cutouts[2].aperture.shape
+        == (cutout_size[1], cutout_size[0])
+    )
     assert np.all(cutouts[0].aperture == cutouts[1].aperture)
     assert np.all(cutouts[0].aperture == cutouts[2].aperture)
 
@@ -298,7 +311,7 @@ def test_tess_cube_cutout_write_to_tpf(cube_file, tmpdir, cutout_size, coordinat
     cutout = TessCubeCutout(cube_file, coordinates, cutout_size, product=ffi_type)
 
     # Write to TPF with output_file specified
-    cutout_paths = cutout.write_as_tpf(tmpdir, 'cutout.fits')
+    cutout_paths = cutout.write_as_tpf(tmpdir, "cutout.fits")
     cutout_path = cutout_paths[0]
 
     # Should return a list of filepaths
@@ -307,7 +320,7 @@ def test_tess_cube_cutout_write_to_tpf(cube_file, tmpdir, cutout_size, coordinat
 
     # Check pathname
     assert Path(cutout_path).exists()
-    assert 'cutout.fits' in cutout_path
+    assert "cutout.fits" in cutout_path
     assert str(tmpdir) in cutout_path
 
     # Check that file can be opened with fits
@@ -320,11 +333,11 @@ def test_tess_cube_cutout_write_to_tpf(cube_file, tmpdir, cutout_size, coordinat
     # Check pathname
     assert Path(cutout_path).exists()
     assert str(tmpdir) in cutout_path
-    assert 'test' in cutout_path
-    assert f'{coordinates.ra.value:.7f}' in cutout_path
-    assert f'{coordinates.dec.value:.7f}' in cutout_path
-    assert f'{cutout_size}-x-{cutout_size}' in cutout_path
-    assert 'astrocut' in cutout_path
+    assert "test" in cutout_path
+    assert f"{coordinates.ra.value:.7f}" in cutout_path
+    assert f"{coordinates.dec.value:.7f}" in cutout_path
+    assert f"{cutout_size}-x-{cutout_size}" in cutout_path
+    assert "astrocut" in cutout_path
 
 
 @pytest.mark.parametrize("ffi_type", ["SPOC"])
@@ -334,19 +347,19 @@ def test_tess_cube_cutout_write_to_zip(cube_file, cutout_size, coordinates, tmpd
     zip_path = cutout.write_as_zip(output_dir=tmpdir)
     assert Path(zip_path).exists()
 
-    with zipfile.ZipFile(zip_path, 'r') as zf:
+    with zipfile.ZipFile(zip_path, "r") as zf:
         names = zf.namelist()
         assert len(names) == 1
         name = names[0]
-        assert name.endswith('_astrocut.fits')
+        assert name.endswith("_astrocut.fits")
         # Open the TPF from the zip
         data = zf.read(name)
         with fits.open(io.BytesIO(data)) as hdul:
             assert isinstance(hdul, fits.HDUList)
             # Primary + PIXELS + APERTURE
             assert len(hdul) == 3
-            assert hdul[1].header.get('EXTNAME') == 'PIXELS'
-            assert hdul[2].header.get('EXTNAME') == 'APERTURE'
+            assert hdul[1].header.get("EXTNAME") == "PIXELS"
+            assert hdul[2].header.get("EXTNAME") == "APERTURE"
 
 
 def test_tess_cube_cutout_s3():
@@ -390,13 +403,13 @@ def test_tess_cube_cutout_threads():
 def test_tess_cube_cutout_not_in_footprint(cube_file):
     # Make a cutout with a coordinate outside the image footprint
     coord = SkyCoord(10, 10, unit="deg", frame="icrs")
-    with pytest.warns(DataWarning, match='Cutout footprint does not overlap'):
-        with pytest.raises(InvalidQueryError, match='Cube cutout contains no data!'):
+    with pytest.warns(DataWarning, match="Cutout footprint does not overlap"):
+        with pytest.raises(InvalidQueryError, match="Cube cutout contains no data!"):
             TessCubeCutout(cube_file, coord, 3)
 
 
 @pytest.mark.parametrize("ffi_type", ["SPOC"])
 def test_tess_cube_cutout_invalid_product(cube_file):
     # Error if an invalid product name is input
-    with pytest.raises(InvalidInputError, match='Product for TESS cube cutouts must be'):
-        TessCubeCutout(cube_file, SkyCoord(0, 0, unit='deg'), 3, product='INVALID')
+    with pytest.raises(InvalidInputError, match="Product for TESS cube cutouts must be"):
+        TessCubeCutout(cube_file, SkyCoord(0, 0, unit="deg"), 3, product="INVALID")

--- a/astrocut/tests/test_tess_footprint_cutout.py
+++ b/astrocut/tests/test_tess_footprint_cutout.py
@@ -1,11 +1,11 @@
-from pathlib import Path
-import pytest
 import re
 import zipfile
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import astropy.units as u
 import numpy as np
+import pytest
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Table
@@ -15,9 +15,14 @@ from .. import footprint_cutout
 from ..cube_cutout import CubeCutout
 from ..exceptions import InvalidInputError, InvalidQueryError
 from ..footprint_cutout import get_ffis, ra_dec_crossmatch
-from ..tess_footprint_cutout import (TessFootprintCutout, cube_cut_from_footprint, get_tess_sectors, 
-                                     _extract_sequence_information, _create_sequence_list)
 from ..tess_cube_cutout import TessCubeCutout
+from ..tess_footprint_cutout import (
+    TessFootprintCutout,
+    _create_sequence_list,
+    _extract_sequence_information,
+    cube_cut_from_footprint,
+    get_tess_sectors,
+)
 
 
 @pytest.fixture
@@ -29,13 +34,13 @@ def cutout_size():
 @pytest.fixture
 def coordinates():
     """Fixture to return the coordinates at the center of the images"""
-    return SkyCoord('350 -80', unit='deg')
+    return SkyCoord("350 -80", unit="deg")
 
 
 @pytest.fixture
-def all_ffis(scope='module'):
+def all_ffis(scope="module"):
     """Fixture to return the table of all FFIs"""
-    return get_ffis('s3://stpubdata/tess/public/footprints/tess_ffi_footprint_cache.json')
+    return get_ffis("s3://stpubdata/tess/public/footprints/tess_ffi_footprint_cache.json")
 
 
 @pytest.fixture
@@ -59,11 +64,11 @@ def check_output_tpf(tpf, sequences=[], cutout_size=5):
 
     # SPOC cutouts have 1 extra columns in EXT 1
     assert len(tpf_table.columns) == 12
-    assert tpf_table[0]['FLUX'].shape == (cutout_size, cutout_size)
+    assert tpf_table[0]["FLUX"].shape == (cutout_size, cutout_size)
 
     # Check that sector matches a provided sequence
     if sequences:
-        assert tpf[0].header['SECTOR'] in sequences
+        assert tpf[0].header["SECTOR"] in sequences
 
     # Close TPF
     tpf.close()
@@ -71,31 +76,32 @@ def check_output_tpf(tpf, sequences=[], cutout_size=5):
 
 def test_s_region_to_polygon_unsupported_region():
     """Test that ValueError is raised if s_region is not a polygon"""
-    s_region = 'CIRCLE'
-    err = f'Unsupported s_region type: {s_region}'
+    s_region = "CIRCLE"
+    err = f"Unsupported s_region type: {s_region}"
     with pytest.raises(ValueError, match=err):
         TessFootprintCutout._s_region_to_polygon(s_region)
 
 
-@pytest.mark.parametrize("lon, lat, center, expected", [
-    ((345, 355, 355, 345), (-15, -15, -5, -5), (350, -10), True),  # intersecting
-    ((335, 345, 345, 335), (-15, -15, -5, -5), (340, -10), False),  # non-intersecting
-    ((340, 350, 350, 340), (-15, -15, -5, -5), (345, -10), True),  # edge object that intersects
-    ((340, 349, 349, 340), (-15, -15, -5, -5), (345, -10), False),  # edge object that does not intersect
-])
+@pytest.mark.parametrize(
+    "lon, lat, center, expected",
+    [
+        ((345, 355, 355, 345), (-15, -15, -5, -5), (350, -10), True),  # intersecting
+        ((335, 345, 345, 335), (-15, -15, -5, -5), (340, -10), False),  # non-intersecting
+        ((340, 350, 350, 340), (-15, -15, -5, -5), (345, -10), True),  # edge object that intersects
+        ((340, 349, 349, 340), (-15, -15, -5, -5), (345, -10), False),  # edge object that does not intersect
+    ],
+)
 def test_ffi_intersect(lon, lat, center, expected):
     """Test that FFI intersection with cutout outputs proper results."""
     # SphericalPolygon object for cutout
-    cutout_sp = SphericalPolygon.from_radec(lon=(350, 10, 10, 350),
-                                            lat=(-10, -10, 10, 10),
-                                            center=(0, 0))
+    cutout_sp = SphericalPolygon.from_radec(lon=(350, 10, 10, 350), lat=(-10, -10, 10, 10), center=(0, 0))
 
     # Create a SphericalPolygon with the parametrized lon, lat, and center
     polygon = SphericalPolygon.from_radec(lon=lon, lat=lat, center=center)
 
     # Create a table with this polygon
-    polygon_table = Table(names=['polygon'], dtype=[SphericalPolygon])
-    polygon_table['polygon'] = [polygon]
+    polygon_table = Table(names=["polygon"], dtype=[SphericalPolygon])
+    polygon_table["polygon"] = [polygon]
 
     # Perform the intersection check
     intersection = TessFootprintCutout._ffi_intersect(polygon_table, cutout_sp)
@@ -104,11 +110,13 @@ def test_ffi_intersect(lon, lat, center, expected):
     assert intersection.value[0] == expected
 
 
-@pytest.mark.parametrize("cutout_size", [0, 0 * u.arcmin, [0, 0], (0, 0), (0*u.pix, 0*u.pix), 
-                                         [0*u.arcsec, 0*u.arcsec], np.array([0, 0])])
+@pytest.mark.parametrize(
+    "cutout_size",
+    [0, 0 * u.arcmin, [0, 0], (0, 0), (0 * u.pix, 0 * u.pix), [0 * u.arcsec, 0 * u.arcsec], np.array([0, 0])],
+)
 def test_ra_dec_crossmatch_point(coordinates, all_ffis, cutout_size, crossmatch_spies):
     spy_point, spy_poly = crossmatch_spies
-    
+
     # Cutout size of 0 should do a point match
     results = ra_dec_crossmatch(all_ffis, coordinates, cutout_size)
     assert isinstance(results, Table)
@@ -116,12 +124,12 @@ def test_ra_dec_crossmatch_point(coordinates, all_ffis, cutout_size, crossmatch_
     spy_poly.assert_not_called()
 
 
-@pytest.mark.parametrize("cutout_size", [5, 5 * u.arcmin, [5, 5], [5*u.arcsec, 5*u.arcsec], (5, 0), (5, 0)])
+@pytest.mark.parametrize("cutout_size", [5, 5 * u.arcmin, [5, 5], [5 * u.arcsec, 5 * u.arcsec], (5, 0), (5, 0)])
 def test_ra_dec_crossmatch_poly(all_ffis, cutout_size, crossmatch_spies):
     spy_point, spy_poly = crossmatch_spies
-    
+
     # Cutout size of 0 should do a point match
-    results = ra_dec_crossmatch(all_ffis, '350 -80', cutout_size)
+    results = ra_dec_crossmatch(all_ffis, "350 -80", cutout_size)
     assert isinstance(results, Table)
     spy_poly.assert_called_once()
     spy_point.assert_not_called()
@@ -129,7 +137,7 @@ def test_ra_dec_crossmatch_poly(all_ffis, cutout_size, crossmatch_spies):
 
 def test_tess_footprint_cutout(cutout_size, caplog):
     """Test that a single data cube is created for a given sequence"""
-    cutout = TessFootprintCutout('130 30', cutout_size, sequence=44, verbose=True)
+    cutout = TessFootprintCutout("130 30", cutout_size, sequence=44, verbose=True)
 
     # Check cutouts attribute
     cutouts = cutout.cutouts
@@ -162,20 +170,20 @@ def test_tess_footprint_cutout(cutout_size, caplog):
     # Check tess_cube attribute
     tess_cube = cutout.tess_cube_cutout
     assert isinstance(tess_cube, TessCubeCutout)
-    
+
     # Assert that messages were printed
     captured = caplog.text
-    assert 'Coordinates:' in captured
-    assert 'Cutout size: [5 5]' in captured
-    assert re.search(r'Found \d+ footprint files.', captured)
-    assert re.search(r'Filtered to \d+ footprints for sequences: 44', captured)
-    assert re.search(r'Found \d+ matching files.', captured)
-    assert 'Generating cutouts...' in captured
+    assert "Coordinates:" in captured
+    assert "Cutout size: [5 5]" in captured
+    assert re.search(r"Found \d+ footprint files.", captured)
+    assert re.search(r"Filtered to \d+ footprints for sequences: 44", captured)
+    assert re.search(r"Found \d+ matching files.", captured)
+    assert "Generating cutouts..." in captured
 
     # Check that _extract_sequence_information works correctly
     # Should return empty dict if sector name does not match format
-    sector_name = 'invalid_s'
-    sector_name += '0044-4-1'
+    sector_name = "invalid_s"
+    sector_name += "0044-4-1"
     info = _extract_sequence_information(sector_name)
     assert info == {}
 
@@ -200,9 +208,9 @@ def test_tess_footprint_cutout_all_sequences(coordinates, cutout_size):
 
     # Crossmatch to get sectors that contain cutout
     all_ffis = get_ffis(cutout.S3_FOOTPRINT_CACHE)
-    cone_results = ra_dec_crossmatch(all_ffis, '350 -80', cutout_size, 21)
+    cone_results = ra_dec_crossmatch(all_ffis, "350 -80", cutout_size, 21)
     seq_list = _create_sequence_list(cone_results)
-    sequences = [int(seq['sector']) for seq in seq_list]
+    sequences = [int(seq["sector"]) for seq in seq_list]
 
     # Assert non-empty results
     assert len(seq_list) == len(cutout_tpfs)
@@ -218,7 +226,7 @@ def test_tess_footprint_cutout_write_as_tpf(coordinates, cutout_size, tmpdir):
     for cutout_path in paths:
         path = Path(cutout_path)
         assert path.exists()
-        assert path.suffix == '.fits'
+        assert path.suffix == ".fits"
 
         # Check that file can be opened
         with fits.open(path) as hdu:
@@ -228,31 +236,31 @@ def test_tess_footprint_cutout_write_as_tpf(coordinates, cutout_size, tmpdir):
 def test_tess_footprint_cutout_write_to_zip(coordinates, cutout_size, tmpdir):
     """Test that TPF cutouts are written to a ZIP archive"""
     cutout = TessFootprintCutout(coordinates, cutout_size, sequence=[1, 13])
-    zip_path = cutout.write_as_zip(output_dir=tmpdir, filename='tess_cutouts')
+    zip_path = cutout.write_as_zip(output_dir=tmpdir, filename="tess_cutouts")
 
     path = Path(zip_path)
     assert path.exists()
-    assert path.name == 'tess_cutouts.zip'
-    assert path.suffix == '.zip'
+    assert path.name == "tess_cutouts.zip"
+    assert path.suffix == ".zip"
 
     # Check contents of ZIP file
-    with zipfile.ZipFile(path, 'r') as zf:
+    with zipfile.ZipFile(path, "r") as zf:
         namelist = zf.namelist()
         assert len(namelist) == 2  # Two sequences
         for name in namelist:
-            assert name.endswith('.fits')
+            assert name.endswith(".fits")
 
 
 def test_tess_footprint_cutout_invalid_sequence(coordinates, cutout_size):
     """Test that InvalidQueryError is raised if sequence does not have cube files"""
-    err = 'No files were found for sequences: -1'
+    err = "No files were found for sequences: -1"
     with pytest.raises(InvalidQueryError, match=err):
         TessFootprintCutout(coordinates, cutout_size, sequence=-1)
 
 
 def test_tess_footprint_cutout_outside_coords(coordinates, cutout_size):
     """Test that InvalidQueryError is raised if coordinates are not found in sequence"""
-    err = 'The given coordinates were not found within the specified sequence(s).'
+    err = "The given coordinates were not found within the specified sequence(s)."
     with pytest.raises(InvalidQueryError, match=re.escape(err)):
         TessFootprintCutout(coordinates, cutout_size, sequence=2)
 
@@ -261,56 +269,50 @@ def test_tess_footprint_cutout_invalid_product(coordinates, cutout_size):
     """Test that InvalidQueryError is raised if an invalid product is given"""
     err = 'Product for TESS cube cutouts must be "SPOC".'
     with pytest.raises(InvalidInputError, match=err):
-        TessFootprintCutout(coordinates, cutout_size, product='invalid')
+        TessFootprintCutout(coordinates, cutout_size, product="invalid")
 
     with pytest.raises(InvalidInputError, match=err):
-        TessFootprintCutout(coordinates, cutout_size, product='TICA')
-        
+        TessFootprintCutout(coordinates, cutout_size, product="TICA")
+
 
 def test_cube_cut_from_footprint(coordinates, cutout_size, tmpdir):
     """Test that data cube is cut from FFI file using parallel processing"""
     # Writing to memory, should return cutouts as memory objects
-    cutouts = cube_cut_from_footprint(coordinates, 
-                                      cutout_size,
-                                      sequence=13,
-                                      memory_only=True)
+    cutouts = cube_cut_from_footprint(coordinates, cutout_size, sequence=13, memory_only=True)
     assert len(cutouts) == 1
     assert isinstance(cutouts, list)
     assert isinstance(cutouts[0], fits.HDUList)
 
     # Writing to disk, should return cutout filepaths
-    cutouts = cube_cut_from_footprint(coordinates, 
-                                      cutout_size,
-                                      sequence=13,
-                                      output_dir=tmpdir)
+    cutouts = cube_cut_from_footprint(coordinates, cutout_size, sequence=13, output_dir=tmpdir)
     assert len(cutouts) == 1
     assert isinstance(cutouts, list)
     assert isinstance(cutouts[0], str)
     assert str(tmpdir) in cutouts[0]
 
 
-@pytest.mark.parametrize("cutout_size", [0, 5, 1 * u.arcmin, [5, 5], (3*u.arcsec, 3*u.arcsec)])
+@pytest.mark.parametrize("cutout_size", [0, 5, 1 * u.arcmin, [5, 5], (3 * u.arcsec, 3 * u.arcsec)])
 def test_get_tess_sectors(coordinates, cutout_size):
     """Test that get_tess_sectors returns sector list"""
     sector_table = get_tess_sectors(coordinates, cutout_size)
     assert isinstance(sector_table, Table)
-    assert 'sectorName' in sector_table.colnames
-    assert 'sector' in sector_table.colnames
-    assert 'camera' in sector_table.colnames
-    assert 'ccd' in sector_table.colnames
+    assert "sectorName" in sector_table.colnames
+    assert "sector" in sector_table.colnames
+    assert "camera" in sector_table.colnames
+    assert "ccd" in sector_table.colnames
     assert len(sector_table) >= 7
 
 
 def test_get_tess_sectors_invalid_coordinates():
     """Test that InvalidInputError is raised for invalid coordinates input"""
-    with pytest.raises(InvalidInputError, match='Invalid coordinates input'):
-        get_tess_sectors('400 -120', 0)
+    with pytest.raises(InvalidInputError, match="Invalid coordinates input"):
+        get_tess_sectors("400 -120", 0)
 
 
 def test_get_tess_sectors_no_matches(monkeypatch, coordinates):
     """When no FFIs overlap the cutout, the sectors table should be empty."""
-    empty_table = Table(names=['sectorName', 'sector', 'camera', 'ccd'], dtype=['S10', 'i4', 'i4', 'i4'])
-    monkeypatch.setattr('astrocut.tess_footprint_cutout.ra_dec_crossmatch', lambda *_a, **_k: empty_table)
+    empty_table = Table(names=["sectorName", "sector", "camera", "ccd"], dtype=["S10", "i4", "i4", "i4"])
+    monkeypatch.setattr("astrocut.tess_footprint_cutout.ra_dec_crossmatch", lambda *_a, **_k: empty_table)
 
     sector_table = get_tess_sectors(coordinates, 0)
     assert isinstance(sector_table, Table)

--- a/astrocut/tests/test_utils.py
+++ b/astrocut/tests/test_utils.py
@@ -1,29 +1,30 @@
 import numpy as np
-
-from astropy.io import fits
+import pytest
+from astropy import units as u
 from astropy import wcs
 from astropy.coordinates import SkyCoord
-from astropy import units as u
+from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
-import pytest
 
 from astrocut.exceptions import InputWarning, InvalidQueryError
 
 from ..utils import utils
 
-
 # Example FFI WCS for testing
-with open(get_pkg_data_filename('data/ex_ffi_wcs.txt'), "r") as FLE:
+with open(get_pkg_data_filename("data/ex_ffi_wcs.txt"), "r") as FLE:
     WCS_STR = FLE.read()
 
 
-@pytest.mark.parametrize("input_value, expected", [
-    (5, np.array((5, 5))),  # scalar
-    (10 * u.pix, np.array((10, 10)) * u.pix),  # Astropy quantity
-    ((5, 10), np.array((5, 10))),  # tuple
-    ([10, 5], np.array((10, 5))),  # list
-    (np.array((5, 10)), np.array((5, 10))),  # array
-])
+@pytest.mark.parametrize(
+    "input_value, expected",
+    [
+        (5, np.array((5, 5))),  # scalar
+        (10 * u.pix, np.array((10, 10)) * u.pix),  # Astropy quantity
+        ((5, 10), np.array((5, 10))),  # tuple
+        ([10, 5], np.array((10, 5))),  # list
+        (np.array((5, 10)), np.array((5, 10))),  # array
+    ],
+)
 def test_parse_size_input(input_value, expected):
     """Test that different types of input are accurately parsed into cutout sizes."""
     cutout_size = utils.parse_size_input(input_value)
@@ -40,7 +41,7 @@ def test_parse_size_input_dimension_warning():
 
 def test_parse_size_input_invalid():
     """Test that an error is raised when one of the size dimensions is not positive"""
-    err = ('Cutout size dimensions must be greater than zero.')
+    err = "Cutout size dimensions must be greater than zero."
     with pytest.raises(InvalidQueryError, match=err):
         utils.parse_size_input(0)
 
@@ -49,30 +50,33 @@ def test_parse_size_input_invalid():
 
     with pytest.raises(InvalidQueryError, match=err):
         utils.parse_size_input((0, 5))
-    
+
 
 def test_get_cutout_limits():
+    test_img_wcs_kwds = fits.Header(
+        cards=[
+            ("NAXIS", 2, "number of array dimensions"),
+            ("NAXIS1", 20, ""),
+            ("NAXIS2", 30, ""),
+            ("CTYPE1", "RA---TAN", "Right ascension, gnomonic projection"),
+            ("CTYPE2", "DEC--TAN", "Declination, gnomonic projection"),
+            ("CRVAL1", 100, "[deg] Coordinate value at reference point"),
+            ("CRVAL2", 20, "[deg] Coordinate value at reference point"),
+            ("CRPIX1", 10, "Pixel coordinate of reference point"),
+            ("CRPIX2", 15, "Pixel coordinate of reference point"),
+            ("CDELT1", 1.0, "[deg] Coordinate increment at reference point"),
+            ("CDELT2", 1.0, "[deg] Coordinate increment at reference point"),
+            ("WCSAXES", 2, "Number of coordinate axes"),
+            ("PC1_1", 1, "Coordinate transformation matrix element"),
+            ("PC2_2", 1, "Coordinate transformation matrix element"),
+            ("CUNIT1", "deg", "Units of coordinate increment and value"),
+            ("CUNIT2", "deg", "Units of coordinate increment and value"),
+        ]
+    )
 
-    test_img_wcs_kwds = fits.Header(cards=[('NAXIS', 2, 'number of array dimensions'),
-                                           ('NAXIS1', 20, ''),
-                                           ('NAXIS2', 30, ''),
-                                           ('CTYPE1', 'RA---TAN', 'Right ascension, gnomonic projection'),
-                                           ('CTYPE2', 'DEC--TAN', 'Declination, gnomonic projection'),
-                                           ('CRVAL1', 100, '[deg] Coordinate value at reference point'),
-                                           ('CRVAL2', 20, '[deg] Coordinate value at reference point'),
-                                           ('CRPIX1', 10, 'Pixel coordinate of reference point'),
-                                           ('CRPIX2', 15, 'Pixel coordinate of reference point'),
-                                           ('CDELT1', 1.0, '[deg] Coordinate increment at reference point'),
-                                           ('CDELT2', 1.0, '[deg] Coordinate increment at reference point'),
-                                           ('WCSAXES', 2, 'Number of coordinate axes'),
-                                           ('PC1_1', 1, 'Coordinate transformation matrix element'),
-                                           ('PC2_2', 1, 'Coordinate transformation matrix element'),
-                                           ('CUNIT1', 'deg', 'Units of coordinate increment and value'),
-                                           ('CUNIT2', 'deg', 'Units of coordinate increment and value')])
-    
     test_img_wcs = wcs.WCS(test_img_wcs_kwds)
 
-    center_coord = SkyCoord("100 20", unit='deg')
+    center_coord = SkyCoord("100 20", unit="deg")
     cutout_size = [10, 10]
 
     lims = utils.get_cutout_limits(test_img_wcs, center_coord, cutout_size)
@@ -84,65 +88,68 @@ def test_get_cutout_limits():
     assert (lims[0, 1] - lims[0, 0]) == 10
     assert (lims[1, 1] - lims[1, 0]) == 5
 
-    cutout_size = [.1, .1]*u.deg
+    cutout_size = [0.1, 0.1] * u.deg
     lims = utils.get_cutout_limits(test_img_wcs, center_coord, cutout_size)
     assert (lims[0, 1] - lims[0, 0]) == (lims[1, 1] - lims[1, 0])
     assert (lims[0, 1] - lims[0, 0]) == 1
 
-    cutout_size = [4, 5]*u.deg
+    cutout_size = [4, 5] * u.deg
     lims = utils.get_cutout_limits(test_img_wcs, center_coord, cutout_size)
     assert (lims[0, 1] - lims[0, 0]) == 4
     assert (lims[1, 1] - lims[1, 0]) == 5
 
-    center_coord = SkyCoord("90 20", unit='deg')
-    cutout_size = [4, 5]*u.deg
+    center_coord = SkyCoord("90 20", unit="deg")
+    cutout_size = [4, 5] * u.deg
     lims = utils.get_cutout_limits(test_img_wcs, center_coord, cutout_size)
     assert lims[0, 0] < 0
 
-    center_coord = SkyCoord("100 5", unit='deg')
-    cutout_size = [4, 5]*u.pixel
+    center_coord = SkyCoord("100 5", unit="deg")
+    cutout_size = [4, 5] * u.pixel
     lims = utils.get_cutout_limits(test_img_wcs, center_coord, cutout_size)
     assert lims[1, 0] < 0
 
 
 def test_get_cutout_wcs():
-    test_img_wcs_kwds = fits.Header(cards=[('NAXIS', 2, 'number of array dimensions'),
-                                           ('NAXIS1', 20, ''),
-                                           ('NAXIS2', 30, ''),
-                                           ('CTYPE1', 'RA---TAN', 'Right ascension, gnomonic projection'),
-                                           ('CTYPE2', 'DEC--TAN', 'Declination, gnomonic projection'),
-                                           ('CRVAL1', 100, '[deg] Coordinate value at reference point'),
-                                           ('CRVAL2', 20, '[deg] Coordinate value at reference point'),
-                                           ('CRPIX1', 10, 'Pixel coordinate of reference point'),
-                                           ('CRPIX2', 15, 'Pixel coordinate of reference point'),
-                                           ('CDELT1', 1.0, '[deg] Coordinate increment at reference point'),
-                                           ('CDELT2', 1.0, '[deg] Coordinate increment at reference point'),
-                                           ('WCSAXES', 2, 'Number of coordinate axes'),
-                                           ('PC1_1', 1, 'Coordinate transformation matrix element'),
-                                           ('PC2_2', 1, 'Coordinate transformation matrix element'),
-                                           ('CUNIT1', 'deg', 'Units of coordinate increment and value'),
-                                           ('CUNIT2', 'deg', 'Units of coordinate increment and value')])
-    
+    test_img_wcs_kwds = fits.Header(
+        cards=[
+            ("NAXIS", 2, "number of array dimensions"),
+            ("NAXIS1", 20, ""),
+            ("NAXIS2", 30, ""),
+            ("CTYPE1", "RA---TAN", "Right ascension, gnomonic projection"),
+            ("CTYPE2", "DEC--TAN", "Declination, gnomonic projection"),
+            ("CRVAL1", 100, "[deg] Coordinate value at reference point"),
+            ("CRVAL2", 20, "[deg] Coordinate value at reference point"),
+            ("CRPIX1", 10, "Pixel coordinate of reference point"),
+            ("CRPIX2", 15, "Pixel coordinate of reference point"),
+            ("CDELT1", 1.0, "[deg] Coordinate increment at reference point"),
+            ("CDELT2", 1.0, "[deg] Coordinate increment at reference point"),
+            ("WCSAXES", 2, "Number of coordinate axes"),
+            ("PC1_1", 1, "Coordinate transformation matrix element"),
+            ("PC2_2", 1, "Coordinate transformation matrix element"),
+            ("CUNIT1", "deg", "Units of coordinate increment and value"),
+            ("CUNIT2", "deg", "Units of coordinate increment and value"),
+        ]
+    )
+
     test_img_wcs = wcs.WCS(test_img_wcs_kwds)
 
-    center_coord = SkyCoord("100 20", unit='deg')
-    cutout_size = [4, 5]*u.deg
+    center_coord = SkyCoord("100 20", unit="deg")
+    cutout_size = [4, 5] * u.deg
     lims = utils.get_cutout_limits(test_img_wcs, center_coord, cutout_size)
     cutout_wcs = utils.get_cutout_wcs(test_img_wcs, lims)
     assert (cutout_wcs.wcs.crval == [100, 20]).all()
     assert (cutout_wcs.wcs.crpix == [3, 4]).all()
 
-    center_coord = SkyCoord("100 5", unit='deg')
-    cutout_size = [4, 5]*u.deg
+    center_coord = SkyCoord("100 5", unit="deg")
+    cutout_size = [4, 5] * u.deg
     lims = utils.get_cutout_limits(test_img_wcs, center_coord, cutout_size)
     cutout_wcs = utils.get_cutout_wcs(test_img_wcs, lims)
     assert (cutout_wcs.wcs.crval == [100, 20]).all()
     assert (cutout_wcs.wcs.crpix == [3, 19]).all()
 
-    center_coord = SkyCoord("110 20", unit='deg')
-    cutout_size = [10, 10]*u.deg
+    center_coord = SkyCoord("110 20", unit="deg")
+    cutout_size = [10, 10] * u.deg
     lims = utils.get_cutout_limits(test_img_wcs, center_coord, cutout_size)
     cutout_wcs = utils.get_cutout_wcs(test_img_wcs, lims)
     assert (cutout_wcs.wcs.crval == [100, 20]).all()
     assert (cutout_wcs.wcs.crpix == [-3, 6]).all()
-

--- a/astrocut/tests/utils_for_test.py
+++ b/astrocut/tests/utils_for_test.py
@@ -1,226 +1,229 @@
-import numpy as np
 from os import path
-from astropy.io import fits    
+
+import numpy as np
+from astropy.io import fits
 
 
 def add_keywords(hdu, extname, time_increment, primary=False):
     """
     Add a bunch of required keywords (mostly fake values).
     """
-    
-    hdu.header['extname'] = extname
-    hdu.header['camera'] = 1
-    hdu.header['ccd'] = 1
-    hdu.header['tstart'] = float(time_increment)
-    hdu.header['tstop'] = float(time_increment+1)
-    hdu.header['date-obs'] = '2019-05-11T00:08:26.816Z'
-    hdu.header['date-end'] = '2019-05-11T00:38:26.816Z'
-    hdu.header['barycorr'] = 5.0085597E-03
-    hdu.header['dquality'] = 0
-    hdu.header['FFIINDEX'] = 151696
+
+    hdu.header["extname"] = extname
+    hdu.header["camera"] = 1
+    hdu.header["ccd"] = 1
+    hdu.header["tstart"] = float(time_increment)
+    hdu.header["tstop"] = float(time_increment + 1)
+    hdu.header["date-obs"] = "2019-05-11T00:08:26.816Z"
+    hdu.header["date-end"] = "2019-05-11T00:38:26.816Z"
+    hdu.header["barycorr"] = 5.0085597e-03
+    hdu.header["dquality"] = 0
+    hdu.header["FFIINDEX"] = 151696
 
     if not primary:
         # WCS keywords just copied from example
-        hdu.header['RADESYS'] = 'ICRS    '
-        hdu.header['EQUINOX'] = 2000.0
-        hdu.header['WCSAXES'] = 2
-        hdu.header['CTYPE1'] = ('RA---TAN-SIP', "Gnomonic projection + SIP distortions")
-        hdu.header['CTYPE2'] = ('DEC--TAN-SIP', "Gnomonic projection + SIP distortions")
-        hdu.header['CRVAL1'] = 250.3497414839765200
-        hdu.header['CRVAL2'] = 2.2809255996090630
-        hdu.header['CRPIX1'] = 1045.0
-        hdu.header['CRPIX2'] = 1001.0
-        hdu.header['CD1_1'] = -0.005564478186178
-        hdu.header['CD1_2'] = -0.001042099258152
-        hdu.header['CD2_1'] = 0.001181441465850
-        hdu.header['CD2_2'] = -0.005590816683583
-        hdu.header['A_ORDER'] = 2
-        hdu.header['B_ORDER'] = 2
-        hdu.header['A_2_0'] = 2.024511892340E-05
-        hdu.header['A_0_2'] = 3.317603337918E-06
-        hdu.header['A_1_1'] = 1.73456334971071E-5
-        hdu.header['B_2_0'] = 3.331330003472E-06
-        hdu.header['B_0_2'] = 2.042474824825892E-5
-        hdu.header['B_1_1'] = 1.714767108041439E-5
-        hdu.header['AP_ORDER'] = 2
-        hdu.header['BP_ORDER'] = 2
-        hdu.header['AP_1_0'] = 9.047002963896363E-4
-        hdu.header['AP_0_1'] = 6.276607155847164E-4
-        hdu.header['AP_2_0'] = -2.023482905861E-05
-        hdu.header['AP_0_2'] = -3.332285841011E-06
-        hdu.header['AP_1_1'] = -1.731636633824E-05
-        hdu.header['BP_1_0'] = 6.279608820532116E-4
-        hdu.header['BP_0_1'] = 9.112228860848081E-4
-        hdu.header['BP_2_0'] = -3.343918167224E-06
-        hdu.header['BP_0_2'] = -2.041598249021E-05
-        hdu.header['BP_1_1'] = -1.711876336719E-05
-        hdu.header['A_DMAX'] = 44.72893589844534
-        hdu.header['B_DMAX'] = 44.62692873032506
+        hdu.header["RADESYS"] = "ICRS    "
+        hdu.header["EQUINOX"] = 2000.0
+        hdu.header["WCSAXES"] = 2
+        hdu.header["CTYPE1"] = ("RA---TAN-SIP", "Gnomonic projection + SIP distortions")
+        hdu.header["CTYPE2"] = ("DEC--TAN-SIP", "Gnomonic projection + SIP distortions")
+        hdu.header["CRVAL1"] = 250.3497414839765200
+        hdu.header["CRVAL2"] = 2.2809255996090630
+        hdu.header["CRPIX1"] = 1045.0
+        hdu.header["CRPIX2"] = 1001.0
+        hdu.header["CD1_1"] = -0.005564478186178
+        hdu.header["CD1_2"] = -0.001042099258152
+        hdu.header["CD2_1"] = 0.001181441465850
+        hdu.header["CD2_2"] = -0.005590816683583
+        hdu.header["A_ORDER"] = 2
+        hdu.header["B_ORDER"] = 2
+        hdu.header["A_2_0"] = 2.024511892340e-05
+        hdu.header["A_0_2"] = 3.317603337918e-06
+        hdu.header["A_1_1"] = 1.73456334971071e-5
+        hdu.header["B_2_0"] = 3.331330003472e-06
+        hdu.header["B_0_2"] = 2.042474824825892e-5
+        hdu.header["B_1_1"] = 1.714767108041439e-5
+        hdu.header["AP_ORDER"] = 2
+        hdu.header["BP_ORDER"] = 2
+        hdu.header["AP_1_0"] = 9.047002963896363e-4
+        hdu.header["AP_0_1"] = 6.276607155847164e-4
+        hdu.header["AP_2_0"] = -2.023482905861e-05
+        hdu.header["AP_0_2"] = -3.332285841011e-06
+        hdu.header["AP_1_1"] = -1.731636633824e-05
+        hdu.header["BP_1_0"] = 6.279608820532116e-4
+        hdu.header["BP_0_1"] = 9.112228860848081e-4
+        hdu.header["BP_2_0"] = -3.343918167224e-06
+        hdu.header["BP_0_2"] = -2.041598249021e-05
+        hdu.header["BP_1_1"] = -1.711876336719e-05
+        hdu.header["A_DMAX"] = 44.72893589844534
+        hdu.header["B_DMAX"] = 44.62692873032506
 
 
 def add_tica_keywords(hdu, time_increment):
     """
-    Add a bunch of required keywords (mostly fake values). TICA specific. 
+    Add a bunch of required keywords (mostly fake values). TICA specific.
     """
-    
-    hdu.header['CAMNUM'] = 1
-    hdu.header['CCDNUM'] = 1
-    hdu.header['STARTTJD'] = float(time_increment)
-    hdu.header['ENDTJD'] = float(time_increment+1)
-    hdu.header['QUAL_BIT'] = 0
-    hdu.header['CADENCE'] = 151696
-    hdu.header['CRM'] = True
-    hdu.header['DEADC'] = 0.792
+
+    hdu.header["CAMNUM"] = 1
+    hdu.header["CCDNUM"] = 1
+    hdu.header["STARTTJD"] = float(time_increment)
+    hdu.header["ENDTJD"] = float(time_increment + 1)
+    hdu.header["QUAL_BIT"] = 0
+    hdu.header["CADENCE"] = 151696
+    hdu.header["CRM"] = True
+    hdu.header["DEADC"] = 0.792
 
     # WCS keywords just copied from example
     # hdu.header['RADESYS'] = 'ICRS    '
-    hdu.header['EQUINOX'] = 2000.0
-    hdu.header['WCAX3'] = 2
-    hdu.header['CTYPE1'] = ('RA---TAN-SIP', "Gnomonic projection + SIP distortions")
-    hdu.header['CTYPE2'] = ('DEC--TAN-SIP', "Gnomonic projection + SIP distortions")
-    hdu.header['CRVAL1'] = 250.3497414839765200
-    hdu.header['CRVAL2'] = 2.2809255996090630
-    hdu.header['CRPIX1'] = 1045.0
-    hdu.header['CRPIX2'] = 1001.0
-    hdu.header['CD1_1'] = -0.005564478186178
-    hdu.header['CD1_2'] = -0.001042099258152
-    hdu.header['CD2_1'] = 0.001181441465850
-    hdu.header['CD2_2'] = -0.005590816683583
-    hdu.header['A_ORDER'] = 2
-    hdu.header['B_ORDER'] = 2
-    hdu.header['A_2_0'] = 2.024511892340E-05
-    hdu.header['A_0_2'] = 3.317603337918E-06
-    hdu.header['A_1_1'] = 1.73456334971071E-5
-    hdu.header['B_2_0'] = 3.331330003472E-06
-    hdu.header['B_0_2'] = 2.042474824825892E-5
-    hdu.header['B_1_1'] = 1.714767108041439E-5
-    hdu.header['AP_ORDER'] = 2
-    hdu.header['BP_ORDER'] = 2
-    hdu.header['AP_1_0'] = 9.047002963896363E-4
-    hdu.header['AP_0_1'] = 6.276607155847164E-4
-    hdu.header['AP_2_0'] = -2.023482905861E-05
-    hdu.header['AP_0_2'] = -3.332285841011E-06
-    hdu.header['AP_1_1'] = -1.731636633824E-05
-    hdu.header['BP_1_0'] = 6.279608820532116E-4
-    hdu.header['BP_0_1'] = 9.112228860848081E-4
-    hdu.header['BP_2_0'] = -3.343918167224E-06
-    hdu.header['BP_0_2'] = -2.041598249021E-05
-    hdu.header['BP_1_1'] = -1.711876336719E-05
-    hdu.header['A_DMAX'] = 44.72893589844534
-    hdu.header['B_DMAX'] = 44.62692873032506
-    hdu.header['COMMENT'] = 'TICA TEST'
+    hdu.header["EQUINOX"] = 2000.0
+    hdu.header["WCAX3"] = 2
+    hdu.header["CTYPE1"] = ("RA---TAN-SIP", "Gnomonic projection + SIP distortions")
+    hdu.header["CTYPE2"] = ("DEC--TAN-SIP", "Gnomonic projection + SIP distortions")
+    hdu.header["CRVAL1"] = 250.3497414839765200
+    hdu.header["CRVAL2"] = 2.2809255996090630
+    hdu.header["CRPIX1"] = 1045.0
+    hdu.header["CRPIX2"] = 1001.0
+    hdu.header["CD1_1"] = -0.005564478186178
+    hdu.header["CD1_2"] = -0.001042099258152
+    hdu.header["CD2_1"] = 0.001181441465850
+    hdu.header["CD2_2"] = -0.005590816683583
+    hdu.header["A_ORDER"] = 2
+    hdu.header["B_ORDER"] = 2
+    hdu.header["A_2_0"] = 2.024511892340e-05
+    hdu.header["A_0_2"] = 3.317603337918e-06
+    hdu.header["A_1_1"] = 1.73456334971071e-5
+    hdu.header["B_2_0"] = 3.331330003472e-06
+    hdu.header["B_0_2"] = 2.042474824825892e-5
+    hdu.header["B_1_1"] = 1.714767108041439e-5
+    hdu.header["AP_ORDER"] = 2
+    hdu.header["BP_ORDER"] = 2
+    hdu.header["AP_1_0"] = 9.047002963896363e-4
+    hdu.header["AP_0_1"] = 6.276607155847164e-4
+    hdu.header["AP_2_0"] = -2.023482905861e-05
+    hdu.header["AP_0_2"] = -3.332285841011e-06
+    hdu.header["AP_1_1"] = -1.731636633824e-05
+    hdu.header["BP_1_0"] = 6.279608820532116e-4
+    hdu.header["BP_0_1"] = 9.112228860848081e-4
+    hdu.header["BP_2_0"] = -3.343918167224e-06
+    hdu.header["BP_0_2"] = -2.041598249021e-05
+    hdu.header["BP_1_1"] = -1.711876336719e-05
+    hdu.header["A_DMAX"] = 44.72893589844534
+    hdu.header["B_DMAX"] = 44.62692873032506
+    hdu.header["COMMENT"] = "TICA TEST"
 
 
-def create_test_ffis(img_size, num_images, dir_name=".", product='SPOC', basename='make_cube-test{:04d}.fits'):
+def create_test_ffis(img_size, num_images, dir_name=".", product="SPOC", basename="make_cube-test{:04d}.fits"):
     """
     Create test fits files
 
     Write negative values for data array and positive values for error array,
-    with unique values for all the pixels. 
+    with unique values for all the pixels.
     """
 
-    img = np.arange(img_size*img_size, dtype=np.float32).reshape((img_size, img_size))
+    img = np.arange(img_size * img_size, dtype=np.float32).reshape((img_size, img_size))
     file_list = []
 
     basename = path.join(dir_name, basename)
     for i in range(num_images):
-        
         file_list.append(basename.format(i))
 
-        if product == 'SPOC':
+        if product == "SPOC":
             primary_hdu = fits.PrimaryHDU()
-        elif product == 'TICA':
+        elif product == "TICA":
             primary_hdu = fits.PrimaryHDU(-img)
 
-        if product == 'SPOC':
+        if product == "SPOC":
             add_keywords(primary_hdu, "PRIMARY", i, primary=True)
-        elif product == 'TICA':
+        elif product == "TICA":
             add_tica_keywords(primary_hdu, i)
 
-        if product == 'SPOC':   
+        if product == "SPOC":
             hdu = fits.ImageHDU(-img)
-            add_keywords(hdu, 'CAMERA.CCD 1.1 cal', i)
-            
+            add_keywords(hdu, "CAMERA.CCD 1.1 cal", i)
+
             ehdu = fits.ImageHDU(img)
-            add_keywords(ehdu, 'CAMERA.CCD 1.1 uncert', i)
-            
+            add_keywords(ehdu, "CAMERA.CCD 1.1 uncert", i)
+
             hdulist = fits.HDUList([primary_hdu, hdu, ehdu])
 
-        elif product == 'TICA':
-            hdulist = fits.HDUList([primary_hdu])   
+        elif product == "TICA":
+            hdulist = fits.HDUList([primary_hdu])
 
         hdulist.writeto(file_list[-1], overwrite=True, checksum=True)
-        
-        img = img + img_size*img_size
+
+        img = img + img_size * img_size
 
     return file_list
 
 
-def add_wcs_nosip_keywords(hdu, img_size, product='SPOC'):
+def add_wcs_nosip_keywords(hdu, img_size, product="SPOC"):
     """
     Adds example wcs keywords without sip distortions to the given header.
 
     Center coordinate is: 150.1163213, 2.200973097
     """
 
-    wcsaxes = 'WCSAXES' if product == 'SPOC' else 'WCAX3'
-    hdu.header.extend([(wcsaxes, 2, 'Number of coordinate axes'),
-                       ('CRPIX1', img_size/2, 'Pixel coordinate of reference point'),
-                       ('CRPIX2', img_size/2, 'Pixel coordinate of reference point'),
-                       ('PC1_1', -1.666667e-05, 'Coordinate transformation matrix element'),
-                       ('PC2_2', 1.666667e-05, 'Coordinate transformation matrix element'),
-                       ('CDELT1', 1.0, '[deg] Coordinate increment at reference point'),
-                       ('CDELT2', 1.0, '[deg] Coordinate increment at reference point'),
-                       ('CUNIT1', 'deg', 'Units of coordinate increment and value'),
-                       ('CUNIT2', 'deg', 'Units of coordinate increment and value'),
-                       ('CTYPE1', 'RA---TAN', 'Right ascension, gnomonic projection'),
-                       ('CTYPE2', 'DEC--TAN', 'Declination, gnomonic projection'),
-                       ('CRVAL1', 150.1163213, '[deg] Coordinate value at reference point'),
-                       ('CRVAL2', 2.200973097, '[deg] Coordinate value at reference point')])
+    wcsaxes = "WCSAXES" if product == "SPOC" else "WCAX3"
+    hdu.header.extend(
+        [
+            (wcsaxes, 2, "Number of coordinate axes"),
+            ("CRPIX1", img_size / 2, "Pixel coordinate of reference point"),
+            ("CRPIX2", img_size / 2, "Pixel coordinate of reference point"),
+            ("PC1_1", -1.666667e-05, "Coordinate transformation matrix element"),
+            ("PC2_2", 1.666667e-05, "Coordinate transformation matrix element"),
+            ("CDELT1", 1.0, "[deg] Coordinate increment at reference point"),
+            ("CDELT2", 1.0, "[deg] Coordinate increment at reference point"),
+            ("CUNIT1", "deg", "Units of coordinate increment and value"),
+            ("CUNIT2", "deg", "Units of coordinate increment and value"),
+            ("CTYPE1", "RA---TAN", "Right ascension, gnomonic projection"),
+            ("CTYPE2", "DEC--TAN", "Declination, gnomonic projection"),
+            ("CRVAL1", 150.1163213, "[deg] Coordinate value at reference point"),
+            ("CRVAL2", 2.200973097, "[deg] Coordinate value at reference point"),
+        ]
+    )
 
-    
+
 def add_bad_sip_keywords(hdu):
     """
     Adding a number of dummy keywords, basically so the drop_after argument to fits_cut can be tested.
     """
-    hdu.header['A_ORDER'] = 2
-    hdu.header['B_ORDER'] = 2
-    hdu.header['A_2_0'] = 2.024511892340E-05
-    hdu.header['A_0_2'] = 3.317603337918E-06
-    hdu.header['A_1_1'] = 1.73456334971071E-5
-    hdu.header['B_2_0'] = 3.331330003472E-06
-    hdu.header['B_0_2'] = 2.042474824825892E-5
-    hdu.header['B_1_1'] = 1.714767108041439E-5
-    hdu.header['AP_ORDER'] = 2
-    hdu.header['BP_ORDER'] = 2
-    hdu.header['AP_1_0'] = 9.047002963896363E-4
-    hdu.header['AP_0_1'] = 6.276607155847164E-4
-    hdu.header['AP_2_0'] = -2.023482905861E-05
-    hdu.header['AP_0_2'] = -3.332285841011E-06
-    hdu.header['AP_1_1'] = -1.731636633824E-05
-    hdu.header['BP_1_0'] = 6.279608820532116E-4
-    hdu.header['BP_0_1'] = 9.112228860848081E-4
-    hdu.header['BP_2_0'] = -3.343918167224E-06
-    hdu.header['BP_0_2'] = -2.041598249021E-05
-    hdu.header['BP_1_1'] = -1.711876336719E-05
-    hdu.header['A_DMAX'] = 44.72893589844534
-    hdu.header['B_DMAX'] = 44.62692873032506
-    
+    hdu.header["A_ORDER"] = 2
+    hdu.header["B_ORDER"] = 2
+    hdu.header["A_2_0"] = 2.024511892340e-05
+    hdu.header["A_0_2"] = 3.317603337918e-06
+    hdu.header["A_1_1"] = 1.73456334971071e-5
+    hdu.header["B_2_0"] = 3.331330003472e-06
+    hdu.header["B_0_2"] = 2.042474824825892e-5
+    hdu.header["B_1_1"] = 1.714767108041439e-5
+    hdu.header["AP_ORDER"] = 2
+    hdu.header["BP_ORDER"] = 2
+    hdu.header["AP_1_0"] = 9.047002963896363e-4
+    hdu.header["AP_0_1"] = 6.276607155847164e-4
+    hdu.header["AP_2_0"] = -2.023482905861e-05
+    hdu.header["AP_0_2"] = -3.332285841011e-06
+    hdu.header["AP_1_1"] = -1.731636633824e-05
+    hdu.header["BP_1_0"] = 6.279608820532116e-4
+    hdu.header["BP_0_1"] = 9.112228860848081e-4
+    hdu.header["BP_2_0"] = -3.343918167224e-06
+    hdu.header["BP_0_2"] = -2.041598249021e-05
+    hdu.header["BP_1_1"] = -1.711876336719e-05
+    hdu.header["A_DMAX"] = 44.72893589844534
+    hdu.header["B_DMAX"] = 44.62692873032506
 
-def create_test_imgs(product, img_size, num_images, bad_sip_keywords=False, dir_name=".", basename='img_{:04d}.fits'):
+
+def create_test_imgs(product, img_size, num_images, bad_sip_keywords=False, dir_name=".", basename="img_{:04d}.fits"):
     """
     Create test fits image files, single extension.
 
-    Write unique values for all the pixels. 
+    Write unique values for all the pixels.
     The header keywords are populated with a simple WCS for testing.
     """
 
-    img = np.arange(img_size*img_size, dtype=np.float32).reshape((img_size, img_size))
+    img = np.arange(img_size * img_size, dtype=np.float32).reshape((img_size, img_size))
     file_list = []
 
     basename = path.join(dir_name, basename)
     for i in range(num_images):
-        
         file_list.append(basename.format(i))
 
         primary_hdu = fits.PrimaryHDU(data=img)
@@ -228,10 +231,10 @@ def create_test_imgs(product, img_size, num_images, bad_sip_keywords=False, dir_
 
         if bad_sip_keywords:
             add_bad_sip_keywords(primary_hdu)
-        
+
         hdulist = fits.HDUList([primary_hdu])
         hdulist.writeto(file_list[-1], overwrite=True, checksum=True)
-        
-        img = img + img_size*img_size
+
+        img = img + img_size * img_size
 
     return file_list

--- a/astrocut/tica_cube_factory.py
+++ b/astrocut/tica_cube_factory.py
@@ -9,16 +9,19 @@ from astropy.utils.decorators import deprecated
 from .cube_factory import CubeFactory
 
 
-@deprecated(since='1.1.0', message='The `TicaCubeFactory` class is deprecated and will be removed in a future version. ' 
-                                   'Use the `CubeFactory` class for creating image cubes from SPOC product files.')
+@deprecated(
+    since="1.1.0",
+    message="The `TicaCubeFactory` class is deprecated and will be removed in a future version. "
+    "Use the `CubeFactory` class for creating image cubes from SPOC product files.",
+)
 class TicaCubeFactory(CubeFactory):
     """
-    Class for creating TICA image cubes. 
+    Class for creating TICA image cubes.
 
-    The TESS Image CAlibrator (TICA) products are high level science products (HLSPs) 
-    developed by the MIT Quick Look Pipeline (https://github.com/mmfausnaugh/tica). These 
+    The TESS Image CAlibrator (TICA) products are high level science products (HLSPs)
+    developed by the MIT Quick Look Pipeline (https://github.com/mmfausnaugh/tica). These
     images are produced and delivered up to 4x sooner than their SPOC counterparts (as of TESS EM2),
-    and can therefore be used to produce the most up-to-date cutouts of a target. 
+    and can therefore be used to produce the most up-to-date cutouts of a target.
     More information on TICA can be found here: https://archive.stsci.edu/hlsp/tica
 
     Parameters
@@ -28,14 +31,15 @@ class TicaCubeFactory(CubeFactory):
         Note, this is the maximum amount of space to be used for the cube array only,
         so should not be set to the full amount of memory on the system.
     """
+
     def __init__(self, max_memory: int = 50):
-        """ Setting up the class members."""
+        """Setting up the class members."""
         super().__init__(max_memory=max_memory)
 
-        self._time_keyword = 'STARTTJD'  # Start time in TJD. TICA-specific.
-        self._last_file_keywords = ['ENDTJD']  # Stop time in TJD. TICA-specific (assumed to be in extension 0)                  
-        self._image_header_keywords = ['CAMNUM', 'CCDNUM']  # Camera number and CCD number 
-        self._template_requirements = {'NAXIS': 2}  # Using NAXIS instead of WCSAXES. 
+        self._time_keyword = "STARTTJD"  # Start time in TJD. TICA-specific.
+        self._last_file_keywords = ["ENDTJD"]  # Stop time in TJD. TICA-specific (assumed to be in extension 0)
+        self._image_header_keywords = ["CAMNUM", "CCDNUM"]  # Camera number and CCD number
+        self._template_requirements = {"NAXIS": 2}  # Using NAXIS instead of WCSAXES.
         self._img_ext = 0  # TICA has image data in the primary extension
         self._naxis1 = 1  # TICA has data values only
 
@@ -52,9 +56,9 @@ class TicaCubeFactory(CubeFactory):
         -------
         float
             The start time of the image.
-        """       
+        """
         return img_data[self._img_ext].header.get(self._time_keyword)
-        
+
     def _get_img_shape(self, img_data: fits.HDUList) -> tuple:
         """
         Get the shape of the image data.
@@ -68,13 +72,13 @@ class TicaCubeFactory(CubeFactory):
         -------
         tuple
             The shape of the image data.
-        """  
-        try:            
-            return img_data[self._img_ext].data.shape          
+        """
+        try:
+            return img_data[self._img_ext].data.shape
         except AttributeError:
-            # If data is not found in the image extension, raise an error          
+            # If data is not found in the image extension, raise an error
             raise ValueError(self.ERROR_MSG)
-    
+
     def _write_to_sub_cube(self, sub_cube: np.ndarray, idx: int, img_data: fits.HDUList, start_row: int, end_row: int):
         """
         Write data from an input image to a sub-cube.
@@ -110,7 +114,7 @@ class TicaCubeFactory(CubeFactory):
             The image data.
         nulval : int or str
             The null value for the keyword.
-        """        
+        """
         val = img_data[0].header.get(kwd, nulval)
 
         # The "COMMENT" keyword is in the form of a _HeaderCommentaryCard instead of a string

--- a/astrocut/utils/logger.py
+++ b/astrocut/utils/logger.py
@@ -12,7 +12,7 @@ def setup_logger():
 
     # Create a console handler with format
     sh = logging.StreamHandler()
-    formatter = logging.Formatter('%(levelname)s: %(message)s [%(module)s]')
+    formatter = logging.Formatter("%(levelname)s: %(message)s [%(module)s]")
     sh.setFormatter(formatter)
     log.addHandler(sh)
 

--- a/astrocut/utils/utils.py
+++ b/astrocut/utils/utils.py
@@ -53,7 +53,7 @@ def parse_size_input(cutout_size):
     ny, nx = cutout_size
     if ny <= 0 or nx <= 0:
         raise InvalidQueryError(
-            "Cutout size dimensions must be greater than zero. " f"Provided size: ({cutout_size[0]}, {cutout_size[1]})"
+            f"Cutout size dimensions must be greater than zero. Provided size: ({cutout_size[0]}, {cutout_size[1]})"
         )
 
     return cutout_size

--- a/astrocut/utils/utils.py
+++ b/astrocut/utils/utils.py
@@ -2,19 +2,18 @@
 
 """This module includes a variety of functions that may be used by multiple modules."""
 
-import warnings
-import numpy as np
 import logging
-
+import warnings
 from datetime import date
 
+import numpy as np
+from astropy import units as u
 from astropy import wcs
 from astropy.io import fits
-from astropy import units as u
 from astropy.utils import deprecated
 
 from .. import __version__, log
-from ..exceptions import InvalidQueryError, InputWarning
+from ..exceptions import InputWarning, InvalidQueryError
 
 
 def parse_size_input(cutout_size):
@@ -24,10 +23,10 @@ def parse_size_input(cutout_size):
     Parameters
     ----------
     cutout_size : int, array-like, `~astropy.units.Quantity`
-        The size of the cutout array. If ``cutout_size`` is a scalar number or a scalar 
-        `~astropy.units.Quantity`, then a square cutout of ``cutout_size`` will be created.  
-        If ``cutout_size`` has two elements, they should be in ``(ny, nx)`` order.  Scalar numbers 
-        in ``cutout_size`` are assumed to be in units of pixels. `~astropy.units.Quantity` objects 
+        The size of the cutout array. If ``cutout_size`` is a scalar number or a scalar
+        `~astropy.units.Quantity`, then a square cutout of ``cutout_size`` will be created.
+        If ``cutout_size`` has two elements, they should be in ``(ny, nx)`` order.  Scalar numbers
+        in ``cutout_size`` are assumed to be in units of pixels. `~astropy.units.Quantity` objects
         must be in pixel or angular units.
 
     Returns
@@ -48,14 +47,14 @@ def parse_size_input(cutout_size):
         cutout_size = np.array(cutout_size)
 
     if len(cutout_size) > 2:
-        warnings.warn("Too many dimensions in cutout size, only the first two will be used.",
-                      InputWarning)
+        warnings.warn("Too many dimensions in cutout size, only the first two will be used.", InputWarning)
         cutout_size = cutout_size[:2]
 
     ny, nx = cutout_size
     if ny <= 0 or nx <= 0:
-        raise InvalidQueryError('Cutout size dimensions must be greater than zero. '
-                                f'Provided size: ({cutout_size[0]}, {cutout_size[1]})')
+        raise InvalidQueryError(
+            "Cutout size dimensions must be greater than zero. " f"Provided size: ({cutout_size[0]}, {cutout_size[1]})"
+        )
 
     return cutout_size
 
@@ -66,7 +65,7 @@ def get_cutout_limits(img_wcs, center_coord, cutout_size):
     which the cutout is being taken and returns the x and y pixel limits
     for the cutout.
 
-    Note: This function does no bounds checking, so the returned limits are not 
+    Note: This function does no bounds checking, so the returned limits are not
           guaranteed to overlap the original image.
 
     Parameters
@@ -83,7 +82,7 @@ def get_cutout_limits(img_wcs, center_coord, cutout_size):
     response : `numpy.array`
         The cutout pixel limits in an array of the form [[xmin,xmax],[ymin,ymax]]
     """
-        
+
     # Note: This is returning the center pixel in 1-up
     try:
         center_pixel = center_coord.to_pixel(img_wcs, 1)
@@ -93,18 +92,16 @@ def get_cutout_limits(img_wcs, center_coord, cutout_size):
     # For some reason you can sometimes get nans without a no convergance error
     if np.isnan(center_pixel).all():
         raise InvalidQueryError("Cutout location is not in image footprint!")
-    
+
     lims = np.zeros((2, 2), dtype=int)
 
     for axis, size in enumerate(cutout_size):
-        
         if not isinstance(size, u.Quantity):  # assume pixels
             dim = size / 2
         elif size.unit == u.pixel:  # also pixels
             dim = size.value / 2
-        elif size.unit.physical_type == 'angle':
-            pixel_scale = u.Quantity(wcs.utils.proj_plane_pixel_scales(img_wcs)[axis],
-                                     img_wcs.wcs.cunit[axis])
+        elif size.unit.physical_type == "angle":
+            pixel_scale = u.Quantity(wcs.utils.proj_plane_pixel_scales(img_wcs)[axis], img_wcs.wcs.cunit[axis])
             dim = (size / pixel_scale).decompose() / 2
 
         lims[axis, 0] = int(np.round(center_pixel[axis] - 1 - dim))
@@ -137,7 +134,7 @@ def get_cutout_wcs(img_wcs, cutout_lims):
     """
 
     # relax = True is important when the WCS has sip distortions, otherwise it has no effect
-    wcs_header = img_wcs.to_header(relax=True) 
+    wcs_header = img_wcs.to_header(relax=True)
 
     # Adjusting the CRPIX values
     wcs_header["CRPIX1"] -= cutout_lims[0, 0]
@@ -146,13 +143,13 @@ def get_cutout_wcs(img_wcs, cutout_lims):
     # Adding the physical wcs keywords
     wcs_header.set("WCSNAMEP", "PHYSICAL", "name of world coordinate system alternate P")
     wcs_header.set("WCSAXESP", 2, "number of WCS physical axes")
-    
+
     wcs_header.set("CTYPE1P", "RAWX", "physical WCS axis 1 type CCD col")
     wcs_header.set("CUNIT1P", "PIXEL", "physical WCS axis 1 unit")
     wcs_header.set("CRPIX1P", 1, "reference CCD column")
     wcs_header.set("CRVAL1P", cutout_lims[0, 0] + 1, "value at reference CCD column")
     wcs_header.set("CDELT1P", 1.0, "physical WCS axis 1 step")
-                
+
     wcs_header.set("CTYPE2P", "RAWY", "physical WCS axis 2 type CCD col")
     wcs_header.set("CUNIT2P", "PIXEL", "physical WCS axis 2 unit")
     wcs_header.set("CRPIX2P", 1, "reference CCD row")
@@ -168,9 +165,13 @@ def _build_astrocut_primaryhdu(**keywords):
     """
 
     primary_hdu = fits.PrimaryHDU()
-    primary_hdu.header.extend([("ORIGIN", 'STScI/MAST', "institution responsible for creating this file"),
-                               ("DATE", str(date.today()), "file creation date"),
-                               ('PROCVER', __version__, 'software version')])
+    primary_hdu.header.extend(
+        [
+            ("ORIGIN", "STScI/MAST", "institution responsible for creating this file"),
+            ("DATE", str(date.today()), "file creation date"),
+            ("PROCVER", __version__, "software version"),
+        ]
+    )
     for kwd in keywords:
         primary_hdu.header[kwd] = keywords[kwd]
 
@@ -198,12 +199,14 @@ def get_fits(cutout_hdus, center_coord=None, output_path=None):
 
     if isinstance(cutout_hdus, fits.hdu.image.ImageHDU):
         cutout_hdus = [cutout_hdus]
-    
+
     # Setting up the Primary HDU
     keywords = dict()
     if center_coord:
-        keywords = {"RA_OBJ": (center_coord.ra.deg, '[deg] right ascension'),
-                    "DEC_OBJ": (center_coord.dec.deg, '[deg] declination')}
+        keywords = {
+            "RA_OBJ": (center_coord.ra.deg, "[deg] right ascension"),
+            "DEC_OBJ": (center_coord.dec.deg, "[deg] declination"),
+        }
     primary_hdu = _build_astrocut_primaryhdu(**keywords)
 
     cutout_hdulist = fits.HDUList([primary_hdu] + cutout_hdus)
@@ -211,7 +214,7 @@ def get_fits(cutout_hdus, center_coord=None, output_path=None):
     if output_path:
         # Writing out the hdu often causes a warning as the ORIG_FLE card description is truncated
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore") 
+            warnings.simplefilter("ignore")
             cutout_hdulist.writeto(output_path, overwrite=True, checksum=True)
 
     return cutout_hdulist

--- a/astrocut/utils/wcs_fitting.py
+++ b/astrocut/utils/wcs_fitting.py
@@ -13,14 +13,12 @@
 #
 #################################################################################
 
-# flake8: noqa
-
 import copy
-import numpy as np
 
+import numpy as np
 from astropy import units as u
-from astropy.wcs.utils import celestial_frame_to_wcs
 from astropy.coordinates import Angle, SkyCoord, UnitSphericalRepresentation
+from astropy.wcs.utils import celestial_frame_to_wcs
 
 
 def offset_by(lon, lat, posang, distance):
@@ -73,7 +71,7 @@ def offset_by(lon, lat, posang, distance):
     small_sin_c = sin_c < 1e-12
     if small_sin_c.any():
         # For south pole (cos_c = -1), A = posang; for North pole, A=180 deg - posang
-        A_pole = (90*u.deg + cos_c*(90*u.deg-Angle(posang, u.radian))).to(u.rad)
+        A_pole = (90 * u.deg + cos_c * (90 * u.deg - Angle(posang, u.radian))).to(u.rad)
         if A.shape:
             # broadcast to ensure the shape is like that of A, which is also
             # affected by the (possible) shapes of lat, posang, and distance.
@@ -82,57 +80,56 @@ def offset_by(lon, lat, posang, distance):
         else:
             A = A_pole
 
-    outlon = (Angle(lon, u.radian) + A).wrap_at(360.0*u.deg).to(u.deg)
+    outlon = (Angle(lon, u.radian) + A).wrap_at(360.0 * u.deg).to(u.deg)
     outlat = Angle(np.arcsin(cos_b), u.radian).to(u.deg)
 
     return outlon, outlat
 
+
 def directional_offset_by(sky_coord, position_angle, separation):
-        """
-        Computes coordinates at the given offset from this coordinate.
+    """
+    Computes coordinates at the given offset from this coordinate.
 
-        Parameters
-        ----------
-        position_angle : `~astropy.coordinates.Angle`
-            position_angle of offset
-        separation : `~astropy.coordinates.Angle`
-            offset angular separation
+    Parameters
+    ----------
+    position_angle : `~astropy.coordinates.Angle`
+        position_angle of offset
+    separation : `~astropy.coordinates.Angle`
+        offset angular separation
 
-        Returns
-        -------
-        newpoints : `~astropy.coordinates.SkyCoord`
-            The coordinates for the location that corresponds to offsetting by
-            the given `position_angle` and `separation`.
+    Returns
+    -------
+    newpoints : `~astropy.coordinates.SkyCoord`
+        The coordinates for the location that corresponds to offsetting by
+        the given `position_angle` and `separation`.
 
-        Notes
-        -----
-        Returned SkyCoord frame retains only the frame attributes that are for
-        the resulting frame type.  (e.g. if the input frame is
-        `~astropy.coordinates.ICRS`, an ``equinox`` value will be retained, but
-        an ``obstime`` will not.)
+    Notes
+    -----
+    Returned SkyCoord frame retains only the frame attributes that are for
+    the resulting frame type.  (e.g. if the input frame is
+    `~astropy.coordinates.ICRS`, an ``equinox`` value will be retained, but
+    an ``obstime`` will not.)
 
-        For a more complete set of transform offsets, use `~astropy.wcs.WCS`.
-        `~astropy.coordinates.SkyCoord.skyoffset_frame()` can also be used to
-        create a spherical frame with (lat=0, lon=0) at a reference point,
-        approximating an xy cartesian system for small offsets. This method
-        is distinct in that it is accurate on the sphere.
+    For a more complete set of transform offsets, use `~astropy.wcs.WCS`.
+    `~astropy.coordinates.SkyCoord.skyoffset_frame()` can also be used to
+    create a spherical frame with (lat=0, lon=0) at a reference point,
+    approximating an xy cartesian system for small offsets. This method
+    is distinct in that it is accurate on the sphere.
 
-        See Also
-        --------
-        position_angle : inverse operation for the ``position_angle`` component
-        separation : inverse operation for the ``separation`` component
+    See Also
+    --------
+    position_angle : inverse operation for the ``position_angle`` component
+    separation : inverse operation for the ``separation`` component
 
-        """
+    """
 
-        slat = sky_coord.represent_as(UnitSphericalRepresentation).lat
-        slon = sky_coord.represent_as(UnitSphericalRepresentation).lon
+    slat = sky_coord.represent_as(UnitSphericalRepresentation).lat
+    slon = sky_coord.represent_as(UnitSphericalRepresentation).lon
 
-        newlon, newlat = offset_by(lon=slon, lat=slat,
-                                   posang=position_angle, distance=separation)
+    newlon, newlat = offset_by(lon=slon, lat=slat, posang=position_angle, distance=separation)
 
-        return SkyCoord(newlon, newlat, frame=sky_coord.frame)
+    return SkyCoord(newlon, newlat, frame=sky_coord.frame)
 
-    
 
 def _linear_wcs_fit(params, lon, lat, x, y, w_obj):  # pragma: no cover
     """
@@ -148,7 +145,7 @@ def _linear_wcs_fit(params, lon, lat, x, y, w_obj):  # pragma: no cover
         Pixel coordinates
     w_obj: `~astropy.wcs.WCS`
         WCS object
-        """
+    """
     cd = params[0:4]
     crpix = params[4:6]
 
@@ -156,16 +153,15 @@ def _linear_wcs_fit(params, lon, lat, x, y, w_obj):  # pragma: no cover
     w_obj.wcs.crpix = crpix
     lon2, lat2 = w_obj.wcs_pix2world(x, y, 0)
 
-    resids = np.concatenate((lon-lon2, lat-lat2))
+    resids = np.concatenate((lon - lon2, lat - lat2))
     resids[resids > 180] = 360 - resids[resids > 180]
-    resids[resids < -180] = 360	+ resids[resids < -180]
+    resids[resids < -180] = 360 + resids[resids < -180]
 
     return resids
 
 
 def _sip_fit(params, lon, lat, u, v, w_obj, order, coeff_names):  # pragma: no cover
-
-    """ Objective function for fitting SIP.
+    """Objective function for fitting SIP.
      Parameters
     -----------
     params : array
@@ -178,13 +174,13 @@ def _sip_fit(params, lon, lat, u, v, w_obj, order, coeff_names):  # pragma: no c
         WCS object
     """
 
-    from astropy.modeling.models import SIP, InverseSIP   # here to avoid circular import
+    from astropy.modeling.models import SIP  # here to avoid circular import
 
     # unpack params
     crpix = params[0:2]
     cdx = params[2:6].reshape((2, 2))
-    a_params = params[6:6+len(coeff_names)]
-    b_params = params[6+len(coeff_names):]
+    a_params = params[6 : 6 + len(coeff_names)]
+    b_params = params[6 + len(coeff_names) :]
 
     # assign to wcs, used for transfomations in this function
     w_obj.wcs.cd = cdx
@@ -192,20 +188,19 @@ def _sip_fit(params, lon, lat, u, v, w_obj, order, coeff_names):  # pragma: no c
 
     a_coeff, b_coeff = {}, {}
     for i in range(len(coeff_names)):
-        a_coeff['A_' + coeff_names[i]] = a_params[i]
-        b_coeff['B_' + coeff_names[i]] = b_params[i]
+        a_coeff["A_" + coeff_names[i]] = a_params[i]
+        b_coeff["B_" + coeff_names[i]] = b_params[i]
 
-    sip = SIP(crpix=crpix, a_order=order, b_order=order,
-              a_coeff=a_coeff, b_coeff=b_coeff)
+    sip = SIP(crpix=crpix, a_order=order, b_order=order, a_coeff=a_coeff, b_coeff=b_coeff)
     fuv, guv = sip(u, v)
 
-    xo, yo = np.dot(cdx, np.array([u+fuv-crpix[0], v+guv-crpix[1]]))
+    xo, yo = np.dot(cdx, np.array([u + fuv - crpix[0], v + guv - crpix[1]]))
 
     # use all pix2world in case `projection` contains distortion table
     x, y = w_obj.all_world2pix(lon, lat, 0)
-    x, y = np.dot(w_obj.wcs.cd, (x-w_obj.wcs.crpix[0], y-w_obj.wcs.crpix[1]))
+    x, y = np.dot(w_obj.wcs.cd, (x - w_obj.wcs.crpix[0], y - w_obj.wcs.crpix[1]))
 
-    resids = np.concatenate((x-xo, y-yo))
+    resids = np.concatenate((x - xo, y - yo))
     # to avoid bad restuls if near 360 -> 0 degree crossover
     resids[resids > 180] = 360 - resids[resids > 180]
     resids[resids < -180] = 360 + resids[resids < -180]
@@ -213,9 +208,7 @@ def _sip_fit(params, lon, lat, u, v, w_obj, order, coeff_names):  # pragma: no c
     return resids
 
 
-
-def fit_wcs_from_points(xy, world_coords, proj_point='center',
-                        projection='TAN', sip_degree=None):  # pragma: no cover
+def fit_wcs_from_points(xy, world_coords, proj_point="center", projection="TAN", sip_degree=None):  # pragma: no cover
     """
     Given two matching sets of coordinates on detector and sky,
     compute the WCS.
@@ -275,8 +268,8 @@ def fit_wcs_from_points(xy, world_coords, proj_point='center',
         The best-fit WCS to the points given.
     """
 
-    from astropy.coordinates import SkyCoord # here to avoid circular import
     import astropy.units as u
+    from astropy.coordinates import SkyCoord  # here to avoid circular import
     from astropy.wcs import Sip
     from scipy.optimize import least_squares
 
@@ -284,106 +277,138 @@ def fit_wcs_from_points(xy, world_coords, proj_point='center',
     try:
         lon, lat = world_coords.data.lon.deg, world_coords.data.lat.deg
     except AttributeError:
-        unit_sph =  world_coords.unit_spherical
+        unit_sph = world_coords.unit_spherical
         lon, lat = unit_sph.lon.deg, unit_sph.lat.deg
 
     # verify input
-    if (proj_point != 'center') and (type(proj_point) != type(world_coords)):
-        raise ValueError("proj_point must be set to 'center', or an" +
-                         "`~astropy.coordinates.SkyCoord` object with " +
-                         "a pair of points.")
-    if proj_point != 'center':
+    if (proj_point != "center") and (type(proj_point) is type(world_coords)):
+        raise ValueError(
+            "proj_point must be set to 'center', or an"
+            + "`~astropy.coordinates.SkyCoord` object with "
+            + "a pair of points."
+        )
+    if proj_point != "center":
         assert proj_point.size == 1
 
     proj_codes = [
-        'AZP', 'SZP', 'TAN', 'STG', 'SIN', 'ARC', 'ZEA', 'AIR', 'CYP',
-        'CEA', 'CAR', 'MER', 'SFL', 'PAR', 'MOL', 'AIT', 'COP', 'COE',
-        'COD', 'COO', 'BON', 'PCO', 'TSC', 'CSC', 'QSC', 'HPX', 'XPH'
+        "AZP",
+        "SZP",
+        "TAN",
+        "STG",
+        "SIN",
+        "ARC",
+        "ZEA",
+        "AIR",
+        "CYP",
+        "CEA",
+        "CAR",
+        "MER",
+        "SFL",
+        "PAR",
+        "MOL",
+        "AIT",
+        "COP",
+        "COE",
+        "COD",
+        "COO",
+        "BON",
+        "PCO",
+        "TSC",
+        "CSC",
+        "QSC",
+        "HPX",
+        "XPH",
     ]
-    if type(projection) == str:
+    if isinstance(projection, str):
         if projection not in proj_codes:
-            raise ValueError("Must specify valid projection code from list of "
-                             + "supported types: ", ', '.join(proj_codes))
+            raise ValueError(
+                "Must specify valid projection code from list of " + "supported types: ", ", ".join(proj_codes)
+            )
         # empty wcs to fill in with fit values
-        wcs = celestial_frame_to_wcs(frame=world_coords.frame,
-                                     projection=projection)
-    else: #if projection is not string, should be wcs object. use as template.
+        wcs = celestial_frame_to_wcs(frame=world_coords.frame, projection=projection)
+    else:  # if projection is not string, should be wcs object. use as template.
         wcs = copy.deepcopy(projection)
-        wcs.cdelt = (1., 1.) # make sure cdelt is 1
+        wcs.cdelt = (1.0, 1.0)  # make sure cdelt is 1
         wcs.sip = None
 
     # Change PC to CD, since cdelt will be set to 1
     if wcs.wcs.has_pc():
         wcs.wcs.cd = wcs.wcs.pc
-        wcs.wcs.__delattr__('pc')
+        wcs.wcs.__delattr__("pc")
 
-    if (type(sip_degree) != type(None)) and (type(sip_degree) != int):
+    if sip_degree is not None and not isinstance(sip_degree, int):
         raise ValueError("sip_degree must be None, or integer.")
 
     # set pixel_shape to span of input points
-    wcs.pixel_shape = (xp.max()+1-xp.min(), yp.max()+1-yp.min())
+    wcs.pixel_shape = (xp.max() + 1 - xp.min(), yp.max() + 1 - yp.min())
 
     # determine CRVAL from input
-    close = lambda l, p: p[np.argmin(np.abs(l))]
-    if str(proj_point) == 'center':  # use center of input points
-        sc1 = SkyCoord(lon.min()*u.deg, lat.max()*u.deg)
-        sc2 = SkyCoord(lon.max()*u.deg, lat.min()*u.deg)
+    def closest_point(points, offsets):
+        return points[np.argmin(np.abs(offsets))]
+
+    if str(proj_point) == "center":  # use center of input points
+        sc1 = SkyCoord(lon.min() * u.deg, lat.max() * u.deg)
+        sc2 = SkyCoord(lon.max() * u.deg, lat.min() * u.deg)
         pa = sc1.position_angle(sc2)
         sep = sc1.separation(sc2)
-        midpoint_sc = directional_offset_by(sc1, pa, sep/2)
-        wcs.wcs.crval = ((midpoint_sc.data.lon.deg, midpoint_sc.data.lat.deg))
-        wcs.wcs.crpix = ((xp.max()+xp.min())/2., (yp.max()+yp.min())/2.)
+        midpoint_sc = directional_offset_by(sc1, pa, sep / 2)
+        wcs.wcs.crval = (midpoint_sc.data.lon.deg, midpoint_sc.data.lat.deg)
+        wcs.wcs.crpix = ((xp.max() + xp.min()) / 2.0, (yp.max() + yp.min()) / 2.0)
     elif proj_point is not None:  # convert units, initial guess for crpix
         proj_point.transform_to(world_coords)
         wcs.wcs.crval = (proj_point.data.lon.deg, proj_point.data.lat.deg)
-        wcs.wcs.crpix = (close(lon-wcs.wcs.crval[0], xp),
-                         close(lon-wcs.wcs.crval[1], yp))
+        wcs.wcs.crpix = (closest_point(lon - wcs.wcs.crval[0], xp), closest_point(lon - wcs.wcs.crval[1], yp))
 
     # fit linear terms, assign to wcs
     # use (1, 0, 0, 1) as initial guess, in case input wcs was passed in
     # and cd terms are way off.
     p0 = np.concatenate([wcs.wcs.cd.flatten(), wcs.wcs.crpix.flatten()])
-    
-    xpmin, xpmax, ypmin, ypmax = xp.min(), xp.max(), yp.min(), yp.max()
-    if xpmin==xpmax: xpmin, xpmax = xpmin-0.5, xpmax+0.5
-    if ypmin==ypmax: ypmin, ypmax = ypmin-0.5, ypmax+0.5
 
-    fit = least_squares(_linear_wcs_fit, p0,
-                        args=(lon, lat, xp, yp, wcs),
-                        bounds=[[-np.inf,-np.inf,-np.inf,-np.inf, xpmin, ypmin],
-                                [ np.inf, np.inf, np.inf, np.inf, xpmax, ypmax]])
+    xpmin, xpmax, ypmin, ypmax = xp.min(), xp.max(), yp.min(), yp.max()
+    if xpmin == xpmax:
+        xpmin, xpmax = xpmin - 0.5, xpmax + 0.5
+    if ypmin == ypmax:
+        ypmin, ypmax = ypmin - 0.5, ypmax + 0.5
+
+    fit = least_squares(
+        _linear_wcs_fit,
+        p0,
+        args=(lon, lat, xp, yp, wcs),
+        bounds=[[-np.inf, -np.inf, -np.inf, -np.inf, xpmin, ypmin], [np.inf, np.inf, np.inf, np.inf, xpmax, ypmax]],
+    )
     wcs.wcs.crpix = np.array(fit.x[4:6])
     wcs.wcs.cd = np.array(fit.x[0:4].reshape((2, 2)))
 
     # fit SIP, if specified. Only fit forward coefficients
     if sip_degree:
         degree = sip_degree
-        if '-SIP' not in wcs.wcs.ctype[0]:
-            wcs.wcs.ctype = [x + '-SIP' for x in wcs.wcs.ctype]
+        if "-SIP" not in wcs.wcs.ctype[0]:
+            wcs.wcs.ctype = [x + "-SIP" for x in wcs.wcs.ctype]
 
-        coef_names = ['{0}_{1}'.format(i, j) for i in range(degree+1)
-                      for j in range(degree+1) if (i+j) < (degree+1) and
-                      (i+j) > 1]
-        p0 = np.concatenate((np.array(wcs.wcs.crpix), wcs.wcs.cd.flatten(),
-                             np.zeros(2*len(coef_names))))
+        coef_names = [
+            "{0}_{1}".format(i, j)
+            for i in range(degree + 1)
+            for j in range(degree + 1)
+            if (i + j) < (degree + 1) and (i + j) > 1
+        ]
+        p0 = np.concatenate((np.array(wcs.wcs.crpix), wcs.wcs.cd.flatten(), np.zeros(2 * len(coef_names))))
 
-        fit = least_squares(_sip_fit, p0,
-                            args=(lon, lat, xp, yp, wcs, degree, coef_names))
-        coef_fit = (list(fit.x[6:6+len(coef_names)]),
-                    list(fit.x[6+len(coef_names):]))
+        fit = least_squares(_sip_fit, p0, args=(lon, lat, xp, yp, wcs, degree, coef_names))
+        coef_fit = (list(fit.x[6 : 6 + len(coef_names)]), list(fit.x[6 + len(coef_names) :]))
 
         # put fit values in wcs
         wcs.wcs.cd = fit.x[2:6].reshape((2, 2))
         wcs.wcs.crpix = fit.x[0:2]
 
-        a_vals = np.zeros((degree+1, degree+1))
-        b_vals = np.zeros((degree+1, degree+1))
+        a_vals = np.zeros((degree + 1, degree + 1))
+        b_vals = np.zeros((degree + 1, degree + 1))
 
         for coef_name in coef_names:
             a_vals[int(coef_name[0])][int(coef_name[2])] = coef_fit[0].pop(0)
             b_vals[int(coef_name[0])][int(coef_name[2])] = coef_fit[1].pop(0)
 
-        wcs.sip = Sip(a_vals, b_vals, np.zeros((degree+1, degree+1)),
-                      np.zeros((degree+1, degree+1)), wcs.wcs.crpix)
+        wcs.sip = Sip(
+            a_vals, b_vals, np.zeros((degree + 1, degree + 1)), np.zeros((degree + 1, degree + 1)), wcs.wcs.crpix
+        )
 
     return wcs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,23 +33,24 @@ from importlib import import_module
 try:
     from sphinx_astropy.conf.v1 import *  # noqa
 except ImportError:
-    print('ERROR: the documentation requires the sphinx-astropy package to be installed')
+    print("ERROR: the documentation requires the sphinx-astropy package to be installed")
     sys.exit(1)
 
 # Get configuration information from setup.cfg
 from configparser import ConfigParser
+
 conf = ConfigParser()
 
-conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
-setup_cfg = dict(conf.items('metadata'))
+conf.read([os.path.join(os.path.dirname(__file__), "..", "setup.cfg")])
+setup_cfg = dict(conf.items("metadata"))
 
 # -- General configuration ----------------------------------------------------
 
 # By default, highlight as Python 3.
-highlight_language = 'python3'
+highlight_language = "python3"
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.2'
+# needs_sphinx = '1.2'
 
 # To perform a Sphinx version check that needs to be more specific than
 # major.minor, call `check_sphinx_version("x.y.z")` here.
@@ -66,20 +67,19 @@ rst_epilog += """
 # -- Project information ------------------------------------------------------
 
 # This does not *have* to match the package name, but typically does
-project = setup_cfg['name']
-author = setup_cfg['author']
-copyright = '{0}, {1}'.format(
-    datetime.datetime.now().year, setup_cfg['author'])
+project = setup_cfg["name"]
+author = setup_cfg["author"]
+copyright = "{0}, {1}".format(datetime.datetime.now().year, setup_cfg["author"])
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-import_module(setup_cfg['name'])
-package = sys.modules[setup_cfg['name']]
+import_module(setup_cfg["name"])
+package = sys.modules[setup_cfg["name"]]
 
 # The short X.Y version.
-version = package.__version__.split('-', 1)[0]
+version = package.__version__.split("-", 1)[0]
 # The full version, including alpha/beta/rc tags.
 release = package.__version__
 
@@ -96,7 +96,7 @@ release = package.__version__
 
 # Add any paths that contain custom themes here, relative to this directory.
 # To use a different custom theme, add the directory containing the theme.
-#html_theme_path = ["_themes",]
+# html_theme_path = ["_themes",]
 
 # Custome template path, adding custom css and home link
 templates_path = ["_templates"]
@@ -104,72 +104,71 @@ templates_path = ["_templates"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes. To override the custom theme, set this to the
 # name of a builtin theme or the name of a custom theme in html_theme_path.
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
+
 
 def setup_style(app):
     app.add_stylesheet("astrocut.css")
 
-master_doc='astrocut/contents'
-html_extra_path=['index.html']
+
+master_doc = "astrocut/contents"
+html_extra_path = ["index.html"]
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = { '**': ['globaltoc.html', 'localtoc.html', 'searchbox.html'] }
+html_sidebars = {"**": ["globaltoc.html", "localtoc.html", "searchbox.html"]}
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = '_static/AstroCut_thumb.png'
+html_logo = "_static/AstroCut_thumb.png"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = '_static/AstroCut_thumb.png'
+html_favicon = "_static/AstroCut_thumb.png"
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = ''
+# html_last_updated_fmt = ''
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = '{0} v{1}'.format(project, release)
+html_title = "{0} v{1}".format(project, release)
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = project + 'doc'
+htmlhelp_basename = project + "doc"
 
 # Static files to copy after template files
-html_static_path = ['_static']
-html_css_files = ['astrocut.css']
+html_static_path = ["_static"]
+html_css_files = ["astrocut.css"]
 
 
 # -- Options for LaTeX output -------------------------------------------------
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
-latex_documents = [('index', project + '.tex', project + u' Documentation',
-                    author, 'manual')]
+latex_documents = [("index", project + ".tex", project + " Documentation", author, "manual")]
 
 
 # -- Options for manual page output -------------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [('index', project.lower(), project + u' Documentation',
-              [author], 1)]
+man_pages = [("index", project.lower(), project + " Documentation", [author], 1)]
 
 
 # -- Options for the edit_on_github extension ---------------------------------
 
-if setup_cfg.get('edit_on_github').lower() == 'true':
+if setup_cfg.get("edit_on_github").lower() == "true":
+    extensions += ["sphinx_astropy.ext.edit_on_github"]
 
-    extensions += ['sphinx_astropy.ext.edit_on_github']
-
-    edit_on_github_project = setup_cfg['github_project']
+    edit_on_github_project = setup_cfg["github_project"]
     edit_on_github_branch = "main"
 
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"
 
 # -- Resolving issue number to links in changelog -----------------------------
-github_issues_url = 'https://github.com/{0}/issues/'.format(setup_cfg['github_project'])
+github_issues_url = "https://github.com/{0}/issues/".format(setup_cfg["github_project"])
 
 # -- Turn on nitpicky mode for sphinx (to warn about references not found) ----
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,10 @@ build-backend = 'setuptools.build_meta'
 line-length = 120
 
 [tool.ruff.lint]
-ignore = ["E303", "E266", "E226", "E203"]
+select = ["E", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+"docs/conf.py" = ["F403", "F405"]
+
+[tool.ruff.format]
+quote-style = "double"

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,12 +54,6 @@ doctest_plus = enabled
 text_file_format = rst
 addopts = --doctest-rst
 
-[flake8]
-exclude = extern,sphinx,*parsetab.py,astrocut
-
-[pycodestyle]
-exclude = extern,sphinx,*parsetab.py
-
 [coverage:run]
 omit =
     astrocut/_astropy_init*

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ import sys
 
 from setuptools import setup
 
-
 # First provide helpful messages if contributors try and run legacy commands
 # for tests or docs.
 
@@ -34,7 +33,7 @@ For more information, see:
   http://docs.astropy.org/en/latest/development/testguide.html#running-tests
 """
 
-if 'test' in sys.argv:
+if "test" in sys.argv:
     print(TEST_HELP)
     sys.exit(1)
 
@@ -59,7 +58,7 @@ For more information, see:
   http://docs.astropy.org/en/latest/install.html#builddocs
 """
 
-if 'build_docs' in sys.argv or 'build_sphinx' in sys.argv:
+if "build_docs" in sys.argv or "build_sphinx" in sys.argv:
     print(DOCS_HELP)
     sys.exit(1)
 
@@ -76,11 +75,14 @@ except Exception:
 
 current_path = os.path.abspath(os.path.dirname(__file__))
 
+
 def read_file(*parts):
-    with open(os.path.join(current_path, *parts), encoding='utf-8') as reader:
+    with open(os.path.join(current_path, *parts), encoding="utf-8") as reader:
         return reader.read()
 
-setup(use_scm_version={'write_to': os.path.join('astrocut', 'version.py'),
-                       'write_to_template': VERSION_TEMPLATE},
-     long_description=read_file('README.rst'),
-     long_description_content_type='text/x-rst')
+
+setup(
+    use_scm_version={"write_to": os.path.join("astrocut", "version.py"), "write_to_template": VERSION_TEMPLATE},
+    long_description=read_file("README.rst"),
+    long_description_content_type="text/x-rst",
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{38,39,310,311,312,313}-test{,-alldeps,-devdeps}{,-cov}
-    py{38,39,310,311,312,313}-test-numpy{120,123}
-    py{38,39,310,311,312,313}-test-astropy{52}
+    py{39,310,311,312,313,314}-test{,-alldeps,-devdeps}{,-cov}
+    py{39,310,311,312,313,314}-test-numpy{120,123}
+    py{39,310,311,312,313,314}-test-astropy{52}
     build_docs
     linkcheck
     codestyle
@@ -13,33 +13,19 @@ requires =
 isolated_build = true
 
 [testenv]
+description = run tests
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,TRAVIS
+passenv = HOME, WINDIR, LC_ALL, LC_CTYPE, CC, CI, TRAVIS
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree
 changedir = .tmp/{envname}
 
-# tox environments are constructed with so-called 'factors' (or terms)
-# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
-# will only take effect if that factor is included in the environment name. To
-# see a list of example environments that can be run, along with a description,
-# run:
-#
-#     tox -l -v
-#
-description =
-    run tests
-    alldeps: with all optional dependencies
-    devdeps: with the latest developer version of key dependencies
-    oldestdeps: with the oldest supported version of key dependencies
-    cov: and test coverage
-    astropy52: with astropy 5.2.*
-    numpy120: with numpy 1.20.*
-    numpy123: with numpy 1.23.*
-    numpy2: with numpy 2
-    astroquery04: with astroquery 0.4.*
+# The following indicates which extras_require from setup.cfg will be installed
+extras =
+    test
+    alldeps: docs
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -49,24 +35,17 @@ deps =
 
     astropy52: astropy==5.2.*
 
-    astroquery04: astroquery==0.4.*
-
     stdatamodels; python_version >= "3.11"
 
     devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
-    devdeps: git+https://github.com/astropy/astroquery.git
-
-# The following indicates which extras_require from setup.cfg will be installed
-extras =
-    test
-    alldeps: docs
 
 commands =
     pip freeze
-    !cov: pytest --pyargs astrocut {toxinidir}/docs {posargs}
-    cov: pytest --pyargs astrocut {toxinidir}/docs --cov astrocut --cov-config={toxinidir}/setup.cfg {posargs}
-    cov: coverage xml -o {toxinidir}/coverage.xml
+
+    cov: pytest --cov=astrocut --cov-config={toxinidir}/setup.cfg --cov-report=term-missing --cov-report=xml:{toxinidir}/coverage.xml {toxinidir}/astrocut {toxinidir}/docs {posargs}
+
+    !cov: pytest {toxinidir}/astrocut {toxinidir}/docs {posargs}
 
 [testenv:build_docs]
 changedir = docs
@@ -90,6 +69,7 @@ commands =
 [testenv:codestyle]
 skip_install = true
 changedir = .
-description = check code style, e.g. with flake8
-deps = flake8
-commands = flake8 astrocut --count --show-source --statistics --ignore=W291,W293,W391,E303,E266,E226,W504,E203 --max-line-length=120 --exclude=astrocut/conftest.py
+description = check code style, e.g. with ruff
+deps = ruff
+commands =
+    ruff check .

--- a/tox.ini
+++ b/tox.ini
@@ -73,3 +73,4 @@ description = check code style, e.g. with ruff
 deps = ruff
 commands =
     ruff check .
+    ruff format --check .

--- a/tox.ini
+++ b/tox.ini
@@ -43,9 +43,9 @@ deps =
 commands =
     pip freeze
 
-    cov: pytest --cov=astrocut --cov-config={toxinidir}/setup.cfg --cov-report=term-missing --cov-report=xml:{toxinidir}/coverage.xml {toxinidir}/astrocut {toxinidir}/docs {posargs}
+    cov: pytest --pyargs astrocut --cov=astrocut --cov-config={toxinidir}/setup.cfg --cov-report=term-missing --cov-report=xml:{toxinidir}/coverage.xml {toxinidir}/astrocut {toxinidir}/docs {posargs}
 
-    !cov: pytest {toxinidir}/astrocut {toxinidir}/docs {posargs}
+    !cov: pytest --pyargs astrocut {toxinidir}/astrocut {toxinidir}/docs {posargs}
 
 [testenv:build_docs]
 changedir = docs


### PR DESCRIPTION
Switching to use `ruff` in our codestyle checks. Also updating all the current files with ruff formatting.