### PR TITLE
Drop support for Python 3.9, some docs fixes

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -13,111 +13,162 @@ on:
 
 jobs:
   tests:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
         include:
-          - name: Python 3.9 with minimal dependencies
-            os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-test
-
-          - name: Python 3.9 with all optional dependencies
-            os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-test-alldeps
-            toxargs: -v --develop
-
-          - name: Python 3.10 with numpy 1.23 and full coverage
+          - name: PR Python 3.10 baseline
             os: ubuntu-latest
             python: "3.10"
-            toxenv: py310-test-alldeps-numpy123-cov
+            toxenv: py310-test
 
-          - name: Python 3.10 with all optional dependencies (MacOS X)
-            os: macos-latest
-            python: "3.10"
-            toxenv: py310-test-alldeps
-
-          - name: Python 3.10 with numpy 2
+          - name: PR Python 3.11 baseline
             os: ubuntu-latest
-            python: "3.10"
-            toxenv: py310-test-alldeps-numpy2
-
-          - name: Python 3.11 with minimal dependencies
-            os: ubuntu-latest
-            python: 3.11
+            python: "3.11"
             toxenv: py311-test
 
-          - name: Python 3.12 with minimal dependencies
+          - name: PR Python 3.12 baseline
             os: ubuntu-latest
-            python: 3.12
+            python: "3.12"
             toxenv: py312-test
 
-          - name: Python 3.13 with minimal dependencies
+          - name: PR Python 3.13 baseline
             os: ubuntu-latest
-            python: 3.13
+            python: "3.13"
             toxenv: py313-test
+
+          - name: PR Python 3.14 baseline
+            os: ubuntu-latest
+            python: "3.14"
+            toxenv: py314-test
+
+          - name: PR Python 3.14 on macOS
+            os: macos-latest
+            python: "3.14"
+            toxenv: py314-test
+
+          - name: PR Python 3.12 alldeps with coverage
+            os: ubuntu-latest
+            python: "3.12"
+            toxenv: py312-test-alldeps-cov
+
+          - name: PR code style checks
+            os: ubuntu-latest
+            python: "3.12"
+            toxenv: codestyle
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install language-pack-de and tzdata
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install language-pack-de tzdata
+
       - name: Install Python dependencies
         run: python -m pip install --upgrade tox
+
       - name: Run tests
-        run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+        run: tox -e ${{ matrix.toxenv }}
+
       - name: Upload coverage to codecov
         if: ${{ contains(matrix.toxenv,'-cov') }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  allowed_failures:
+  nightly_tests:
+    if: github.event_name == 'schedule'
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: Code style checks
+          - name: Nightly Python 3.10 baseline
             os: ubuntu-latest
-            python: 3.x
-            toxenv: codestyle
+            python: "3.10"
+            toxenv: py310-test
 
-          - name: (Allowed Failure) Python 3.12 with dev version of key dependencies
+          - name: Nightly Python 3.11 baseline
             os: ubuntu-latest
-            python: 3.12
-            toxenv: py312-test-devdeps
+            python: "3.11"
+            toxenv: py311-test
+
+          - name: Nightly Python 3.12 baseline
+            os: ubuntu-latest
+            python: "3.12"
+            toxenv: py312-test
+
+          - name: Nightly Python 3.13 baseline
+            os: ubuntu-latest
+            python: "3.13"
+            toxenv: py313-test
+
+          - name: Nightly Python 3.14 baseline
+            os: ubuntu-latest
+            python: "3.14"
+            toxenv: py314-test
+
+          - name: Nightly Python 3.14 dev dependencies
+            os: ubuntu-latest
+            python: "3.14"
+            toxenv: py314-test-devdeps
+
+          - name: Nightly Python 3.14 all dependencies
+            os: ubuntu-latest
+            python: "3.14"
+            toxenv: py314-test-alldeps
+
+          - name: Nightly docs linkcheck
+            os: ubuntu-latest
+            python: "3.12"
+            toxenv: linkcheck
+
+          - name: Nighly Python 3.10 numpy 1.23 pin
+            os: ubuntu-latest
+            python: "3.10"
+            toxenv: py310-test-numpy123
+
+          - name: Nightly Python 3.12 astropy 5.2 pin
+            os: ubuntu-latest
+            python: "3.12"
+            toxenv: py312-test-astropy52
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install language-pack-de and tzdata
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install language-pack-de tzdata
+
       - name: Install Python dependencies
-        run: python -m pip install --upgrade tox codecov
+        run: python -m pip install --upgrade tox
+
       - name: Run tests
-        run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+        run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   tests:
-    name: PR and Push Tests
+    name: PR Tests
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -13,8 +13,8 @@ on:
 
 jobs:
   tests:
+    name: PR and Push Tests
     if: github.event_name == 'pull_request' || github.event_name == 'push'
-    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -93,7 +93,7 @@ jobs:
 
   nightly_tests:
     if: github.event_name == 'schedule'
-    name: ${{ matrix.name }}
+    name: Nightly Tests
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Breaking Changes
 ^^^^^^^^^^^^^^^^
 
 - Removed support for Python 3.8. [#181]
+- Removed support for Python 3.9. [#185]
 - Remove the ``TicaCubeFactory`` class after deprecation in 1.1.0. [#182]
 - Remove the ``product`` parameter from the ``TessCubeCutout`` class, the ``TessFootprintCutout`` class, the ``cube_cut`` function,
   the ``CutoutFactory.cube_cut`` function, and the ``cube_cut_from_footprint`` function after deprecation in 1.1.0. [#182]

--- a/astrocut/__init__.py
+++ b/astrocut/__init__.py
@@ -18,7 +18,7 @@ This module initializes the astrocut package and performs essential setup tasks,
 """
 
 # Enforce Python version check during package import.
-__minimum_python_version__ = "3.9"  # minimum supported Python version
+__minimum_python_version__ = "3.10"  # minimum supported Python version
 if sys.version_info < tuple(map(int, __minimum_python_version__.split("."))):
     raise UnsupportedPythonError(f"astrocut does not support Python < {__minimum_python_version__}")
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,24 +1,25 @@
 {% extends "!layout.html" %}
 {% block sidebartitle %}
 
-<a href="../index.html">
-  <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}"/>
+{% if logo_url %}
+<a href="{{ pathto(master_doc) }}">
+  <img src="{{ logo_url }}" class="logo" alt="{{ _('Logo') }}">
 </a>
+{% endif %}
 
 {% if theme_display_version %}
-  {%- set nav_version = version %}
-  {% if READTHEDOCS and current_version %}
-    {%- set nav_version = current_version %}
-  {% endif %}
-  {% if nav_version %}
-    <div class="version">
-      {{ nav_version }}
-    </div>
-  {% endif %}
+{%- set nav_version = version %}
+{% if READTHEDOCS and current_version %}
+{%- set nav_version = current_version %}
+{% endif %}
+{% if nav_version %}
+<div class="version">
+  {{ nav_version }}
+</div>
+{% endif %}
 {% endif %}
 
 {% include "searchbox.html" %}
 
 {% endblock %}
 {% set css_files = css_files + [ "_static/astrocut.css" ] %}
-

--- a/docs/astrocut/file_formats.rst
+++ b/docs/astrocut/file_formats.rst
@@ -4,6 +4,8 @@
 Astrocut File Formats
 *********************
 
+.. _fits-cutout-files:
+
 FITS Cutout Files
 =================
 
@@ -38,6 +40,7 @@ updated to match the cutout image. Additionally the keyword ``ORIG_FLE`` has bee
 it contains the name of the file the cutout comes from.
 
 
+.. _asdf-cutout-files:
 
 ASDF Cutout Files
 ==================
@@ -129,6 +132,8 @@ data arrays from the original ASDF file, even when ``lite=False``. This is a key
 
     BinTableHDU (Extension 2, Python 3.11+ and stdatamodels>=4.1.0) - ASDF
     └── Data: <ASDF metadata tree (lite or full) embedded as binary table>
+
+.. _spectral-subsets:
 
 Spectral Subsets
 ^^^^^^^^^^^^^^^^
@@ -351,6 +356,7 @@ The output filename pattern for this grouping is: ``combined_spectral_subset[_li
 For ``group_by='combined'`` with ``lite=False``, top-level non-mission metadata from each input file is grouped into
 ``<key>_combined`` mappings keyed by input filename, while the merged subset ``history`` is stored under ``history``.
 
+.. _cube-files:
 
 Cube Files
 ==========
@@ -409,6 +415,8 @@ contains FFI filename for each row. Each column name keyword also has an entry i
 Image extension header, with the value being the keyword value from the FFI header.
 This last column allows the FFI Image extension headers to be recreated completely if desired.
 
+
+.. _target-pixel-files:
 
 Target Pixel Files
 ==================
@@ -517,6 +525,7 @@ Cosmic Ray Binary Table Extension
 
 This extension is not present in Astrocut TPFs, although it is a part of the Mission pipeline TPFs.
 
+.. _path-focused-target-pixel-files:
 
 Path Focused Target Pixel Files
 ===============================

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -29,7 +29,7 @@ FITS Cutouts
 
 The Flexible Image Transport System (FITS) is a standard format for astronomical data. Astrocut can generate cutouts from FITS files
 and return the results in memory or as a written file, depending on the user's preference. The cutout '~astropy.fits.io.HDUList' object 
-format is described in the `Astrocut File Fomats <file_formats.html#fits-cutout-files>`__ page.
+format is described in the :ref:`Astrocut File Formats <fits-cutout-files>` page.
 
 To make a cutout from a FITS file or files, use the `~astrocut.FITSCutout` class. 
 
@@ -96,7 +96,7 @@ ASDF Cutouts
 
 The Advanced Scientific Data Format (ASDF) is a flexible format for storing scientific data. Astrocut can generate cutouts from ASDF files
 and return the results in memory or as a written file, depending on the user's preference. The cutout ASDF file format is 
-described in the `Astrocut File Formats <file_formats.html#asdf-cutout-files>`__ page.
+described in the :ref:`Astrocut File Formats <asdf-cutout-files>` page.
 
 To make a cutout from an ASDF file or files, use the `~astrocut.ASDFCutout` class.
 
@@ -336,7 +336,7 @@ subsets in different ways. They accept the following parameters:
     to one unique ``(input_file, source_id)`` pair. Use `~astrocut.RomanSpectralSubset.get_source_file_keys` to retrieve the valid keys and
     their ``(input_file, source_id)`` mappings.
   - ``group_by='file'``: Groups all subsets from each input file together, resulting in one subset object per input file.
-  - ``group_by='combined'``: Combines all subsets from all input files into a single subset object.See the `Spectral Subset File Formats <file_formats.html#spectral-subsets>`__ for more details on the structure of subset objects.
+  - ``group_by='combined'``: Combines all subsets from all input files into a single subset object. See the :ref:`Spectral Subset File Formats <spectral-subsets>` for more details on the structure of subset objects.
 
 .. code-block:: python
 
@@ -455,7 +455,7 @@ all output.
 
 Note, you can only make cubes from a set of FFIs that were observed in the same sector, camera, and CCD.
 
-The output image cube file format is described in the `Astrocut File Formats <file_formats.html#cube-files>`__ page.
+The output image cube file format is described in the :ref:`Astrocut File Formats <cube-files>` page.
 
 .. code-block:: python
 
@@ -495,7 +495,7 @@ Making Cutout Target Pixel Files
 
 Astrocut can generate cutout target pixel files from TESS cubes using the `astrocut.TessCubeCutout` class and return the results
 in memory or as a file, depending on the user's preference. The cutout target pixel file format is described in the 
-`Astrocut File Formats <file_formats.html#target-pixel-files>`__ page.
+:ref:`Astrocut File Formats <target-pixel-files>` page.
 
 The `astrocut.TessCubeCutout` class takes the following parameters:
 
@@ -623,7 +623,7 @@ To restrict the cutouts to specific sectors, use the ``sequence`` parameter with
 If ``sequence`` is set to None, cutouts will be returned for all matching cube files.
 
 The resulting cutouts can be returned in memory or as a file, depending on the user's preference. The cutout target pixel file format is
-described in the `Astrocut File Formats <file_formats.html#target-pixel-files>`__ page.
+described in the :ref:`Astrocut File Formats <target-pixel-files>` page.
 
 .. code-block:: python
 
@@ -686,7 +686,7 @@ The `~astrocut.center_on_path` function allows the user to take one or more Astr
 TPF(s) and create a single cutout, centered on a moving target that crosses through
 the file(s). The user can optionally pass in a target object name and FFI WCS object.
 
-The output target pixel file format is described `here <file_formats.html#path-focused-target-pixel-files>`__.
+The output target pixel file format is described on the :ref:`Astrocut File Formats <path-focused-target-pixel-files>` page.
 
 This example starts with a path, and uses several `TESScut services <https://mast.stsci.edu/tesscut/docs/>`__
 to retrieve all of the inputs for the `~astrocut.center_on_path` function. We also use the helper function

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ github_project = spacetelescope/astrocut
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 setup_requires = setuptools_scm
 install_requires =
     asdf>=4.1.0 # for ASDF file format
@@ -37,10 +37,10 @@ test =
     pytest-astropy
     astroquery>=0.4.6
 docs =
-    sphinx != 4.1.0
-    docutils == 0.16
-    sphinx-astropy
-    sphinx_rtd_theme >= 0.5.2
+    sphinx>4.1.0
+    docutils>=0.16
+    sphinx-astropy>=1.11
+    sphinx_rtd_theme>=0.5.2
 all =
     stdatamodels>=4.1.0  # stdatamodels is optional; required for ASDF-in-FITS embedding (Python>=3.11)
 


### PR DESCRIPTION
Dropping support for Python 3.9, fixing up some docs that were failing the link check, and also fixing up some issues with the new version of `sphinx_astropy`. I also took this opportunity to organize our CI tests a bit more.