### PR TITLE
Accept multiple coordinates in ASDF Cutouts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Unreleased
 -----------
 
+- Extend the ASDF cutout workflow to accept multiple target coordinates and to expose downstream cutout products in
+  an ``astropy.table.Table`` object with columns for input file, coordinate, and cutout object. [#196]
+
+1.3.0 (2026-09-02)
+-------------------
+
 - Added ``fsspec_kwargs`` parameter to ``FITSCutout`` to pass through to ``s3fs`` for cloud-hosted files. [#177]
 - New ``RomanSpectralSubset`` class for creating spectral subsets from Roman Space Telescope ASDF data. [#179]
 - Added ``flip_orientation`` parameter to ``get_image_cutouts`` and ``write_as_img`` methods in ``FITSCutout`` and ``ASDFCutout``
@@ -19,8 +25,6 @@ Unreleased
   to opt into the pre-1.2.0 cutout/target pixel file filename format (``<ny>x<nx>`` size separator
   and 6-decimal RA/Dec precision) instead of the current format (``<ny>-x-<nx>`` size separator
   and 7-decimal RA/Dec precision). Default is False. [#194]
-- Extend the ASDF cutout workflow to accept multiple target coordinates and to expose downstream cutout products in
-  an ``astropy.table.Table`` object with columns for input file, coordinate, and cutout object. [#196]
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Unreleased
   and 6-decimal RA/Dec precision) instead of the current format (``<ny>-x-<nx>`` size separator
   and 7-decimal RA/Dec precision). Default is False. [#194]
 - Extend the ASDF cutout workflow to accept multiple target coordinates and to expose downstream cutout products in
-  an ``astropy.table.Table`` object. [#196]
+  an ``astropy.table.Table`` object with columns for input file, coordinate, and cutout object. [#196]
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Unreleased
   to opt into the pre-1.2.0 cutout/target pixel file filename format (``<ny>x<nx>`` size separator
   and 6-decimal RA/Dec precision) instead of the current format (``<ny>-x-<nx>`` size separator
   and 7-decimal RA/Dec precision). Default is False. [#194]
+- Extend the ASDF cutout workflow to accept multiple target coordinates and to expose downstream cutout products in
+  an ``astropy.table.Table`` object. [#196]
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -955,7 +955,7 @@ class ASDFCutout(ImageCutout):
             asdf_file = nullcontext(file)
 
         with asdf_file as file_handle:
-            with asdf.open(file_handle) as af:
+            with asdf.open(file_handle, memmap=True) as af:
                 # Load the data from the input file
                 tree = af.tree
                 mission_tree = tree[self._mission_kwd] if self._mission_kwd in tree else None

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -142,7 +142,8 @@ class ASDFCutout(ImageCutout):
     @property
     def asdf_cutouts(self) -> Table:
         """
-        Return the cutouts as a list of `asdf.AsdfFile` objects.
+        Return the cutouts as a `astropy.table.Table` with columns for input file, coordinate, and
+        the corresponding `asdf.AsdfFile` object.
         """
         if self._asdf_cutouts is not None:
             return self._asdf_cutouts
@@ -153,7 +154,8 @@ class ASDFCutout(ImageCutout):
     @property
     def fits_cutouts(self) -> Table:
         """
-        Return the cutouts as a list `astropy.io.fits.HDUList` objects.
+        Return the cutouts as a `astropy.table.Table` with columns for input file, coordinate, and
+        the corresponding `astropy.io.fits.HDUList` object.
         """
         if self._fits_cutouts is not None:
             return self._fits_cutouts
@@ -1043,6 +1045,7 @@ class ASDFCutout(ImageCutout):
                     # Make a per-coordinate copy because _get_cutout_data may modify the mission_tree
                     # in place if not in lite mode
                     coord_mission_tree = dict(new_mission_tree)
+                    coord_mission_tree["meta"] = dict(new_mission_tree["meta"])
 
                     try:
                         data_cutout = self._get_cutout_data(coord_mission_tree, wcs, pixel_coords)
@@ -1501,7 +1504,7 @@ def asdf_cut(
         )
 
 
-def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> Tuple[Tuple[int, int], WCS]:
+def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> Tuple[int, int]:
     """
     Get the closest pixel location on an input image for a given set of coordinates.
 
@@ -1517,7 +1520,7 @@ def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> Tuple[Tupl
     Returns
     -------
     pixel_coords : tuple
-        The (row, col) pixel coordinates of the input coordinates.
+        The (row, col) pixel coordinates of the input coordinates on the image.
     """
     # Map the coordinates to a pixel's location on the 2d image
     row, col = gwcsobj.invert(np.atleast_1d(ra), np.atleast_1d(dec), with_bounding_box=False)

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -1,11 +1,11 @@
 import sys
 import warnings
 from contextlib import nullcontext
-from copy import copy
+from copy import deepcopy
 from datetime import date
 from pathlib import Path
 from time import monotonic
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import asdf
 import gwcs
@@ -15,14 +15,16 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.modeling import models
 from astropy.nddata.utils import Cutout2D, NoOverlapError
+from astropy.table import Column, Table
 from astropy.units import Quantity
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.wcs import WCS
 from packaging.version import Version
+from PIL.Image import Image, Transpose, fromarray
 from s3path import S3Path
 
 from . import __version__, log
-from .exceptions import DataWarning, InvalidInputError, InvalidQueryError, ModuleWarning
+from .exceptions import DataWarning, InputWarning, InvalidInputError, InvalidQueryError, ModuleWarning
 from .image_cutout import ImageCutout
 
 
@@ -34,8 +36,8 @@ class ASDFCutout(ImageCutout):
     ----------
     input_files : list
         List of input image files.
-    coordinates : str | `~astropy.coordinates.SkyCoord`
-        Coordinates of the center of the cutout.
+    coordinates : str | `~astropy.coordinates.SkyCoord` | list
+        Coordinates of the center of the cutout. You can pass a single coordinate or a list of coordinates.
     cutout_size : int | array | list | tuple | `~astropy.units.Quantity`
         Size of the cutout array.
     fill_value : int | float
@@ -83,7 +85,7 @@ class ASDFCutout(ImageCutout):
     def __init__(
         self,
         input_files: List[Union[str, Path, S3Path]],
-        coordinates: Union[SkyCoord, str],
+        coordinates: Union[SkyCoord, str, List[Union[SkyCoord, str]]],
         cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
         fill_value: Union[int, float] = np.nan,
         key: Optional[str] = None,
@@ -92,7 +94,6 @@ class ASDFCutout(ImageCutout):
         lite: Optional[bool] = True,
         verbose: bool = False,
     ):
-        # Superclass constructor
         super().__init__(input_files, coordinates, cutout_size, fill_value, verbose=verbose)
 
         # Must be using Python 3.11 or higher to support stdatamodels and ASDF-in-FITS embedding
@@ -108,47 +109,13 @@ class ASDFCutout(ImageCutout):
         self.cutouts = []  # Public attribute to hold `Cutout2D` objects
         self._asdf_cutouts = None  # Store ASDF objects
         self._fits_cutouts = None  # Store FITS objects
-        self._sliced_gwcs_objects = []  # Store sliced GWCS objects for lite mode
-        self._asdf_trees = []  # Store ASDF trees for each cutout
+        self._asdf_trees = {}  # Store ASDF trees for each cutout
         self._lite = lite  # Flag for lite mode
         self._primary_header_template = None  # Optional template for primary header keywords
         self._fill_value_cache = {}  # Cache for converted fill values based on input data types
 
         # Make cutouts
         self.cutout()
-
-    def _check_asdf_in_fits_support(self):
-        if self._asdf_in_fits is not None:
-            return
-
-        # Try to import stdatamodels for ASDF-in-FITS embedding
-        if self._py311_or_higher:
-            try:
-                # Check version of stdatamodels
-                from stdatamodels import __version__ as stdata_version
-                from stdatamodels import asdf_in_fits
-
-                if Version(stdata_version) < Version("4.1.0"):
-                    warnings.warn(
-                        "The `stdatamodels` package is not available in the correct version (>=4.1.0); "
-                        "ASDF-in-FITS embedding will be skipped for these cutouts. Install the optional "
-                        'dependency with: pip install "astrocut[all]" or pip install stdatamodels>=4.1.0',
-                        ModuleWarning,
-                    )
-                else:
-                    self._asdf_in_fits = asdf_in_fits
-            except ImportError:
-                warnings.warn(
-                    "The `stdatamodels` package cannot be imported; ASDF-in-FITS embedding will be "
-                    "skipped for these cutouts. Install the optional dependency with: "
-                    'pip install "astrocut[all]" or pip install stdatamodels>=4.1.0',
-                    ModuleWarning,
-                )
-        else:
-            warnings.warn(
-                "ASDF-in-FITS embedding requires Python 3.11 or higher. Skipping embedding for these cutouts.",
-                ModuleWarning,
-            )
 
     @property
     def fits_cutouts(self) -> List[fits.HDUList]:
@@ -158,51 +125,9 @@ class ASDFCutout(ImageCutout):
         if self._fits_cutouts is not None:
             return self._fits_cutouts
 
-        fits_cutouts = []
-        today_str = str(date.today())
-        for i, (file, cutouts) in enumerate(self.cutouts_by_file.items()):
-            cutout = cutouts[0]
-            if self._lite:
-                tree = {
-                    # Tree should only include sliced WCS and original filename
-                    self._mission_kwd: {"meta": {"wcs": self._sliced_gwcs_objects[i], "orig_file": str(file)}}
-                }
-            else:
-                source_tree = self._asdf_trees[i]
-                # Build a metadata-only tree for FITS embedding without mutating cached ASDF trees.
-                tree = {self._mission_kwd: {"meta": source_tree[self._mission_kwd]["meta"]}}
+        self._fits_cutouts = self.get_fits_cutouts()
 
-            # Build the PrimaryHDU with keywords
-            if self._primary_header_template is None:
-                self._primary_header_template = fits.Header(
-                    [
-                        ("ORIGIN", "STScI/MAST"),
-                        ("PROCVER", __version__),
-                        ("RA_OBJ", self._coordinates.ra.deg),
-                        ("DEC_OBJ", self._coordinates.dec.deg),
-                    ]
-                )
-            primary_header = self._primary_header_template.copy()
-            primary_header["DATE"] = today_str  # Update date to current date for each file
-            primary_hdu = fits.PrimaryHDU(header=primary_header)
-
-            # Build ImageHDU with cutout data and WCS
-            image_hdu = fits.ImageHDU(data=cutout.data, header=cutout.wcs.to_header(relax=True))
-            image_hdu.header["ORIG_FLE"] = str(file)  # Add original file to header
-            image_hdu.header["EXTNAME"] = "CUTOUT"
-            hdul = fits.HDUList([primary_hdu, image_hdu])
-
-            # Check for ASDF-in-FITS embedding support and set flag
-            self._check_asdf_in_fits_support()
-
-            if self._asdf_in_fits is not None:
-                hdul_embed = self._asdf_in_fits.to_hdulist(tree, hdul)
-            else:
-                hdul_embed = hdul
-            fits_cutouts.append(hdul_embed)
-
-        self._fits_cutouts = fits_cutouts
-        return fits_cutouts
+        return self._fits_cutouts
 
     @property
     def asdf_cutouts(self) -> List[asdf.AsdfFile]:
@@ -212,24 +137,45 @@ class ASDFCutout(ImageCutout):
         if self._asdf_cutouts is not None:
             return self._asdf_cutouts
 
-        asdf_cutouts = []
-        for i, (file, cutouts) in enumerate(self.cutouts_by_file.items()):
-            cutout = cutouts[0]
-            if self._lite:
-                tree = {
-                    self._mission_kwd: {
-                        "meta": {"wcs": self._sliced_gwcs_objects[i], "orig_file": str(file)},
-                        "data": cutout.data,
-                    }
-                }
-            else:
-                tree = self._asdf_trees[i]
+        self._asdf_cutouts = self.get_asdf_cutouts()
 
-            # Create the AsdfFile object and add history to it
+        return self._asdf_cutouts
+
+    def get_asdf_cutouts(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> Dict[Tuple[str, str], asdf.AsdfFile]:
+        """
+        Get the cutouts as `asdf.AsdfFile` objects.
+
+        Parameters
+        ----------
+        input_files : list
+            Optional. List of input image files to include in the output. If not specified, all input files will be
+            included.
+        coordinates : list
+            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
+
+        Returns
+        -------
+        asdf_cutouts : astropy.table.Table
+            Table with columns for input file, coordinate, and the corresponding `asdf.AsdfFile` object representing
+            the cutout.
+        """
+        asdf_cutouts = []
+
+        file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
+        for file, coord in file_coord_pairs:
+            cutout = self.cutouts_by_file[file][coord]
+
+            tree = self._asdf_trees[file][coord]
+
             af = asdf.AsdfFile(tree)
+            ra, dec = coord.split()
             af.add_history_entry(
-                f"Cutout of size {cutout.shape} at sky coordinates "
-                f"({self._coordinates.ra.value}, {self._coordinates.dec.value})",
+                f"Cutout of size {cutout.shape} at sky coordinates ({ra}, {dec})",
                 software={
                     "name": "astrocut",
                     "author": "Space Telescope Science Institute",
@@ -237,10 +183,276 @@ class ASDFCutout(ImageCutout):
                     "homepage": "https://astrocut.readthedocs.io/en/latest/",
                 },
             )
-            asdf_cutouts.append(af)
+            asdf_cutouts.append({"file": file, "coord": coord, "cutout": af})
 
-        self._asdf_cutouts = asdf_cutouts
-        return asdf_cutouts
+        # Make an astropy table
+        cutout_table = Table(
+            rows=[(item["file"], item["coord"], item["cutout"]) for item in asdf_cutouts],
+            names=["file", "coordinate", "cutout"],
+        )
+        return cutout_table
+
+    def get_fits_cutouts(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> Dict[Tuple[str, str], fits.HDUList]:
+        """
+        Get the cutouts as `astropy.io.fits.HDUList` objects.
+
+        Parameters
+        ----------
+        input_files : list
+            Optional. List of input image files to include in the output. If not specified, all input files will be
+            included.
+        coordinates : list
+            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
+
+        Returns
+        -------
+        fits_cutouts : dict
+            Dictionary of `astropy.io.fits.HDUList` objects representing the cutouts,
+            keyed by a tuple of (input_file, coordinate)
+        """
+        file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
+        fits_cutouts = []
+        today_str = str(date.today())
+        for file, coord in file_coord_pairs:
+            cutout = self.cutouts_by_file[file][coord]
+
+            source_tree = self._asdf_trees[file][coord]
+            # Build a metadata-only tree for FITS embedding without mutating cached ASDF trees.
+            tree = {self._mission_kwd: {"meta": source_tree[self._mission_kwd]["meta"]}}
+
+            # Build the PrimaryHDU with keywords
+            ra, dec = coord.split()
+            if self._primary_header_template is None:
+                self._primary_header_template = fits.Header(
+                    [
+                        ("ORIGIN", "STScI/MAST"),
+                        ("PROCVER", __version__),
+                        ("RA_OBJ", ra),
+                        ("DEC_OBJ", dec),
+                    ]
+                )
+            primary_header = self._primary_header_template.copy()
+            primary_header["DATE"] = today_str
+            primary_hdu = fits.PrimaryHDU(header=primary_header)
+
+            image_hdu = fits.ImageHDU(data=cutout.data, header=cutout.wcs.to_header(relax=True))
+            image_hdu.header["ORIG_FLE"] = file
+            image_hdu.header["EXTNAME"] = "CUTOUT"
+            hdul = fits.HDUList([primary_hdu, image_hdu])
+
+            self._check_asdf_in_fits_support()
+            if self._asdf_in_fits is not None:
+                hdul_embed = self._asdf_in_fits.to_hdulist(tree, hdul)
+            else:
+                hdul_embed = hdul
+
+            fits_cutouts.append({"file": file, "coord": coord, "cutout": hdul_embed})
+
+        # Make an astropy table
+        cutout_table = Table()
+        cutout_table["file"] = [item["file"] for item in fits_cutouts]
+        cutout_table["coordinate"] = [item["coord"] for item in fits_cutouts]
+        cutout_table.add_column(Column(length=len(fits_cutouts), dtype=object, name="cutout"))
+        for i, item in enumerate(fits_cutouts):
+            cutout_table["cutout"][i] = item["cutout"]
+        return cutout_table
+        return cutout_table
+
+    def get_image_cutouts(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+        stretch: Optional[str] = "asinh",
+        minmax_percent: Optional[List[int]] = None,
+        minmax_value: Optional[List[int]] = None,
+        invert: Optional[bool] = False,
+        colorize: Optional[bool] = False,
+        flip_orientation: Optional[bool] = True,
+    ) -> List[Image]:
+        """
+        Get the cutouts as `~PIL.Image` objects given certain normalization parameters. This method also sets
+        the `image_cutouts` attribute.
+
+        Parameters
+        ----------
+        input_files : list
+            Optional. List of input image files to include in the output. If not specified, all input files will be
+            included.
+        coordinates : list
+            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
+        stretch : str
+            Optional, default 'asinh'. The stretch to apply to the image array.
+            Valid values are: asinh, sinh, sqrt, log, linear
+        minmax_percent : array
+            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric)
+            when scaling the image. The format is [lower percentile, upper percentile], where pixel
+            values below the lower percentile and above the upper percentile are clipped.
+            Only one of minmax_percent and minmax_value should be specified.
+        minmax_value : array
+            Optional. Interval based on user-specified pixel values when scaling the image.
+            The format is [min value, max value], where pixel values below the min value and above
+            the max value are clipped.
+            Only one of minmax_percent and minmax_value should be specified.
+        invert : bool
+            Optional, default False.  If True the image is inverted (light pixels become dark and vice versa).
+        colorize : bool
+            Optional, default False. If True, the first three cutouts will be combined into a single RGB image.
+        flip_orientation : bool
+            Optional, default True. If True, the cutout images are flipped vertically to match the orientation
+            of the input images.
+
+        Returns
+        -------
+        image_cutouts : list
+            If colorize is False, a dictionary of `~PIL.Image` objects representing the cutouts, keyed by a
+            tuple of (input_file, coordinate). If colorize is True, a dictionary of `~PIL.Image` objects
+            representing the color cutouts, keyed by the coordinate string.
+        """
+        # Validate the stretch parameter
+        valid_stretches = ["asinh", "sinh", "sqrt", "log", "linear"]
+        if not isinstance(stretch, str) or stretch.lower() not in valid_stretches:
+            raise InvalidInputError(f"Stretch {stretch} is not recognized. Valid options are {valid_stretches}.")
+        stretch = stretch.lower()
+
+        # Apply default scaling for image outputs
+        if (minmax_percent is None) and (minmax_value is None):
+            minmax_percent = [0.5, 99.5]
+
+        image_cutouts = []
+        if colorize:  # color cutouts
+            coordinates = self._coordinates if coordinates is None else coordinates
+            for coordinate in coordinates:
+                # Collect all the input files that have cutouts for this coordinate
+                file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinate)
+                coordinate = coordinate.to_string(precision=8)
+
+                coord_cutouts = []
+                coord_cutout_files = []
+                for file, coord in file_coord_pairs:
+                    coord_cutouts.append(self.cutouts_by_file[file][coord])
+                    coord_cutout_files.append(file)
+
+                    if len(coord_cutouts) > 3:
+                        warnings.warn(
+                            f"More than 3 cutouts found for coordinate {coord}. Only the first three will "
+                            "be used for the color cutout.",
+                            InputWarning,
+                        )
+                        coord_cutouts = coord_cutouts[:3]
+                        coord_cutout_files = coord_cutout_files[:3]
+                        break
+
+                if len(coord_cutouts) < 3:
+                    warnings.warn(
+                        f"Color cutouts require 3 input images (RGB) for coordinate {coordinate}. "
+                        "If you supplied 3 images one of the cutouts may have been empty.",
+                        InputWarning,
+                    )
+
+                img_arrs = []
+                for cutout in coord_cutouts:
+                    # Image output, applying the appropriate normalization parameters
+                    img_arrs.append(self.normalize_img(cutout.data, stretch, minmax_percent, minmax_value, invert))
+
+                # Combine the three cutouts into a single RGB image
+                color_img = fromarray(np.dstack([img_arrs[0], img_arrs[1], img_arrs[2]]).astype(np.uint8))
+                if flip_orientation:
+                    # Flip the image vertically to match the orientation of the input cutouts
+                    color_img = color_img.transpose(Transpose.FLIP_TOP_BOTTOM)
+                color_img.info.update(self._build_cutout_metadata(coord_cutout_files, coord_cutouts[0], coordinate))
+                image_cutouts.append({"file": ", ".join(coord_cutout_files), "coord": coord, "cutout": color_img})
+        else:  # one image per cutout
+            file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
+
+            for file, coord in file_coord_pairs:
+                cutout = self.cutouts_by_file[file][coord]
+                # Apply the appropriate normalization parameters
+                img_arr = self.normalize_img(cutout.data, stretch, minmax_percent, minmax_value, invert)
+                img = fromarray(img_arr)
+                # Flip the image vertically to match the orientation of the input cutouts
+                if flip_orientation:
+                    # Flip the image vertically to match the orientation of the input cutouts
+                    img = img.transpose(Transpose.FLIP_TOP_BOTTOM)
+                img.info.update(self._build_cutout_metadata([file], cutout, coord))
+
+                image_cutouts.append({"file": file, "coord": coord, "cutout": img})
+
+        cutout_table = Table()
+        cutout_table["file"] = [item["file"] for item in image_cutouts]
+        cutout_table["coordinate"] = [item["coord"] for item in image_cutouts]
+        cutout_table.add_column(Column(length=len(image_cutouts), dtype=object, name="cutout"))
+        for i, item in enumerate(image_cutouts):
+            cutout_table["cutout"][i] = item["cutout"]
+        return cutout_table
+
+    def get_file_coord_pairs(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> List[Tuple[str, str]]:
+        """
+        Get a list of tuples for each valid (input_file, coordinate) pair.
+
+        Parameters
+        ----------
+        input_files : list
+            Optional. List of input image files to include in the output. If not specified, all input files will be
+            included.
+        coordinates : list
+            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
+
+        Returns
+        -------
+        keys : list
+            List of tuples for each valid (input_file, coordinate) pair.
+        """
+        files_to_include, coords_to_include = self._resolve_selection(input_files, coordinates)
+
+        file_coord_pairs = []
+        for file in files_to_include:
+            for coord in coords_to_include:
+                if coord not in self.cutouts_by_file[file]:
+                    continue  # Skip coordinates that are not associated with this file
+                file_coord_pairs.append((file, coord))
+
+        return file_coord_pairs
+
+    def cutout(self) -> Union[str, List[str], List[fits.HDUList]]:
+        """
+        Generate cutouts from a list of input images.
+
+        Returns
+        -------
+        cutout_path : Path | list
+            Cutouts as memory objects or path(s) to the written cutout files.
+
+        Raises
+        ------
+        InvalidQueryError
+            If no cutouts contain data.
+        """
+        # Track start time
+        start_time = monotonic()
+
+        # Cutout each input file
+        for file in self._input_files:
+            self._cutout_file(file)
+
+        # If no cutouts contain data, raise exception
+        if not self.cutouts:
+            raise InvalidQueryError("Cutout contains no data! (Check image footprint.)")
+
+        # Log total time elapsed
+        log.debug("Total time: %.2f sec", monotonic() - start_time)
+
+        return self.cutouts
 
     def _get_cloud_file(self, input_file: Union[str, S3Path]):
         """
@@ -271,6 +483,36 @@ class ASDFCutout(ImageCutout):
                 fsspec_kwargs["token"] = self._token
 
         return fsspec.open(input_file, mode="rb", **fsspec_kwargs)
+
+    def _convert_gwcs_to_fits_wcs(self, gwcsobj: gwcs.wcs.WCS) -> WCS:
+        """
+        Convert a GWCS object to an approximated FITS WCS object.
+
+        Parameters
+        ----------
+        gwcsobj : gwcs.wcs.WCS
+            The GWCS object to convert.
+
+        Returns
+        -------
+        wcs_updated : `~astropy.wcs.WCS`
+            The approximated FITS WCS object.
+        """
+        # Convert the gwcs object to an astropy FITS WCS header
+        header = gwcsobj.to_fits_sip()
+
+        # Update WCS header with some keywords that it's missing.
+        # Otherwise, it won't work with astropy.wcs tools (TODO: Figure out why. What are these keywords for?)
+        for k in ["cpdis1", "cpdis2", "det2im1", "det2im2", "sip"]:
+            if k not in header:
+                header[k] = "na"
+
+        # New WCS object with updated header
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            wcs_updated = WCS(header)
+
+        return wcs_updated
 
     def _get_fill_value(self, dtype: np.dtype) -> Union[int, float]:
         """
@@ -441,7 +683,7 @@ class ASDFCutout(ImageCutout):
             The sliced GWCS object.
         """
         # Create copy of original gwcs object
-        tmp = copy(gwcs)
+        tmp = deepcopy(gwcs)
 
         # Get the cutout array bounds and create a new shift transform to the cutout
         # Add the new transform to the gwcs
@@ -467,7 +709,7 @@ class ASDFCutout(ImageCutout):
         file : str | Path | S3Path
             The input file to create a cutout from.
         """
-        input_file = file
+        input_file = str(file)
         cloud_file = None
         # If file comes from AWS cloud bucket, open it with fsspec and pass the file handle to ASDF.
         if (isinstance(file, str) and file.startswith("s3://")) or isinstance(file, S3Path):
@@ -507,72 +749,147 @@ class ASDFCutout(ImageCutout):
                         if value.shape[-2:] == data_shape[-2:]:
                             new_mission_tree[key] = value
 
-                # Get closest pixel coordinates and approximated WCS
-                pixel_coords, wcs = get_center_pixel(gwcs, self._coordinates.ra.value, self._coordinates.dec.value)
+                # For each requested coordinate, attempt to make a cutout if it overlaps
+                file_cutouts = {}  # dictionary to hold cutouts for this file, keyed by coordinate
+                wcs = self._convert_gwcs_to_fits_wcs(gwcs)
+                for coord in self._coordinates:
+                    pixel_coords = get_center_pixel(gwcs, coord.ra.value, coord.dec.value)
 
-                # Create the cutout
-                try:
-                    data_cutout = self._get_cutout_data(new_mission_tree, wcs, pixel_coords)
-                except NoOverlapError:
-                    warnings.warn(
-                        f"Cutout footprint does not overlap with data in {input_file}, skipping...", DataWarning
-                    )
-                    return
+                    if any(np.isnan(pixel_coords)):
+                        warnings.warn(
+                            f"Coordinate {coord} is outside the footprint of file {input_file}. "
+                            "Skipping this coordinate for this file.",
+                            DataWarning,
+                        )
+                        continue
 
-                # Check that there is data in the cutout image
-                data = data_cutout.data
-                if np.isnan(data).all() or not np.any(data):
-                    warnings.warn(f"Cutout of {input_file} contains no data, skipping...", DataWarning)
-                    return
+                    try:
+                        data_cutout = self._get_cutout_data(new_mission_tree, wcs, pixel_coords)
+                    except NoOverlapError:
+                        warnings.warn(
+                            f"Cutout of {input_file} at {coord} does not overlap the image. "
+                            "Skipping this coordinate for this file.",
+                            DataWarning,
+                        )
+                        # Skip coordinates that do not overlap this file
+                        continue
 
-                # Store the Cutout2D object
-                self.cutouts.append(data_cutout)
+                    data = data_cutout.data
+                    if np.isnan(data).all() or not np.any(data):
+                        # No useful data for this coordinate in this file
+                        warnings.warn(f"Cutout of {input_file} at {coord} contains no data, skipping...", DataWarning)
+                        continue
 
-                # Slice the GWCS to the cutout and store it for use in lite mode and in ASDF trees
-                sliced_gwcs = self._slice_gwcs(data_cutout, gwcs)
-                self._sliced_gwcs_objects.append(sliced_gwcs)
+                    # Store the Cutout2D object and associated metadata
+                    coord_key = coord.to_string(precision=8)
+                    self.cutouts.append(data_cutout)
+                    file_cutouts[coord_key] = data_cutout
+                    self.cutouts_by_file.setdefault(input_file, {})[coord_key] = data_cutout
 
-                if not self._lite:
-                    new_mission_tree["meta"]["wcs"] = sliced_gwcs
+                    sliced_gwcs = self._slice_gwcs(data_cutout, gwcs)
 
-                    # Store the original filename in the tree metadata for the ASDF cutout
-                    new_mission_tree["meta"]["orig_file"] = str(input_file)
-                    self._asdf_trees.append(new_tree)
+                    if self._lite:
+                        lite_tree = {
+                            self._mission_kwd: {
+                                "meta": {"wcs": sliced_gwcs, "orig_file": input_file},
+                                "data": data,
+                            }
+                        }
+                        self._asdf_trees.setdefault(input_file, {})[coord_key] = lite_tree
+                    else:
+                        new_mission_tree["meta"]["wcs"] = sliced_gwcs
+                        new_mission_tree["meta"]["orig_file"] = input_file
+                        self._asdf_trees.setdefault(input_file, {})[coord_key] = new_tree
 
-                # Store cutout with filename
-                self.cutouts_by_file[input_file] = [data_cutout]
-
-    def cutout(self) -> Union[str, List[str], List[fits.HDUList]]:
+    def _resolve_selection(
+        self,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> Tuple[List[Union[str, Path, S3Path]], List[SkyCoord]]:
         """
-        Generate cutouts from a list of input images.
+        Resolve the input files and coordinates to include in the cutout results.
+
+        Parameters
+        ----------
+        input_files : list, optional
+            List of input files to include. If None, all files in the cutout results are included.
+        coordinates : list, optional
+            List of coordinates to include. If None, all coordinates in the cutout results are included.
 
         Returns
         -------
-        cutout_path : Path | list
-            Cutouts as memory objects or path(s) to the written cutout files.
-
-        Raises
-        ------
-        InvalidQueryError
-            If no cutouts contain data.
+        files_to_include : list
+            List of input files to include in the cutout results.
+        coords_to_include : list
+            List of coordinates to include in the cutout results.
         """
-        # Track start time
-        start_time = monotonic()
+        # Determine which files to include
+        if input_files is None:
+            files_to_include = self.cutouts_by_file.keys()
+        else:
+            files_to_include = input_files if isinstance(input_files, (list, tuple)) else [input_files]
+            files_to_include = [str(file) for file in files_to_include]
 
-        # Cutout each input file
-        for file in self._input_files:
-            self._cutout_file(file)
+            for file in files_to_include:
+                if file not in self.cutouts_by_file:
+                    raise InvalidInputError(f"Input file {file} is not in the cutout results.")
 
-        # If no cutouts contain data, raise exception
-        if not self.cutouts:
-            raise InvalidQueryError("Cutout contains no data! (Check image footprint.)")
+        # Determine which coordinates to include
+        all_coords = set()
+        for file in files_to_include:
+            all_coords.update(self.cutouts_by_file[file].keys())
 
-        # Log total time elapsed
-        log.debug("Total time: %.2f sec", monotonic() - start_time)
+        if coordinates is None:
+            coords_to_include = all_coords
+        else:
+            coords_to_include = coordinates if isinstance(coordinates, (list, tuple)) else [coordinates]
+            coords_to_include = [
+                coord.to_string(precision=8) for coord in coords_to_include if isinstance(coord, SkyCoord)
+            ]
 
-        return self.cutouts
+            for coord in coords_to_include:
+                if coord not in all_coords:
+                    raise InvalidInputError(f"Input coordinate {coord} is not in the cutout results.")
 
-    def _make_cutout_filename(self, file: str, output_format: str) -> str:
+        return files_to_include, coords_to_include
+
+    def _check_asdf_in_fits_support(self):
+        """
+        Check if the `stdatamodels` package is available and meets the version requirement for ASDF-in-FITS embedding.
+        """
+        if self._asdf_in_fits is not None:
+            return
+
+        # Try to import stdatamodels for ASDF-in-FITS embedding
+        if self._py311_or_higher:
+            try:
+                # Check version of stdatamodels
+                from stdatamodels import __version__ as stdata_version
+                from stdatamodels import asdf_in_fits
+
+                if Version(stdata_version) < Version("4.1.0"):
+                    warnings.warn(
+                        "The `stdatamodels` package is not available in the correct version (>=4.1.0); "
+                        "ASDF-in-FITS embedding will be skipped for these cutouts. Install the optional "
+                        'dependency with: pip install "astrocut[all]" or pip install stdatamodels>=4.1.0',
+                        ModuleWarning,
+                    )
+                else:
+                    self._asdf_in_fits = asdf_in_fits
+            except ImportError:
+                warnings.warn(
+                    "The `stdatamodels` package cannot be imported; ASDF-in-FITS embedding will be "
+                    "skipped for these cutouts. Install the optional dependency with: "
+                    'pip install "astrocut[all]" or pip install stdatamodels>=4.1.0',
+                    ModuleWarning,
+                )
+        else:
+            warnings.warn(
+                "ASDF-in-FITS embedding requires Python 3.11 or higher. Skipping embedding for these cutouts.",
+                ModuleWarning,
+            )
+
+    def _make_cutout_filename(self, file: str, output_format: str, coord: str) -> str:
         """
         Generate a standardized filename for the cutout.
 
@@ -584,23 +901,33 @@ class ASDFCutout(ImageCutout):
             The input file name.
         output_format : str
             The output format to write the cutout to. Options are '.fits' and '.asdf'.
+        coord : str
+            The coordinate string associated with the cutout.
 
         Returns
         -------
         filename : str
             The generated filename for the cutout.
         """
+        ra, dec = coord.split()
+
         return "{}_{:.7f}_{:.7f}_{}-x-{}{}_astrocut{}".format(
             Path(file).stem,
-            self._coordinates.ra.value,
-            self._coordinates.dec.value,
+            float(ra),
+            float(dec),
             str(self._cutout_size[0]).replace(" ", ""),
             str(self._cutout_size[1]).replace(" ", ""),
             "_lite" if self._lite else "",
             output_format,
         )
 
-    def _write_as_format(self, output_format: str, output_dir: Union[str, Path] = ".") -> List[str]:
+    def _write_as_format(
+        self,
+        output_format: str,
+        output_dir: Union[str, Path] = ".",
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> List[str]:
         """
         Write the cutout to disk in the specified output format.
 
@@ -616,29 +943,52 @@ class ASDFCutout(ImageCutout):
         cutout_paths : list
             The path(s) to the cutout file(s) or the cutout memory objects.
         """
+        file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
+
+        if output_format == ".asdf":
+            if input_files is None and coordinates is None:
+                table = self.asdf_cutouts
+            else:
+                table = self.get_asdf_cutouts(input_files=input_files, coordinates=coordinates)
+        elif output_format == ".fits":
+            if input_files is None and coordinates is None:
+                table = self.fits_cutouts
+            else:
+                table = self.get_fits_cutouts(input_files=input_files, coordinates=coordinates)
+
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         cutout_paths = []  # List to store paths to cutout files
-        cutouts = self.fits_cutouts if output_format == ".fits" else self.asdf_cutouts
-        for file, cutout in zip(self.cutouts_by_file.keys(), cutouts):
-            # Determine the output path
-            filename = self._make_cutout_filename(file, output_format)
+
+        for pair in file_coord_pairs:
+            file, coord = pair
+            if coord not in self.cutouts_by_file[file]:
+                continue  # Skip coordinates that are not associated with this file
+
+            mask = (table["file"] == file) & (table["coordinate"] == coord)
+            cutout_obj = table["cutout"][mask][0]
+
+            filename = self._make_cutout_filename(file, output_format, coord=coord)
             cutout_path = Path(output_dir, filename)
 
-            # Write the cutout to disk or memory in the specified format
             if output_format == ".fits":
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
-                    cutout.writeto(cutout_path, overwrite=True, checksum=True)
-
+                    cutout_obj.writeto(cutout_path, overwrite=True, checksum=True)
             elif output_format == ".asdf":
-                cutout.write_to(cutout_path)
+                cutout_obj.write_to(cutout_path)
 
             cutout_paths.append(cutout_path.as_posix())
 
         log.debug("Cutout filepaths: %s", cutout_paths)
         return cutout_paths
 
-    def write_as_fits(self, output_dir: Union[str, Path] = ".") -> List[str]:
+    def write_as_fits(
+        self,
+        output_dir: Union[str, Path] = ".",
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> List[str]:
         """
         Write the cutouts to disk or memory in FITS format.
 
@@ -652,9 +1002,17 @@ class ASDFCutout(ImageCutout):
         list
             A list of paths to the cutout FITS files.
         """
-        return self._write_as_format(output_format=".fits", output_dir=output_dir)
+        return self._write_as_format(
+            output_format=".fits", output_dir=output_dir, input_files=input_files, coordinates=coordinates
+        )
 
-    def write_as_asdf(self, output_dir: Union[str, Path] = ".", validate_output: bool = True) -> List[str]:
+    def write_as_asdf(
+        self,
+        output_dir: Union[str, Path] = ".",
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> List[str]:
         """
         Write the cutouts to disk or memory in ASDF format.
 
@@ -672,7 +1030,133 @@ class ASDFCutout(ImageCutout):
         list
             A list of paths to the cutout ASDF files.
         """
-        return self._write_as_format(output_format=".asdf", output_dir=output_dir)
+        return self._write_as_format(
+            output_format=".asdf", output_dir=output_dir, input_files=input_files, coordinates=coordinates
+        )
+
+    def write_as_img(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+        stretch: Optional[str] = "asinh",
+        minmax_percent: Optional[List[int]] = None,
+        minmax_value: Optional[List[int]] = None,
+        invert: Optional[bool] = False,
+        colorize: Optional[bool] = False,
+        output_format: str = ".jpg",
+        output_dir: Union[str, Path] = ".",
+        cutout_prefix: str = "cutout",
+        flip_orientation: Optional[bool] = True,
+    ) -> Union[str, List[str]]:
+        """
+        Write the cutout to memory or to a file in an image format. If colorize is set, the first 3 cutouts
+        will be combined into a single RGB image. Otherwise, each cutout will be written to a separate file.
+
+        Parameters
+        ----------
+        input_files : list
+            Optional. List of input image files to include in the output. If not specified, all input files will be
+            included.
+        coordinates : list
+            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
+        stretch : str
+            Optional, default 'asinh'. The stretch to apply to the image array.
+            Valid values are: asinh, sinh, sqrt, log, linear
+        minmax_percent : array
+            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric)
+            when scaling the image. The format is [lower percentile, upper percentile], where pixel
+            values below the lower percentile and above the upper percentile are clipped.
+            Only one of minmax_percent and minmax_value shoul be specified.
+        minmax_value : array
+            Optional. Interval based on user-specified pixel values when scaling the image.
+            The format is [min value, max value], where pixel values below the min value and above
+            the max value are clipped.
+            Only one of minmax_percent and minmax_value should be specified.
+        invert : bool
+            Optional, default False.  If True the image is inverted (light pixels become dark and vice versa).
+        colorize : bool
+            Optional, default False. If True, the first three cutouts will be combined into a single RGB image.
+        flip_orientation : bool
+            Optional, default True. If True, the cutout images are flipped vertically to match the
+            orientation of the input images.
+        output_format : str
+            Optional, default '.jpg'. The output format for the cutout image(s).
+        output_dir : str | `~pathlib.Path`
+            Optional, default '.'. The directory to write the cutout image(s) to.
+        cutout_prefix : str
+            Optional, default 'cutout'. The prefix to add to the cutout image file name.
+
+        Returns
+        -------
+        cutout_path : List[Path]
+            Path(s) to the written cutout files.
+
+        Raises
+        ------
+        InvalidInputError
+            If less than three inputs were provided for a colorized cutout.
+        """
+        # Parse the output format
+        output_format = self._parse_output_format(output_format)
+
+        # Get the image cutouts with the given normalization parameters
+        image_cutouts = self.get_image_cutouts(
+            input_files=input_files,
+            coordinates=coordinates,
+            stretch=stretch,
+            minmax_percent=minmax_percent,
+            minmax_value=minmax_value,
+            invert=invert,
+            colorize=colorize,
+            flip_orientation=flip_orientation,
+        )
+
+        # Create the output directory if it does not exist
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+        cutout_paths = []  # List to store paths to cutout files
+
+        # Set up output files and write them
+        if colorize:  # Combine first three cutouts into a single RGB image
+            for _, coord, img in image_cutouts:
+                # Write the colorized cutout to disk
+                ra, dec = coord.split()
+                filename = "{}_{:.7f}_{:.7f}_{}-x-{}_astrocut{}".format(
+                    cutout_prefix,
+                    float(ra),
+                    float(dec),
+                    str(self._cutout_size[0]).replace(" ", ""),
+                    str(self._cutout_size[1]).replace(" ", ""),
+                    output_format,
+                )
+
+                # Attempt to write image to file
+                cutout_path = Path(output_dir, filename).as_posix()
+                success = self._save_img_to_file(img, cutout_path)
+                if success:
+                    cutout_paths.append(cutout_path)
+
+        else:  # Write each cutout to a separate image file
+            for file, coord, img in image_cutouts:
+                ra, dec = coord.split()
+                filename = "{}_{:.7f}_{:.7f}_{}-x-{}_astrocut{}".format(
+                    Path(file).stem,
+                    float(ra),
+                    float(dec),
+                    str(self._cutout_size[0]).replace(" ", ""),
+                    str(self._cutout_size[1]).replace(" ", ""),
+                    output_format,
+                )
+
+                # Attempt to write image to file
+                cutout_path = Path(output_dir, filename).as_posix()
+                success = self._save_img_to_file(img, cutout_path)
+                if success:
+                    cutout_paths.append(cutout_path)
+
+        log.debug("Cutout filepaths: {}".format(cutout_paths))
+        return cutout_paths
 
     def write_as_zip(
         self,
@@ -680,6 +1164,8 @@ class ASDFCutout(ImageCutout):
         filename: Union[str, Path, None] = None,
         *,
         output_format: str = ".asdf",
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
     ) -> str:
         """
         Package the ASDF or FITS cutouts into a zip archive without writing intermediates.
@@ -705,13 +1191,30 @@ class ASDFCutout(ImageCutout):
         if fmt not in (".asdf", ".fits"):
             raise InvalidInputError("File format must be either '.asdf' or '.fits'")
 
-        def build_entries():
-            use_fits = fmt == ".fits"
-            objs = self.fits_cutouts if use_fits else self.asdf_cutouts
+        file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
 
-            for i, file in enumerate(self.cutouts_by_file):
-                arcname = self._make_cutout_filename(file, fmt)
-                yield arcname, objs[i]
+        if output_format == ".asdf":
+            if input_files is None and coordinates is None:
+                table = self.asdf_cutouts
+            else:
+                table = self.get_asdf_cutouts(input_files=input_files, coordinates=coordinates)
+        elif output_format == ".fits":
+            if input_files is None and coordinates is None:
+                table = self.fits_cutouts
+            else:
+                table = self.get_fits_cutouts(input_files=input_files, coordinates=coordinates)
+
+        if filename is None:
+            filename = f"astrocut_{fmt[1:]}_cutouts.zip"
+
+        def build_entries():
+            for file, coord in file_coord_pairs:
+                if coord not in self.cutouts_by_file[file]:
+                    continue  # Skip coordinates that are not associated with this file
+
+                arcname = self._make_cutout_filename(file, fmt, coord=coord)
+                mask = (table["file"] == file) & (table["coordinate"] == coord)
+                yield arcname, table["cutout"][mask][0]
 
         return self._write_cutouts_to_zip(output_dir=output_dir, filename=filename, build_entries=build_entries)
 
@@ -736,27 +1239,13 @@ def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> Tuple[Tupl
     wcs_updated : `~astropy.wcs.WCS`
         The approximated FITS WCS object.
     """
-    # Convert the gwcs object to an astropy FITS WCS header
-    header = gwcsobj.to_fits_sip()
-
-    # Update WCS header with some keywords that it's missing.
-    # Otherwise, it won't work with astropy.wcs tools (TODO: Figure out why. What are these keywords for?)
-    for k in ["cpdis1", "cpdis2", "det2im1", "det2im2", "sip"]:
-        if k not in header:
-            header[k] = "na"
-
-    # New WCS object with updated header
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        wcs_updated = WCS(header)
-
     # Map the coordinates to a pixel's location on the 2d image
     row, col = gwcsobj.invert(np.atleast_1d(ra), np.atleast_1d(dec), with_bounding_box=False)
     row_pix = float(row.value[0]) if isinstance(row, Quantity) else float(row[0])
     col_pix = float(col.value[0]) if isinstance(col, Quantity) else float(col[0])
     pixel_coords = (row_pix, col_pix)
 
-    return pixel_coords, wcs_updated
+    return pixel_coords
 
 
 @deprecated_renamed_argument(

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from datetime import date
 from pathlib import Path
 from time import monotonic
-from typing import Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import asdf
 import gwcs
@@ -56,6 +56,9 @@ class ASDFCutout(ImageCutout):
         If False, cutouts will be made from all arrays in the input file (e.g., data, error,
         uncertainty, variance, etc.) where the last two dimensions match the shape of the science data array.
         It also preserves all of the metadata from the input file.
+    asdf_kwargs : dict, optional
+        Keyword arguments passed to `asdf.open` when reading input files. By default,
+        `memmap=True` is applied unless explicitly overridden.
     verbose : bool
         If True, log messages are printed to the console.
 
@@ -92,6 +95,7 @@ class ASDFCutout(ImageCutout):
         secret: Optional[str] = None,
         token: Optional[str] = None,
         lite: Optional[bool] = True,
+        asdf_kwargs: Optional[Dict[str, Any]] = None,
         verbose: bool = False,
     ):
         super().__init__(input_files, coordinates, cutout_size, fill_value, verbose=verbose)
@@ -112,6 +116,10 @@ class ASDFCutout(ImageCutout):
         self._fits_cutouts = None  # Store FITS objects
         self._asdf_trees = {}  # Store ASDF trees for each cutout
         self._lite = lite  # Flag for lite mode
+        if asdf_kwargs is not None and not isinstance(asdf_kwargs, dict):
+            raise InvalidInputError("asdf_kwargs must be a dictionary.")
+        self._asdf_open_kwargs = dict(asdf_kwargs or {})
+        self._asdf_open_kwargs.setdefault("memmap", True)
         self._primary_header_template = None  # Optional template for primary header keywords
         self._fill_value_cache = {}  # Cache for converted fill values based on input data types
         self._gwcs_to_fits_cache = {}  # Cache for converted GWCS to FITS WCS objects
@@ -176,11 +184,49 @@ class ASDFCutout(ImageCutout):
         cutouts : `astropy.table.Table`
             Table with columns for input file, coordinate, and the corresponding `astropy.nddata.Cutout2D` object.
         """
-        cutout_table = Table(
-            rows=list(self.iter_cutouts(input_files=input_files, coordinates=coordinates)),
+        if self._cutouts is not None:
+            # Filter existing cutouts by input_files and coordinates if provided
+            return self._return_filtered_table(self._cutouts, input_files=input_files, coordinates=coordinates)
+
+        return Table(
+            rows=self.iter_cutouts(input_files=input_files, coordinates=coordinates),
             names=["file", "coordinate", "cutout"],
         )
-        return cutout_table
+
+    def _return_filtered_table(
+        self,
+        table: Table,
+        input_files: Optional[List[Union[str, Path, S3Path]]],
+        coordinates: Optional[List[Union[SkyCoord, str]]],
+    ) -> Table:
+        """
+        Return a filtered version of the input table based on the specified input files and coordinates.
+
+        Parameters
+        ----------
+        table : `astropy.table.Table`
+            The input table to filter.
+        input_files : list, optional
+            List of input image files to include in the output. If not specified, all input files will be included.
+        coordinates : list, optional
+            List of coordinates to include in the output. If not specified, all coordinates will be included.
+
+        Returns
+        -------
+        filtered_table : `astropy.table.Table`
+            The filtered table containing only the specified input files and coordinates.
+        """
+        files_to_include, coords_to_include = self._resolve_selection(input_files, coordinates)
+        mask = np.ones(len(table), dtype=bool)
+
+        if input_files is not None:
+            mask &= np.isin(table["file"], files_to_include)
+
+        if coordinates is not None:
+            coord_keys = [coord.to_string(precision=8) for coord in table["coordinate"]]
+            mask &= np.isin(coord_keys, coords_to_include)
+
+        return table[mask]
 
     def iter_cutouts(
         self,
@@ -204,7 +250,7 @@ class ASDFCutout(ImageCutout):
         tuple
             Tuples of (input file, coordinate, `astropy.nddata.Cutout2D`).
         """
-        for file, coord in self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates):
+        for file, coord in self.iter_file_coord_pairs(input_files=input_files, coordinates=coordinates):
             yield file, SkyCoord(coord, unit="deg"), self.cutouts_by_file[file][coord]
 
     def get_asdf_cutouts(
@@ -231,11 +277,13 @@ class ASDFCutout(ImageCutout):
             Table with columns for input file, coordinate, and the corresponding `asdf.AsdfFile` object representing
             the cutout.
         """
-        asdf_cutout_table = Table(
-            rows=list(self.iter_asdf_cutouts(input_files=input_files, coordinates=coordinates)),
+        if self._asdf_cutouts is not None:
+            return self._return_filtered_table(self._asdf_cutouts, input_files=input_files, coordinates=coordinates)
+
+        return Table(
+            rows=self.iter_asdf_cutouts(input_files=input_files, coordinates=coordinates),
             names=["file", "coordinate", "cutout"],
         )
-        return asdf_cutout_table
 
     def iter_asdf_cutouts(
         self,
@@ -259,7 +307,7 @@ class ASDFCutout(ImageCutout):
         tuple
             Tuples of (input file, coordinate, `asdf.AsdfFile`).
         """
-        for file, coord in self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates):
+        for file, coord in self.iter_file_coord_pairs(input_files=input_files, coordinates=coordinates):
             cutout = self.cutouts_by_file[file][coord]
             tree = self._asdf_trees[file][coord]
 
@@ -300,14 +348,20 @@ class ASDFCutout(ImageCutout):
             Table with columns for input file, coordinate, and the corresponding `astropy.io.fits.HDUList` object
             representing the cutout.
         """
+        if self._fits_cutouts is not None:
+            return self._return_filtered_table(self._fits_cutouts, input_files=input_files, coordinates=coordinates)
+
         fits_cutouts = list(self.iter_fits_cutouts(input_files=input_files, coordinates=coordinates))
 
+        # Build a table with columns for file, coordinate, and cutout
+        # We construct this Table manually to avoid issues with heterogeneous data types in the cutout column
         fits_cutout_table = Table()
         fits_cutout_table["file"] = [item[0] for item in fits_cutouts]
         fits_cutout_table["coordinate"] = [item[1] for item in fits_cutouts]
         fits_cutout_table.add_column(Column(length=len(fits_cutouts), dtype=object, name="cutout"))
         for i, item in enumerate(fits_cutouts):
             fits_cutout_table["cutout"][i] = item[2]
+
         return fits_cutout_table
 
     def iter_fits_cutouts(
@@ -335,7 +389,7 @@ class ASDFCutout(ImageCutout):
         self._check_asdf_in_fits_support()
 
         today_str = str(date.today())
-        for file, coord in self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates):
+        for file, coord in self.iter_file_coord_pairs(input_files=input_files, coordinates=coordinates):
             cutout = self.cutouts_by_file[file][coord]
 
             source_tree = self._asdf_trees[file][coord]
@@ -534,7 +588,7 @@ class ASDFCutout(ImageCutout):
         """
         Yield selected ASDF cutouts as (file, coordinate, cutout).
         """
-        for file, coord in self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates):
+        for file, coord in self.iter_file_coord_pairs(input_files=input_files, coordinates=coordinates):
             yield file, SkyCoord(coord, unit="deg"), self.cutouts_by_file[file][coord]
 
     def _warn_too_many_color_cutouts(self, coord: SkyCoord):
@@ -558,14 +612,14 @@ class ASDFCutout(ImageCutout):
         )
         return False
 
-    def get_file_coord_pairs(
+    def iter_file_coord_pairs(
         self,
         *,
         input_files: Optional[List[Union[str, Path, S3Path]]] = None,
         coordinates: Optional[List[Union[SkyCoord, str]]] = None,
-    ) -> List[Tuple[str, str]]:
+    ) -> Iterator[Tuple[str, str]]:
         """
-        Get a list of tuples for each valid (input_file, coordinate) pair.
+        Yield tuples for each valid (input_file, coordinate) pair.
 
         Parameters
         ----------
@@ -577,19 +631,15 @@ class ASDFCutout(ImageCutout):
 
         Returns
         -------
-        keys : list
-            List of tuples for each valid (input_file, coordinate) pair.
+        iterator
+            Iterator of (input_file, coordinate) for valid pairs.
         """
         files_to_include, coords_to_include = self._resolve_selection(input_files, coordinates)
-
-        file_coord_pairs = []
         for file in files_to_include:
             for coord in coords_to_include:
                 if coord not in self.cutouts_by_file[file]:
                     continue  # Skip coordinates that are not associated with this file
-                file_coord_pairs.append((file, coord))
-
-        return file_coord_pairs
+                yield file, coord
 
     def _resolve_selection(
         self,
@@ -634,7 +684,7 @@ class ASDFCutout(ImageCutout):
         if coordinates is None:
             coords_to_include = all_coords
         else:
-            coords_to_include = coordinates if isinstance(coordinates, (list, tuple)) else [coordinates]
+            coords_to_include = self._normalize_coordinates_input(coordinates)
             for i, coord in enumerate(coords_to_include):
                 if isinstance(coord, SkyCoord):
                     coords_to_include[i] = coord.to_string(precision=8)
@@ -955,7 +1005,7 @@ class ASDFCutout(ImageCutout):
             asdf_file = nullcontext(file)
 
         with asdf_file as file_handle:
-            with asdf.open(file_handle, memmap=True) as af:
+            with asdf.open(file_handle, **self._asdf_open_kwargs) as af:
                 # Load the data from the input file
                 tree = af.tree
                 mission_tree = tree[self._mission_kwd] if self._mission_kwd in tree else None

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -20,7 +20,7 @@ from astropy.units import Quantity
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.wcs import WCS
 from packaging.version import Version
-from PIL.Image import Image, Transpose, fromarray
+from PIL.Image import Image
 from s3path import S3Path
 
 from . import __version__, log
@@ -172,39 +172,6 @@ class ASDFCutout(ImageCutout):
         )
         return asdf_cutout_table
 
-    def get_fits_cutouts(
-        self,
-        *,
-        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
-        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
-    ) -> Dict[Tuple[str, str], fits.HDUList]:
-        """
-        Get the cutouts as `astropy.io.fits.HDUList` objects.
-
-        Parameters
-        ----------
-        input_files : list
-            Optional. List of input image files to include in the output. If not specified, all input files will be
-            included.
-        coordinates : list
-            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
-
-        Returns
-        -------
-        fits_cutouts : Table
-            Table with columns for input file, coordinate, and the corresponding `astropy.io.fits.HDUList` object
-            representing the cutout.
-        """
-        fits_cutouts = list(self.iter_fits_cutouts(input_files=input_files, coordinates=coordinates))
-
-        fits_cutout_table = Table()
-        fits_cutout_table["file"] = [item[0] for item in fits_cutouts]
-        fits_cutout_table["coordinate"] = [item[1] for item in fits_cutouts]
-        fits_cutout_table.add_column(Column(length=len(fits_cutouts), dtype=object, name="cutout"))
-        for i, item in enumerate(fits_cutouts):
-            fits_cutout_table["cutout"][i] = item[2]
-        return fits_cutout_table
-
     def iter_asdf_cutouts(
         self,
         *,
@@ -243,6 +210,39 @@ class ASDFCutout(ImageCutout):
                 },
             )
             yield file, SkyCoord(coord, unit="deg"), af
+
+    def get_fits_cutouts(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> Dict[Tuple[str, str], fits.HDUList]:
+        """
+        Get the cutouts as `astropy.io.fits.HDUList` objects.
+
+        Parameters
+        ----------
+        input_files : list
+            Optional. List of input image files to include in the output. If not specified, all input files will be
+            included.
+        coordinates : list
+            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
+
+        Returns
+        -------
+        fits_cutouts : Table
+            Table with columns for input file, coordinate, and the corresponding `astropy.io.fits.HDUList` object
+            representing the cutout.
+        """
+        fits_cutouts = list(self.iter_fits_cutouts(input_files=input_files, coordinates=coordinates))
+
+        fits_cutout_table = Table()
+        fits_cutout_table["file"] = [item[0] for item in fits_cutouts]
+        fits_cutout_table["coordinate"] = [item[1] for item in fits_cutouts]
+        fits_cutout_table.add_column(Column(length=len(fits_cutouts), dtype=object, name="cutout"))
+        for i, item in enumerate(fits_cutouts):
+            fits_cutout_table["cutout"][i] = item[2]
+        return fits_cutout_table
 
     def iter_fits_cutouts(
         self,
@@ -300,6 +300,42 @@ class ASDFCutout(ImageCutout):
 
             yield file, SkyCoord(coord, unit="deg"), hdul
 
+    def _check_asdf_in_fits_support(self):
+        """
+        Check if the `stdatamodels` package is available and meets the version requirement for ASDF-in-FITS embedding.
+        """
+        if self._asdf_in_fits is not None:
+            return
+
+        # Try to import stdatamodels for ASDF-in-FITS embedding
+        if self._py311_or_higher:
+            try:
+                # Check version of stdatamodels
+                from stdatamodels import __version__ as stdata_version
+                from stdatamodels import asdf_in_fits
+
+                if Version(stdata_version) < Version("4.1.0"):
+                    warnings.warn(
+                        "The `stdatamodels` package is not available in the correct version (>=4.1.0); "
+                        "ASDF-in-FITS embedding will be skipped for these cutouts. Install the optional "
+                        'dependency with: pip install "astrocut[all]" or pip install stdatamodels>=4.1.0',
+                        ModuleWarning,
+                    )
+                else:
+                    self._asdf_in_fits = asdf_in_fits
+            except ImportError:
+                warnings.warn(
+                    "The `stdatamodels` package cannot be imported; ASDF-in-FITS embedding will be "
+                    "skipped for these cutouts. Install the optional dependency with: "
+                    'pip install "astrocut[all]" or pip install stdatamodels>=4.1.0',
+                    ModuleWarning,
+                )
+        else:
+            warnings.warn(
+                "ASDF-in-FITS embedding requires Python 3.11 or higher. Skipping embedding for these cutouts.",
+                ModuleWarning,
+            )
+
     def get_image_cutouts(
         self,
         *,
@@ -350,7 +386,7 @@ class ASDFCutout(ImageCutout):
             Table with columns for input file(s), coordinate, and the corresponding `~PIL.Image` object representing
             the image cutout.
         """
-        image_cutouts = list(
+        image_rows = list(
             self.iter_image_cutouts(
                 input_files=input_files,
                 coordinates=coordinates,
@@ -362,14 +398,7 @@ class ASDFCutout(ImageCutout):
                 flip_orientation=flip_orientation,
             )
         )
-
-        img_cutout_table = Table()
-        img_cutout_table["file"] = [item[0] for item in image_cutouts]
-        img_cutout_table["coordinate"] = [item[1] for item in image_cutouts]
-        img_cutout_table.add_column(Column(length=len(image_cutouts), dtype=object, name="cutout"))
-        for i, item in enumerate(image_cutouts):
-            img_cutout_table["cutout"][i] = item[2]
-        return img_cutout_table
+        return self._build_image_cutout_table(image_rows)
 
     def iter_image_cutouts(
         self,
@@ -419,77 +448,49 @@ class ASDFCutout(ImageCutout):
         tuple
             Tuples of (input file(s), coordinate, `~PIL.Image`).
         """
-        # Validate the stretch parameter
-        valid_stretches = ["asinh", "sinh", "sqrt", "log", "linear"]
-        if not isinstance(stretch, str) or stretch.lower() not in valid_stretches:
-            raise InvalidInputError(f"Stretch {stretch} is not recognized. Valid options are {valid_stretches}.")
-        stretch = stretch.lower()
+        yield from self._iter_image_cutout_rows(
+            input_files=input_files,
+            coordinates=coordinates,
+            stretch=stretch,
+            minmax_percent=minmax_percent,
+            minmax_value=minmax_value,
+            invert=invert,
+            colorize=colorize,
+            flip_orientation=flip_orientation,
+        )
 
-        # Apply default scaling for image outputs
-        if (minmax_percent is None) and (minmax_value is None):
-            minmax_percent = [0.5, 99.5]
+    def _iter_selected_cutouts(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> Iterator[Tuple[str, SkyCoord, Cutout2D]]:
+        """
+        Yield selected ASDF cutouts as (file, coordinate, cutout).
+        """
+        for file, coord in self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates):
+            yield file, SkyCoord(coord, unit="deg"), self.cutouts_by_file[file][coord]
 
-        if colorize:  # color cutouts
-            if coordinates is None:
-                coordinates_to_include = self._coordinates
-            elif isinstance(coordinates, (list, tuple)):
-                coordinates_to_include = coordinates
-            else:
-                coordinates_to_include = [coordinates]
+    def _warn_too_many_color_cutouts(self, coord: SkyCoord):
+        """
+        ASDF-specific warning when more than three cutouts exist for one coordinate.
+        """
+        warnings.warn(
+            f"More than 3 cutouts found for coordinate {coord.to_string(precision=8)}. "
+            "Only the first three will be used for the color cutout.",
+            InputWarning,
+        )
 
-            for coordinate in coordinates_to_include:
-                file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinate)
-
-                coord_cutouts = []
-                coord_cutout_files = []
-                for file, coord in file_coord_pairs:
-                    coord_cutouts.append(self.cutouts_by_file[file][coord])
-                    coord_cutout_files.append(file)
-
-                    if len(coord_cutouts) > 3:
-                        warnings.warn(
-                            f"More than 3 cutouts found for coordinate {coord}. Only the first three will "
-                            "be used for the color cutout.",
-                            InputWarning,
-                        )
-                        coord_cutouts = coord_cutouts[:3]
-                        coord_cutout_files = coord_cutout_files[:3]
-                        break
-
-                if len(coord_cutouts) < 3:
-                    warnings.warn(
-                        f"Color cutouts require 3 input images (RGB) for coordinate {coordinate}. "
-                        "If you supplied 3 images one of the cutouts may have been empty.",
-                        InputWarning,
-                    )
-                    continue
-
-                img_arrs = []
-                for cutout in coord_cutouts:
-                    # Image output, applying the appropriate normalization parameters
-                    img_arrs.append(self.normalize_img(cutout.data, stretch, minmax_percent, minmax_value, invert))
-
-                # Combine the three cutouts into a single RGB image
-                color_img = fromarray(np.dstack([img_arrs[0], img_arrs[1], img_arrs[2]]).astype(np.uint8))
-                if flip_orientation:
-                    # Flip the image vertically to match the orientation of the input cutouts
-                    color_img = color_img.transpose(Transpose.FLIP_TOP_BOTTOM)
-                color_img.info.update(self._build_cutout_metadata(coord_cutout_files, coord_cutouts[0], coordinate))
-                yield ", ".join(coord_cutout_files), SkyCoord(coordinate, unit="deg"), color_img
-        else:  # one image per cutout
-            file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
-
-            for file, coord in file_coord_pairs:
-                cutout = self.cutouts_by_file[file][coord]
-                # Apply the appropriate normalization parameters
-                img_arr = self.normalize_img(cutout.data, stretch, minmax_percent, minmax_value, invert)
-                img = fromarray(img_arr)
-                # Flip the image vertically to match the orientation of the input cutouts
-                if flip_orientation:
-                    # Flip the image vertically to match the orientation of the input cutouts
-                    img = img.transpose(Transpose.FLIP_TOP_BOTTOM)
-                img.info.update(self._build_cutout_metadata([file], cutout, coord))
-                yield file, SkyCoord(coord, unit="deg"), img
+    def _handle_insufficient_color_cutouts(self, coord: SkyCoord) -> bool:
+        """
+        ASDF-specific policy for insufficient RGB inputs: warn and skip this coordinate.
+        """
+        warnings.warn(
+            f"Color cutouts require 3 input images (RGB) for coordinate {coord}. "
+            "If you supplied 3 images one of the cutouts may have been empty.",
+            InputWarning,
+        )
+        return False
 
     def get_file_coord_pairs(
         self,
@@ -523,6 +524,67 @@ class ASDFCutout(ImageCutout):
                 file_coord_pairs.append((file, coord))
 
         return file_coord_pairs
+
+    def _resolve_selection(
+        self,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> Tuple[List[Union[str, Path, S3Path]], List[SkyCoord]]:
+        """
+        Resolve the input files and coordinates to include in the cutout results.
+
+        Parameters
+        ----------
+        input_files : list, optional
+            List of input files to include. If None, all files in the cutout results are included.
+        coordinates : list, optional
+            List of coordinates to include. If None, all coordinates in the cutout results are included.
+
+        Returns
+        -------
+        files_to_include : list
+            List of input files to include in the cutout results.
+        coords_to_include : list
+            List of string coordinates to include in the cutout results.
+        """
+        # Determine which files to include
+        if input_files is None:
+            files_to_include = list(self.cutouts_by_file.keys())
+        else:
+            files_to_include = input_files if isinstance(input_files, (list, tuple)) else [input_files]
+            files_to_include = [str(file) for file in files_to_include]
+
+            for file in files_to_include:
+                if file not in self.cutouts_by_file:
+                    raise InvalidInputError(f"Input file {file} is not in the cutout results.")
+
+        # Determine which coordinates to include
+        all_coords = []
+        for file in files_to_include:
+            all_coords.extend(self.cutouts_by_file[file].keys())
+        # Remove duplicates while preserving order
+        all_coords = list(dict.fromkeys(all_coords))
+
+        if coordinates is None:
+            coords_to_include = all_coords
+        else:
+            coords_to_include = coordinates if isinstance(coordinates, (list, tuple)) else [coordinates]
+            for i, coord in enumerate(coords_to_include):
+                if isinstance(coord, SkyCoord):
+                    coords_to_include[i] = coord.to_string(precision=8)
+                elif isinstance(coord, str):
+                    try:
+                        coords_to_include[i] = SkyCoord(coord, unit="deg").to_string(precision=8)
+                    except Exception as e:
+                        raise InvalidInputError(f"Invalid coordinate string: {coord}. Error: {e}")
+                else:
+                    raise InvalidInputError(f"Coordinate {coord} is not a valid SkyCoord or string.")
+
+            for coord in coords_to_include:
+                if coord not in all_coords:
+                    raise InvalidInputError(f"Input coordinate {coord} is not in the cutout results.")
+
+        return files_to_include, coords_to_include
 
     def cutout(self) -> Union[str, List[str], List[fits.HDUList]]:
         """
@@ -911,103 +973,6 @@ class ASDFCutout(ImageCutout):
                         coord_mission_tree["meta"]["coordinate"] = coord_key
                         self._asdf_trees.setdefault(input_file, {})[coord_key] = {self._mission_kwd: coord_mission_tree}
 
-    def _resolve_selection(
-        self,
-        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
-        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
-    ) -> Tuple[List[Union[str, Path, S3Path]], List[SkyCoord]]:
-        """
-        Resolve the input files and coordinates to include in the cutout results.
-
-        Parameters
-        ----------
-        input_files : list, optional
-            List of input files to include. If None, all files in the cutout results are included.
-        coordinates : list, optional
-            List of coordinates to include. If None, all coordinates in the cutout results are included.
-
-        Returns
-        -------
-        files_to_include : list
-            List of input files to include in the cutout results.
-        coords_to_include : list
-            List of string coordinates to include in the cutout results.
-        """
-        # Determine which files to include
-        if input_files is None:
-            files_to_include = list(self.cutouts_by_file.keys())
-        else:
-            files_to_include = input_files if isinstance(input_files, (list, tuple)) else [input_files]
-            files_to_include = [str(file) for file in files_to_include]
-
-            for file in files_to_include:
-                if file not in self.cutouts_by_file:
-                    raise InvalidInputError(f"Input file {file} is not in the cutout results.")
-
-        # Determine which coordinates to include
-        all_coords = []
-        for file in files_to_include:
-            all_coords.extend(self.cutouts_by_file[file].keys())
-        # Remove duplicates while preserving order
-        all_coords = list(dict.fromkeys(all_coords))
-
-        if coordinates is None:
-            coords_to_include = all_coords
-        else:
-            coords_to_include = coordinates if isinstance(coordinates, (list, tuple)) else [coordinates]
-            for i, coord in enumerate(coords_to_include):
-                if isinstance(coord, SkyCoord):
-                    coords_to_include[i] = coord.to_string(precision=8)
-                elif isinstance(coord, str):
-                    try:
-                        coords_to_include[i] = SkyCoord(coord).to_string(precision=8)
-                    except Exception as e:
-                        raise InvalidInputError(f"Invalid coordinate string: {coord}. Error: {e}")
-                else:
-                    raise InvalidInputError(f"Coordinate {coord} is not a valid SkyCoord or string.")
-
-            for coord in coords_to_include:
-                if coord not in all_coords:
-                    raise InvalidInputError(f"Input coordinate {coord} is not in the cutout results.")
-
-        return files_to_include, coords_to_include
-
-    def _check_asdf_in_fits_support(self):
-        """
-        Check if the `stdatamodels` package is available and meets the version requirement for ASDF-in-FITS embedding.
-        """
-        if self._asdf_in_fits is not None:
-            return
-
-        # Try to import stdatamodels for ASDF-in-FITS embedding
-        if self._py311_or_higher:
-            try:
-                # Check version of stdatamodels
-                from stdatamodels import __version__ as stdata_version
-                from stdatamodels import asdf_in_fits
-
-                if Version(stdata_version) < Version("4.1.0"):
-                    warnings.warn(
-                        "The `stdatamodels` package is not available in the correct version (>=4.1.0); "
-                        "ASDF-in-FITS embedding will be skipped for these cutouts. Install the optional "
-                        'dependency with: pip install "astrocut[all]" or pip install stdatamodels>=4.1.0',
-                        ModuleWarning,
-                    )
-                else:
-                    self._asdf_in_fits = asdf_in_fits
-            except ImportError:
-                warnings.warn(
-                    "The `stdatamodels` package cannot be imported; ASDF-in-FITS embedding will be "
-                    "skipped for these cutouts. Install the optional dependency with: "
-                    'pip install "astrocut[all]" or pip install stdatamodels>=4.1.0',
-                    ModuleWarning,
-                )
-        else:
-            warnings.warn(
-                "ASDF-in-FITS embedding requires Python 3.11 or higher. Skipping embedding for these cutouts.",
-                ModuleWarning,
-            )
-
     def _make_cutout_filename(self, file: str, output_format: str, coord: str) -> str:
         """
         Generate a standardized filename for the cutout.
@@ -1039,57 +1004,6 @@ class ASDFCutout(ImageCutout):
             "_lite" if self._lite else "",
             output_format,
         )
-
-    def _write_as_format(
-        self,
-        output_format: str,
-        output_dir: Union[str, Path] = ".",
-        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
-        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
-    ) -> List[str]:
-        """
-        Write the cutout to disk in the specified output format.
-
-        Parameters
-        ----------
-        output_format : str
-            The output format to write the cutout to. Options are '.fits' and '.asdf'.
-        output_dir : str | Path
-            The output directory to write the cutouts to
-
-        Returns
-        -------
-        cutout_paths : list
-            The path(s) to the cutout file(s) or the cutout memory objects.
-        """
-        if output_format == ".asdf":
-            iterator = self.iter_asdf_cutouts(input_files=input_files, coordinates=coordinates)
-        elif output_format == ".fits":
-            iterator = self.iter_fits_cutouts(input_files=input_files, coordinates=coordinates)
-        else:
-            raise InvalidInputError(
-                f'Output format {output_format} is not recognized. Valid options are ".asdf" and ".fits".'
-            )
-
-        Path(output_dir).mkdir(parents=True, exist_ok=True)
-        cutout_paths = []  # List to store paths to cutout files
-
-        for file, coord_obj, cutout_obj in iterator:
-            coord = coord_obj.to_string(precision=8)
-            filename = self._make_cutout_filename(file, output_format, coord=coord)
-            cutout_path = Path(output_dir, filename)
-
-            if output_format == ".fits":
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore")
-                    cutout_obj.writeto(cutout_path, overwrite=True, checksum=True)
-            elif output_format == ".asdf":
-                cutout_obj.write_to(cutout_path)
-
-            cutout_paths.append(cutout_path.as_posix())
-
-        log.debug("Cutout filepaths: %s", cutout_paths)
-        return cutout_paths
 
     def write_as_fits(
         self,
@@ -1142,6 +1056,57 @@ class ASDFCutout(ImageCutout):
         return self._write_as_format(
             output_format=".asdf", output_dir=output_dir, input_files=input_files, coordinates=coordinates
         )
+
+    def _write_as_format(
+        self,
+        output_format: str,
+        output_dir: Union[str, Path] = ".",
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> List[str]:
+        """
+        Write the cutout to disk in the specified output format.
+
+        Parameters
+        ----------
+        output_format : str
+            The output format to write the cutout to. Options are '.fits' and '.asdf'.
+        output_dir : str | Path
+            The output directory to write the cutouts to
+
+        Returns
+        -------
+        cutout_paths : list
+            The path(s) to the cutout file(s) or the cutout memory objects.
+        """
+        if output_format == ".asdf":
+            iterator = self.iter_asdf_cutouts(input_files=input_files, coordinates=coordinates)
+        elif output_format == ".fits":
+            iterator = self.iter_fits_cutouts(input_files=input_files, coordinates=coordinates)
+        else:
+            raise InvalidInputError(
+                f'Output format {output_format} is not recognized. Valid options are ".asdf" and ".fits".'
+            )
+
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        cutout_paths = []  # List to store paths to cutout files
+
+        for file, coord_obj, cutout_obj in iterator:
+            coord = coord_obj.to_string(precision=8)
+            filename = self._make_cutout_filename(file, output_format, coord=coord)
+            cutout_path = Path(output_dir, filename)
+
+            if output_format == ".fits":
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    cutout_obj.writeto(cutout_path, overwrite=True, checksum=True)
+            elif output_format == ".asdf":
+                cutout_obj.write_to(cutout_path)
+
+            cutout_paths.append(cutout_path.as_posix())
+
+        log.debug("Cutout filepaths: %s", cutout_paths)
+        return cutout_paths
 
     def write_as_img(
         self,
@@ -1318,33 +1283,6 @@ class ASDFCutout(ImageCutout):
         return self._write_cutouts_to_zip(output_dir=output_dir, filename=filename, build_entries=build_entries)
 
 
-def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> Tuple[Tuple[int, int], WCS]:
-    """
-    Get the closest pixel location on an input image for a given set of coordinates.
-
-    Parameters
-    ----------
-    gwcsobj : gwcs.wcs.WCS
-        The GWCS object.
-    ra : float
-        The right ascension of the input coordinates.
-    dec : float
-        The declination of the input coordinates.
-
-    Returns
-    -------
-    pixel_coords : tuple
-        The (row, col) pixel coordinates of the input coordinates.
-    """
-    # Map the coordinates to a pixel's location on the 2d image
-    row, col = gwcsobj.invert(np.atleast_1d(ra), np.atleast_1d(dec), with_bounding_box=False)
-    row_pix = float(row.value[0]) if isinstance(row, Quantity) else float(row[0])
-    col_pix = float(col.value[0]) if isinstance(col, Quantity) else float(col[0])
-    pixel_coords = (row_pix, col_pix)
-
-    return pixel_coords
-
-
 @deprecated_renamed_argument(
     "output_file",
     None,
@@ -1452,3 +1390,30 @@ def asdf_cut(
         raise InvalidInputError(
             f'Output format {output_format} is not recognized. Valid options are ".asdf" and ".fits".'
         )
+
+
+def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> Tuple[Tuple[int, int], WCS]:
+    """
+    Get the closest pixel location on an input image for a given set of coordinates.
+
+    Parameters
+    ----------
+    gwcsobj : gwcs.wcs.WCS
+        The GWCS object.
+    ra : float
+        The right ascension of the input coordinates.
+    dec : float
+        The declination of the input coordinates.
+
+    Returns
+    -------
+    pixel_coords : tuple
+        The (row, col) pixel coordinates of the input coordinates.
+    """
+    # Map the coordinates to a pixel's location on the 2d image
+    row, col = gwcsobj.invert(np.atleast_1d(ra), np.atleast_1d(dec), with_bounding_box=False)
+    row_pix = float(row.value[0]) if isinstance(row, Quantity) else float(row[0])
+    col_pix = float(col.value[0]) if isinstance(col, Quantity) else float(col[0])
+    pixel_coords = (row_pix, col_pix)
+
+    return pixel_coords

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -15,7 +15,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.modeling import models
 from astropy.nddata.utils import Cutout2D, NoOverlapError
-from astropy.table import Column, Table
+from astropy.table import Table
 from astropy.units import Quantity
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.wcs import WCS
@@ -188,9 +188,8 @@ class ASDFCutout(ImageCutout):
             # Filter existing cutouts by input_files and coordinates if provided
             return self._return_filtered_table(self._cutouts, input_files=input_files, coordinates=coordinates)
 
-        return Table(
-            rows=self.iter_cutouts(input_files=input_files, coordinates=coordinates),
-            names=["file", "coordinate", "cutout"],
+        return self._build_cutout_table(
+            self.iter_cutouts(input_files=input_files, coordinates=coordinates),
         )
 
     def _return_filtered_table(
@@ -280,9 +279,8 @@ class ASDFCutout(ImageCutout):
         if self._asdf_cutouts is not None:
             return self._return_filtered_table(self._asdf_cutouts, input_files=input_files, coordinates=coordinates)
 
-        return Table(
-            rows=self.iter_asdf_cutouts(input_files=input_files, coordinates=coordinates),
-            names=["file", "coordinate", "cutout"],
+        return self._build_cutout_table(
+            self.iter_asdf_cutouts(input_files=input_files, coordinates=coordinates),
         )
 
     def iter_asdf_cutouts(
@@ -307,12 +305,15 @@ class ASDFCutout(ImageCutout):
         tuple
             Tuples of (input file, coordinate, `asdf.AsdfFile`).
         """
-        for file, coord in self.iter_file_coord_pairs(input_files=input_files, coordinates=coordinates):
-            cutout = self.cutouts_by_file[file][coord]
-            tree = self._asdf_trees[file][coord]
+        for row in self._return_filtered_table(self.cutouts, input_files=input_files, coordinates=coordinates):
+            file = row["file"]
+            coord_obj = row["coordinate"]
+            cutout = row["cutout"]
+            coord_key = coord_obj.to_string(precision=8)
+            tree = self._asdf_trees[file][coord_key]
 
             af = asdf.AsdfFile(tree)
-            ra, dec = coord.split()
+            ra, dec = coord_key.split()
             af.add_history_entry(
                 f"Cutout of size {cutout.shape} at sky coordinates ({ra}, {dec})",
                 software={
@@ -322,7 +323,7 @@ class ASDFCutout(ImageCutout):
                     "homepage": "https://astrocut.readthedocs.io/en/latest/",
                 },
             )
-            yield file, SkyCoord(coord, unit="deg"), af
+            yield file, coord_obj, af
 
     def get_fits_cutouts(
         self,
@@ -351,18 +352,10 @@ class ASDFCutout(ImageCutout):
         if self._fits_cutouts is not None:
             return self._return_filtered_table(self._fits_cutouts, input_files=input_files, coordinates=coordinates)
 
-        fits_cutouts = list(self.iter_fits_cutouts(input_files=input_files, coordinates=coordinates))
-
-        # Build a table with columns for file, coordinate, and cutout
-        # We construct this Table manually to avoid issues with heterogeneous data types in the cutout column
-        fits_cutout_table = Table()
-        fits_cutout_table["file"] = [item[0] for item in fits_cutouts]
-        fits_cutout_table["coordinate"] = [item[1] for item in fits_cutouts]
-        fits_cutout_table.add_column(Column(length=len(fits_cutouts), dtype=object, name="cutout"))
-        for i, item in enumerate(fits_cutouts):
-            fits_cutout_table["cutout"][i] = item[2]
-
-        return fits_cutout_table
+        return self._build_cutout_table(
+            self.iter_fits_cutouts(input_files=input_files, coordinates=coordinates),
+            object_cutout=True,
+        )
 
     def iter_fits_cutouts(
         self,
@@ -389,14 +382,17 @@ class ASDFCutout(ImageCutout):
         self._check_asdf_in_fits_support()
 
         today_str = str(date.today())
-        for file, coord in self.iter_file_coord_pairs(input_files=input_files, coordinates=coordinates):
-            cutout = self.cutouts_by_file[file][coord]
+        for row in self._return_filtered_table(self.cutouts, input_files=input_files, coordinates=coordinates):
+            file = row["file"]
+            coord_obj = row["coordinate"]
+            cutout = row["cutout"]
+            coord_key = coord_obj.to_string(precision=8)
 
-            source_tree = self._asdf_trees[file][coord]
+            source_tree = self._asdf_trees[file][coord_key]
             # Build a metadata-only tree for FITS embedding without mutating cached ASDF trees.
             tree = {self._mission_kwd: {"meta": source_tree[self._mission_kwd]["meta"]}}
 
-            ra, dec = coord.split()
+            ra, dec = coord_key.split()
             if self._primary_header_template is None:
                 self._primary_header_template = fits.Header(
                     [
@@ -418,7 +414,7 @@ class ASDFCutout(ImageCutout):
             if self._asdf_in_fits is not None:
                 hdul = self._asdf_in_fits.to_hdulist(tree, hdul)
 
-            yield file, SkyCoord(coord, unit="deg"), hdul
+            yield file, coord_obj, hdul
 
     def _check_asdf_in_fits_support(self):
         """
@@ -506,19 +502,17 @@ class ASDFCutout(ImageCutout):
             Table with columns for input file(s), coordinate, and the corresponding `~PIL.Image` object representing
             the image cutout.
         """
-        image_rows = list(
-            self.iter_image_cutouts(
-                input_files=input_files,
-                coordinates=coordinates,
-                stretch=stretch,
-                minmax_percent=minmax_percent,
-                minmax_value=minmax_value,
-                invert=invert,
-                colorize=colorize,
-                flip_orientation=flip_orientation,
-            )
+        image_iter = self.iter_image_cutouts(
+            input_files=input_files,
+            coordinates=coordinates,
+            stretch=stretch,
+            minmax_percent=minmax_percent,
+            minmax_value=minmax_value,
+            invert=invert,
+            colorize=colorize,
+            flip_orientation=flip_orientation,
         )
-        return self._build_image_cutout_table(image_rows)
+        return self._build_cutout_table(image_iter, object_cutout=True)
 
     def iter_image_cutouts(
         self,

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from datetime import date
 from pathlib import Path
 from time import monotonic
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 import asdf
 import gwcs
@@ -106,28 +106,18 @@ class ASDFCutout(ImageCutout):
         self._token = token
         self._mission_kwd = "roman"
 
-        self.cutouts = []  # Public attribute to hold `Cutout2D` objects
+        # Store cutouts as a table
+        self.cutouts = Table(names=["file", "coordinate", "cutout"], dtype=["str", "object", "object"])
         self._asdf_cutouts = None  # Store ASDF objects
         self._fits_cutouts = None  # Store FITS objects
         self._asdf_trees = {}  # Store ASDF trees for each cutout
         self._lite = lite  # Flag for lite mode
         self._primary_header_template = None  # Optional template for primary header keywords
         self._fill_value_cache = {}  # Cache for converted fill values based on input data types
+        self._gwcs_to_fits_cache = {}  # Cache for converted GWCS to FITS WCS objects
 
         # Make cutouts
         self.cutout()
-
-    @property
-    def fits_cutouts(self) -> List[fits.HDUList]:
-        """
-        Return the cutouts as a list `astropy.io.fits.HDUList` objects.
-        """
-        if self._fits_cutouts is not None:
-            return self._fits_cutouts
-
-        self._fits_cutouts = self.get_fits_cutouts()
-
-        return self._fits_cutouts
 
     @property
     def asdf_cutouts(self) -> List[asdf.AsdfFile]:
@@ -140,6 +130,18 @@ class ASDFCutout(ImageCutout):
         self._asdf_cutouts = self.get_asdf_cutouts()
 
         return self._asdf_cutouts
+
+    @property
+    def fits_cutouts(self) -> List[fits.HDUList]:
+        """
+        Return the cutouts as a list `astropy.io.fits.HDUList` objects.
+        """
+        if self._fits_cutouts is not None:
+            return self._fits_cutouts
+
+        self._fits_cutouts = self.get_fits_cutouts()
+
+        return self._fits_cutouts
 
     def get_asdf_cutouts(
         self,
@@ -164,33 +166,11 @@ class ASDFCutout(ImageCutout):
             Table with columns for input file, coordinate, and the corresponding `asdf.AsdfFile` object representing
             the cutout.
         """
-        asdf_cutouts = []
-
-        file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
-        for file, coord in file_coord_pairs:
-            cutout = self.cutouts_by_file[file][coord]
-
-            tree = self._asdf_trees[file][coord]
-
-            af = asdf.AsdfFile(tree)
-            ra, dec = coord.split()
-            af.add_history_entry(
-                f"Cutout of size {cutout.shape} at sky coordinates ({ra}, {dec})",
-                software={
-                    "name": "astrocut",
-                    "author": "Space Telescope Science Institute",
-                    "version": __version__,
-                    "homepage": "https://astrocut.readthedocs.io/en/latest/",
-                },
-            )
-            asdf_cutouts.append({"file": file, "coord": SkyCoord(coord, unit="deg"), "cutout": af})
-
-        # Make an astropy table
-        cutout_table = Table(
-            rows=[(item["file"], item["coord"], item["cutout"]) for item in asdf_cutouts],
+        asdf_cutout_table = Table(
+            rows=list(self.iter_asdf_cutouts(input_files=input_files, coordinates=coordinates)),
             names=["file", "coordinate", "cutout"],
         )
-        return cutout_table
+        return asdf_cutout_table
 
     def get_fits_cutouts(
         self,
@@ -211,21 +191,91 @@ class ASDFCutout(ImageCutout):
 
         Returns
         -------
-        fits_cutouts : dict
-            Dictionary of `astropy.io.fits.HDUList` objects representing the cutouts,
-            keyed by a tuple of (input_file, coordinate)
+        fits_cutouts : Table
+            Table with columns for input file, coordinate, and the corresponding `astropy.io.fits.HDUList` object
+            representing the cutout.
         """
-        file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
-        fits_cutouts = []
+        fits_cutouts = list(self.iter_fits_cutouts(input_files=input_files, coordinates=coordinates))
+
+        fits_cutout_table = Table()
+        fits_cutout_table["file"] = [item[0] for item in fits_cutouts]
+        fits_cutout_table["coordinate"] = [item[1] for item in fits_cutouts]
+        fits_cutout_table.add_column(Column(length=len(fits_cutouts), dtype=object, name="cutout"))
+        for i, item in enumerate(fits_cutouts):
+            fits_cutout_table["cutout"][i] = item[2]
+        return fits_cutout_table
+
+    def iter_asdf_cutouts(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> Iterator[Tuple[str, SkyCoord, asdf.AsdfFile]]:
+        """
+        Yield ASDF cutouts lazily for the selected file/coordinate pairs.
+
+        Parameters
+        ----------
+        input_files : list
+            Optional. List of input image files to include in the output. If not specified, all input files will be
+            included.
+        coordinates : list
+            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
+
+        Yields
+        ------
+        tuple
+            Tuples of (input file, coordinate, `asdf.AsdfFile`).
+        """
+        for file, coord in self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates):
+            cutout = self.cutouts_by_file[file][coord]
+            tree = self._asdf_trees[file][coord]
+
+            af = asdf.AsdfFile(tree)
+            ra, dec = coord.split()
+            af.add_history_entry(
+                f"Cutout of size {cutout.shape} at sky coordinates ({ra}, {dec})",
+                software={
+                    "name": "astrocut",
+                    "author": "Space Telescope Science Institute",
+                    "version": __version__,
+                    "homepage": "https://astrocut.readthedocs.io/en/latest/",
+                },
+            )
+            yield file, SkyCoord(coord, unit="deg"), af
+
+    def iter_fits_cutouts(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> Iterator[Tuple[str, SkyCoord, fits.HDUList]]:
+        """
+        Yield FITS cutouts lazily for the selected file/coordinate pairs.
+
+        Parameters
+        ----------
+        input_files : list
+            Optional. List of input image files to include in the output. If not specified, all input files will be
+            included.
+        coordinates : list
+            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
+
+        Yields
+        ------
+        tuple
+            Tuples of (input file, coordinate, `astropy.io.fits.HDUList`).
+        """
+        self._check_asdf_in_fits_support()
+
         today_str = str(date.today())
-        for file, coord in file_coord_pairs:
+        for file, coord in self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates):
             cutout = self.cutouts_by_file[file][coord]
 
             source_tree = self._asdf_trees[file][coord]
             # Build a metadata-only tree for FITS embedding without mutating cached ASDF trees.
             tree = {self._mission_kwd: {"meta": source_tree[self._mission_kwd]["meta"]}}
 
-            # Build the PrimaryHDU with keywords
             ra, dec = coord.split()
             if self._primary_header_template is None:
                 self._primary_header_template = fits.Header(
@@ -245,22 +295,10 @@ class ASDFCutout(ImageCutout):
             image_hdu.header["EXTNAME"] = "CUTOUT"
             hdul = fits.HDUList([primary_hdu, image_hdu])
 
-            self._check_asdf_in_fits_support()
             if self._asdf_in_fits is not None:
-                hdul_embed = self._asdf_in_fits.to_hdulist(tree, hdul)
-            else:
-                hdul_embed = hdul
+                hdul = self._asdf_in_fits.to_hdulist(tree, hdul)
 
-            fits_cutouts.append({"file": file, "coord": SkyCoord(coord, unit="deg"), "cutout": hdul_embed})
-
-        # Make an astropy table
-        cutout_table = Table()
-        cutout_table["file"] = [item["file"] for item in fits_cutouts]
-        cutout_table["coordinate"] = [item["coord"] for item in fits_cutouts]
-        cutout_table.add_column(Column(length=len(fits_cutouts), dtype=object, name="cutout"))
-        for i, item in enumerate(fits_cutouts):
-            cutout_table["cutout"][i] = item["cutout"]
-        return cutout_table
+            yield file, SkyCoord(coord, unit="deg"), hdul
 
     def get_image_cutouts(
         self,
@@ -308,10 +346,78 @@ class ASDFCutout(ImageCutout):
 
         Returns
         -------
-        image_cutouts : list
-            If colorize is False, a dictionary of `~PIL.Image` objects representing the cutouts, keyed by a
-            tuple of (input_file, coordinate). If colorize is True, a dictionary of `~PIL.Image` objects
-            representing the color cutouts, keyed by the coordinate string.
+        image_cutouts : Table
+            Table with columns for input file(s), coordinate, and the corresponding `~PIL.Image` object representing
+            the image cutout.
+        """
+        image_cutouts = list(
+            self.iter_image_cutouts(
+                input_files=input_files,
+                coordinates=coordinates,
+                stretch=stretch,
+                minmax_percent=minmax_percent,
+                minmax_value=minmax_value,
+                invert=invert,
+                colorize=colorize,
+                flip_orientation=flip_orientation,
+            )
+        )
+
+        img_cutout_table = Table()
+        img_cutout_table["file"] = [item[0] for item in image_cutouts]
+        img_cutout_table["coordinate"] = [item[1] for item in image_cutouts]
+        img_cutout_table.add_column(Column(length=len(image_cutouts), dtype=object, name="cutout"))
+        for i, item in enumerate(image_cutouts):
+            img_cutout_table["cutout"][i] = item[2]
+        return img_cutout_table
+
+    def iter_image_cutouts(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+        stretch: Optional[str] = "asinh",
+        minmax_percent: Optional[List[int]] = None,
+        minmax_value: Optional[List[int]] = None,
+        invert: Optional[bool] = False,
+        colorize: Optional[bool] = False,
+        flip_orientation: Optional[bool] = True,
+    ) -> Iterator[Tuple[str, SkyCoord, Image]]:
+        """
+        Yield image cutouts lazily for the selected file/coordinate pairs.
+
+        Parameters
+        ----------
+        input_files : list
+            Optional. List of input image files to include in the output. If not specified, all input files will be
+            included.
+        coordinates : list
+            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
+        stretch : str
+            Optional, default 'asinh'. The stretch to apply to the image array.
+            Valid values are: asinh, sinh, sqrt, log, linear
+        minmax_percent : array
+            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric)
+            when scaling the image. The format is [lower percentile, upper percentile], where pixel
+            values below the lower percentile and above the upper percentile are clipped.
+            Only one of minmax_percent and minmax_value should be specified.
+        minmax_value : array
+            Optional. Interval based on user-specified pixel values when scaling the image.
+            The format is [min value, max value], where pixel values below the min value and above
+            the max value are clipped.
+            Only one of minmax_percent and minmax_value should be specified.
+        invert : bool
+            Optional, default False. If True the image is inverted (light pixels become dark and vice versa).
+        colorize : bool
+            Optional, default False. If True, the first three cutouts will be combined into a single RGB image.
+        flip_orientation : bool
+            Optional, default True. If True, the cutout images are flipped vertically to match the orientation
+            of the input images.
+
+        Yields
+        ------
+        tuple
+            Tuples of (input file(s), coordinate, `~PIL.Image`).
         """
         # Validate the stretch parameter
         valid_stretches = ["asinh", "sinh", "sqrt", "log", "linear"]
@@ -323,11 +429,15 @@ class ASDFCutout(ImageCutout):
         if (minmax_percent is None) and (minmax_value is None):
             minmax_percent = [0.5, 99.5]
 
-        image_cutouts = []
         if colorize:  # color cutouts
-            coordinates = self._coordinates if coordinates is None else coordinates
-            for coordinate in coordinates:
-                # Collect all the input files that have cutouts for this coordinate
+            if coordinates is None:
+                coordinates_to_include = self._coordinates
+            elif isinstance(coordinates, (list, tuple)):
+                coordinates_to_include = coordinates
+            else:
+                coordinates_to_include = [coordinates]
+
+            for coordinate in coordinates_to_include:
                 file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinate)
 
                 coord_cutouts = []
@@ -352,6 +462,7 @@ class ASDFCutout(ImageCutout):
                         "If you supplied 3 images one of the cutouts may have been empty.",
                         InputWarning,
                     )
+                    continue
 
                 img_arrs = []
                 for cutout in coord_cutouts:
@@ -364,9 +475,7 @@ class ASDFCutout(ImageCutout):
                     # Flip the image vertically to match the orientation of the input cutouts
                     color_img = color_img.transpose(Transpose.FLIP_TOP_BOTTOM)
                 color_img.info.update(self._build_cutout_metadata(coord_cutout_files, coord_cutouts[0], coordinate))
-                image_cutouts.append(
-                    {"file": ", ".join(coord_cutout_files), "coord": SkyCoord(coord, unit="deg"), "cutout": color_img}
-                )
+                yield ", ".join(coord_cutout_files), SkyCoord(coordinate, unit="deg"), color_img
         else:  # one image per cutout
             file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
 
@@ -380,15 +489,7 @@ class ASDFCutout(ImageCutout):
                     # Flip the image vertically to match the orientation of the input cutouts
                     img = img.transpose(Transpose.FLIP_TOP_BOTTOM)
                 img.info.update(self._build_cutout_metadata([file], cutout, coord))
-                image_cutouts.append({"file": file, "coord": SkyCoord(coord, unit="deg"), "cutout": img})
-
-        cutout_table = Table()
-        cutout_table["file"] = [item["file"] for item in image_cutouts]
-        cutout_table["coordinate"] = [item["coord"] for item in image_cutouts]
-        cutout_table.add_column(Column(length=len(image_cutouts), dtype=object, name="cutout"))
-        for i, item in enumerate(image_cutouts):
-            cutout_table["cutout"][i] = item["cutout"]
-        return cutout_table
+                yield file, SkyCoord(coord, unit="deg"), img
 
     def get_file_coord_pairs(
         self,
@@ -497,6 +598,9 @@ class ASDFCutout(ImageCutout):
         wcs_updated : `~astropy.wcs.WCS`
             The approximated FITS WCS object.
         """
+        if gwcsobj in self._gwcs_to_fits_cache:
+            return self._gwcs_to_fits_cache[gwcsobj]
+
         # Convert the gwcs object to an astropy FITS WCS header
         header = gwcsobj.to_fits_sip()
 
@@ -511,6 +615,7 @@ class ASDFCutout(ImageCutout):
             warnings.simplefilter("ignore")
             wcs_updated = WCS(header)
 
+        self._gwcs_to_fits_cache[gwcsobj] = wcs_updated
         return wcs_updated
 
     def _get_fill_value(self, dtype: np.dtype) -> Union[int, float]:
@@ -603,14 +708,16 @@ class ASDFCutout(ImageCutout):
         fill_value = self._get_fill_value(array.dtype)
 
         # Build a result array for the cutout filled with the fill value
-        result = np.full(
-            array.shape[:-2] + out_shape,
-            fill_value,
-            dtype=array.dtype,
-        )
+        result = np.empty(array.shape[:-2] + out_shape, dtype=array.dtype)
 
         # Insert original data into the cutout region of the result array
         result[..., cutout_slices[0], cutout_slices[1]] = array[..., orig_slices[0], orig_slices[1]]
+
+        # Fill the rest of the result array with the fill value
+        result[..., : cutout_slices[0].start, :] = fill_value
+        result[..., cutout_slices[0].stop :, :] = fill_value
+        result[..., :, : cutout_slices[1].start] = fill_value
+        result[..., :, cutout_slices[1].stop :] = fill_value
 
         return result
 
@@ -777,14 +884,14 @@ class ASDFCutout(ImageCutout):
                         continue
 
                     data = data_cutout.data
-                    if np.isnan(data).all() or not np.any(data):
+                    if not np.any(np.nan_to_num(data, nan=0.0)):
                         # No useful data for this coordinate in this file
                         warnings.warn(f"Cutout of {input_file} at {coord} contains no data, skipping...", DataWarning)
                         continue
 
                     # Store the Cutout2D object and associated metadata
                     coord_key = coord.to_string(precision=8)
-                    self.cutouts.append(data_cutout)
+                    self.cutouts.add_row((input_file, coord, data_cutout))
                     file_cutouts[coord_key] = data_cutout
                     self.cutouts_by_file.setdefault(input_file, {})[coord_key] = data_cutout
 
@@ -793,7 +900,7 @@ class ASDFCutout(ImageCutout):
                     if self._lite:
                         lite_tree = {
                             self._mission_kwd: {
-                                "meta": {"wcs": sliced_gwcs, "orig_file": input_file},
+                                "meta": {"wcs": sliced_gwcs, "orig_file": input_file, "coordinate": coord_key},
                                 "data": data,
                             }
                         }
@@ -801,6 +908,7 @@ class ASDFCutout(ImageCutout):
                     else:
                         coord_mission_tree["meta"]["wcs"] = sliced_gwcs
                         coord_mission_tree["meta"]["orig_file"] = input_file
+                        coord_mission_tree["meta"]["coordinate"] = coord_key
                         self._asdf_trees.setdefault(input_file, {})[coord_key] = {self._mission_kwd: coord_mission_tree}
 
     def _resolve_selection(
@@ -827,7 +935,7 @@ class ASDFCutout(ImageCutout):
         """
         # Determine which files to include
         if input_files is None:
-            files_to_include = self.cutouts_by_file.keys()
+            files_to_include = list(self.cutouts_by_file.keys())
         else:
             files_to_include = input_files if isinstance(input_files, (list, tuple)) else [input_files]
             files_to_include = [str(file) for file in files_to_include]
@@ -954,30 +1062,20 @@ class ASDFCutout(ImageCutout):
         cutout_paths : list
             The path(s) to the cutout file(s) or the cutout memory objects.
         """
-        file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
-
         if output_format == ".asdf":
-            if input_files is None and coordinates is None:
-                table = self.asdf_cutouts
-            else:
-                table = self.get_asdf_cutouts(input_files=input_files, coordinates=coordinates)
+            iterator = self.iter_asdf_cutouts(input_files=input_files, coordinates=coordinates)
         elif output_format == ".fits":
-            if input_files is None and coordinates is None:
-                table = self.fits_cutouts
-            else:
-                table = self.get_fits_cutouts(input_files=input_files, coordinates=coordinates)
+            iterator = self.iter_fits_cutouts(input_files=input_files, coordinates=coordinates)
+        else:
+            raise InvalidInputError(
+                f'Output format {output_format} is not recognized. Valid options are ".asdf" and ".fits".'
+            )
 
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         cutout_paths = []  # List to store paths to cutout files
 
-        for pair in file_coord_pairs:
-            file, coord = pair
-            if coord not in self.cutouts_by_file[file]:
-                continue  # Skip coordinates that are not associated with this file
-
-            mask = (table["file"] == file) & (table["coordinate"] == SkyCoord(coord, unit="deg"))
-            cutout_obj = table["cutout"][mask][0]
-
+        for file, coord_obj, cutout_obj in iterator:
+            coord = coord_obj.to_string(precision=8)
             filename = self._make_cutout_filename(file, output_format, coord=coord)
             cutout_path = Path(output_dir, filename)
 
@@ -1111,8 +1209,7 @@ class ASDFCutout(ImageCutout):
         # Parse the output format
         output_format = self._parse_output_format(output_format)
 
-        # Get the image cutouts with the given normalization parameters
-        image_cutouts = self.get_image_cutouts(
+        image_cutouts = self.iter_image_cutouts(
             input_files=input_files,
             coordinates=coordinates,
             stretch=stretch,
@@ -1200,30 +1297,23 @@ class ASDFCutout(ImageCutout):
         if fmt not in (".asdf", ".fits"):
             raise InvalidInputError("File format must be either '.asdf' or '.fits'")
 
-        file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
-
-        if output_format == ".asdf":
-            if input_files is None and coordinates is None:
-                table = self.asdf_cutouts
-            else:
-                table = self.get_asdf_cutouts(input_files=input_files, coordinates=coordinates)
-        elif output_format == ".fits":
-            if input_files is None and coordinates is None:
-                table = self.fits_cutouts
-            else:
-                table = self.get_fits_cutouts(input_files=input_files, coordinates=coordinates)
-
         if filename is None:
             filename = f"astrocut_{fmt[1:]}_cutouts.zip"
 
-        def build_entries():
-            for file, coord in file_coord_pairs:
-                if coord not in self.cutouts_by_file[file]:
-                    continue  # Skip coordinates that are not associated with this file
+        if fmt == ".asdf":
 
+            def iterator_factory():
+                return self.iter_asdf_cutouts(input_files=input_files, coordinates=coordinates)
+        else:
+
+            def iterator_factory():
+                return self.iter_fits_cutouts(input_files=input_files, coordinates=coordinates)
+
+        def build_entries():
+            for file, coord_obj, cutout_obj in iterator_factory():
+                coord = coord_obj.to_string(precision=8)
                 arcname = self._make_cutout_filename(file, fmt, coord=coord)
-                mask = (table["file"] == file) & (table["coordinate"] == SkyCoord(coord, unit="deg"))
-                yield arcname, table["cutout"][mask][0]
+                yield arcname, cutout_obj
 
         return self._write_cutouts_to_zip(output_dir=output_dir, filename=filename, build_entries=build_entries)
 
@@ -1243,10 +1333,8 @@ def get_center_pixel(gwcsobj: gwcs.wcs.WCS, ra: float, dec: float) -> Tuple[Tupl
 
     Returns
     -------
-    pixel_position
-        The pixel position of the input coordinates.
-    wcs_updated : `~astropy.wcs.WCS`
-        The approximated FITS WCS object.
+    pixel_coords : tuple
+        The (row, col) pixel coordinates of the input coordinates.
     """
     # Map the coordinates to a pixel's location on the 2d image
     row, col = gwcsobj.invert(np.atleast_1d(ra), np.atleast_1d(dec), with_bounding_box=False)

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -183,7 +183,7 @@ class ASDFCutout(ImageCutout):
                     "homepage": "https://astrocut.readthedocs.io/en/latest/",
                 },
             )
-            asdf_cutouts.append({"file": file, "coord": coord, "cutout": af})
+            asdf_cutouts.append({"file": file, "coord": SkyCoord(coord, unit="deg"), "cutout": af})
 
         # Make an astropy table
         cutout_table = Table(
@@ -232,11 +232,11 @@ class ASDFCutout(ImageCutout):
                     [
                         ("ORIGIN", "STScI/MAST"),
                         ("PROCVER", __version__),
-                        ("RA_OBJ", ra),
-                        ("DEC_OBJ", dec),
                     ]
                 )
             primary_header = self._primary_header_template.copy()
+            primary_header["RA_OBJ"] = float(ra)
+            primary_header["DEC_OBJ"] = float(dec)
             primary_header["DATE"] = today_str
             primary_hdu = fits.PrimaryHDU(header=primary_header)
 
@@ -251,7 +251,7 @@ class ASDFCutout(ImageCutout):
             else:
                 hdul_embed = hdul
 
-            fits_cutouts.append({"file": file, "coord": coord, "cutout": hdul_embed})
+            fits_cutouts.append({"file": file, "coord": SkyCoord(coord, unit="deg"), "cutout": hdul_embed})
 
         # Make an astropy table
         cutout_table = Table()
@@ -260,7 +260,6 @@ class ASDFCutout(ImageCutout):
         cutout_table.add_column(Column(length=len(fits_cutouts), dtype=object, name="cutout"))
         for i, item in enumerate(fits_cutouts):
             cutout_table["cutout"][i] = item["cutout"]
-        return cutout_table
         return cutout_table
 
     def get_image_cutouts(
@@ -330,7 +329,6 @@ class ASDFCutout(ImageCutout):
             for coordinate in coordinates:
                 # Collect all the input files that have cutouts for this coordinate
                 file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinate)
-                coordinate = coordinate.to_string(precision=8)
 
                 coord_cutouts = []
                 coord_cutout_files = []
@@ -366,7 +364,9 @@ class ASDFCutout(ImageCutout):
                     # Flip the image vertically to match the orientation of the input cutouts
                     color_img = color_img.transpose(Transpose.FLIP_TOP_BOTTOM)
                 color_img.info.update(self._build_cutout_metadata(coord_cutout_files, coord_cutouts[0], coordinate))
-                image_cutouts.append({"file": ", ".join(coord_cutout_files), "coord": coord, "cutout": color_img})
+                image_cutouts.append(
+                    {"file": ", ".join(coord_cutout_files), "coord": SkyCoord(coord, unit="deg"), "cutout": color_img}
+                )
         else:  # one image per cutout
             file_coord_pairs = self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates)
 
@@ -380,8 +380,7 @@ class ASDFCutout(ImageCutout):
                     # Flip the image vertically to match the orientation of the input cutouts
                     img = img.transpose(Transpose.FLIP_TOP_BOTTOM)
                 img.info.update(self._build_cutout_metadata([file], cutout, coord))
-
-                image_cutouts.append({"file": file, "coord": coord, "cutout": img})
+                image_cutouts.append({"file": file, "coord": SkyCoord(coord, unit="deg"), "cutout": img})
 
         cutout_table = Table()
         cutout_table["file"] = [item["file"] for item in image_cutouts]
@@ -740,7 +739,6 @@ class ASDFCutout(ImageCutout):
                     return
 
                 new_mission_tree = {"meta": mission_tree.get("meta", {})}
-                new_tree = {self._mission_kwd: new_mission_tree}
 
                 data_shape = mission_tree["data"].shape
 
@@ -763,8 +761,12 @@ class ASDFCutout(ImageCutout):
                         )
                         continue
 
+                    # Make a per-coordinate copy because _get_cutout_data may modify the mission_tree
+                    # in place if not in lite mode
+                    coord_mission_tree = dict(new_mission_tree)
+
                     try:
-                        data_cutout = self._get_cutout_data(new_mission_tree, wcs, pixel_coords)
+                        data_cutout = self._get_cutout_data(coord_mission_tree, wcs, pixel_coords)
                     except NoOverlapError:
                         warnings.warn(
                             f"Cutout of {input_file} at {coord} does not overlap the image. "
@@ -797,9 +799,9 @@ class ASDFCutout(ImageCutout):
                         }
                         self._asdf_trees.setdefault(input_file, {})[coord_key] = lite_tree
                     else:
-                        new_mission_tree["meta"]["wcs"] = sliced_gwcs
-                        new_mission_tree["meta"]["orig_file"] = input_file
-                        self._asdf_trees.setdefault(input_file, {})[coord_key] = new_tree
+                        coord_mission_tree["meta"]["wcs"] = sliced_gwcs
+                        coord_mission_tree["meta"]["orig_file"] = input_file
+                        self._asdf_trees.setdefault(input_file, {})[coord_key] = {self._mission_kwd: coord_mission_tree}
 
     def _resolve_selection(
         self,
@@ -821,7 +823,7 @@ class ASDFCutout(ImageCutout):
         files_to_include : list
             List of input files to include in the cutout results.
         coords_to_include : list
-            List of coordinates to include in the cutout results.
+            List of string coordinates to include in the cutout results.
         """
         # Determine which files to include
         if input_files is None:
@@ -835,17 +837,26 @@ class ASDFCutout(ImageCutout):
                     raise InvalidInputError(f"Input file {file} is not in the cutout results.")
 
         # Determine which coordinates to include
-        all_coords = set()
+        all_coords = []
         for file in files_to_include:
-            all_coords.update(self.cutouts_by_file[file].keys())
+            all_coords.extend(self.cutouts_by_file[file].keys())
+        # Remove duplicates while preserving order
+        all_coords = list(dict.fromkeys(all_coords))
 
         if coordinates is None:
             coords_to_include = all_coords
         else:
             coords_to_include = coordinates if isinstance(coordinates, (list, tuple)) else [coordinates]
-            coords_to_include = [
-                coord.to_string(precision=8) for coord in coords_to_include if isinstance(coord, SkyCoord)
-            ]
+            for i, coord in enumerate(coords_to_include):
+                if isinstance(coord, SkyCoord):
+                    coords_to_include[i] = coord.to_string(precision=8)
+                elif isinstance(coord, str):
+                    try:
+                        coords_to_include[i] = SkyCoord(coord).to_string(precision=8)
+                    except Exception as e:
+                        raise InvalidInputError(f"Invalid coordinate string: {coord}. Error: {e}")
+                else:
+                    raise InvalidInputError(f"Coordinate {coord} is not a valid SkyCoord or string.")
 
             for coord in coords_to_include:
                 if coord not in all_coords:
@@ -964,7 +975,7 @@ class ASDFCutout(ImageCutout):
             if coord not in self.cutouts_by_file[file]:
                 continue  # Skip coordinates that are not associated with this file
 
-            mask = (table["file"] == file) & (table["coordinate"] == coord)
+            mask = (table["file"] == file) & (table["coordinate"] == SkyCoord(coord, unit="deg"))
             cutout_obj = table["cutout"][mask][0]
 
             filename = self._make_cutout_filename(file, output_format, coord=coord)
@@ -1121,11 +1132,10 @@ class ASDFCutout(ImageCutout):
         if colorize:  # Combine first three cutouts into a single RGB image
             for _, coord, img in image_cutouts:
                 # Write the colorized cutout to disk
-                ra, dec = coord.split()
                 filename = "{}_{:.7f}_{:.7f}_{}-x-{}_astrocut{}".format(
                     cutout_prefix,
-                    float(ra),
-                    float(dec),
+                    coord.ra.deg,
+                    coord.dec.deg,
                     str(self._cutout_size[0]).replace(" ", ""),
                     str(self._cutout_size[1]).replace(" ", ""),
                     output_format,
@@ -1139,11 +1149,10 @@ class ASDFCutout(ImageCutout):
 
         else:  # Write each cutout to a separate image file
             for file, coord, img in image_cutouts:
-                ra, dec = coord.split()
                 filename = "{}_{:.7f}_{:.7f}_{}-x-{}_astrocut{}".format(
                     Path(file).stem,
-                    float(ra),
-                    float(dec),
+                    coord.ra.deg,
+                    coord.dec.deg,
                     str(self._cutout_size[0]).replace(" ", ""),
                     str(self._cutout_size[1]).replace(" ", ""),
                     output_format,
@@ -1213,7 +1222,7 @@ class ASDFCutout(ImageCutout):
                     continue  # Skip coordinates that are not associated with this file
 
                 arcname = self._make_cutout_filename(file, fmt, coord=coord)
-                mask = (table["file"] == file) & (table["coordinate"] == coord)
+                mask = (table["file"] == file) & (table["coordinate"] == SkyCoord(coord, unit="deg"))
                 yield arcname, table["cutout"][mask][0]
 
         return self._write_cutouts_to_zip(output_dir=output_dir, filename=filename, build_entries=build_entries)

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from datetime import date
 from pathlib import Path
 from time import monotonic
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Iterator, List, Optional, Tuple, Union
 
 import asdf
 import gwcs
@@ -107,7 +107,7 @@ class ASDFCutout(ImageCutout):
         self._mission_kwd = "roman"
 
         # Store cutouts as a table
-        self.cutouts = Table(names=["file", "coordinate", "cutout"], dtype=["str", "object", "object"])
+        self._cutouts = None  # Store Cutout2D objects
         self._asdf_cutouts = None  # Store ASDF objects
         self._fits_cutouts = None  # Store FITS objects
         self._asdf_trees = {}  # Store ASDF trees for each cutout
@@ -120,7 +120,19 @@ class ASDFCutout(ImageCutout):
         self.cutout()
 
     @property
-    def asdf_cutouts(self) -> List[asdf.AsdfFile]:
+    def cutouts(self) -> Table:
+        """
+        Return the cutouts as an `astropy.table.Table` with columns for input file, coordinate, and the corresponding
+        `astropy.nddata.Cutout2D` object.
+        """
+        if self._cutouts is not None:
+            return self._cutouts
+
+        self._cutouts = self.get_cutouts()
+        return self._cutouts
+
+    @property
+    def asdf_cutouts(self) -> Table:
         """
         Return the cutouts as a list of `asdf.AsdfFile` objects.
         """
@@ -128,11 +140,10 @@ class ASDFCutout(ImageCutout):
             return self._asdf_cutouts
 
         self._asdf_cutouts = self.get_asdf_cutouts()
-
         return self._asdf_cutouts
 
     @property
-    def fits_cutouts(self) -> List[fits.HDUList]:
+    def fits_cutouts(self) -> Table:
         """
         Return the cutouts as a list `astropy.io.fits.HDUList` objects.
         """
@@ -140,17 +151,17 @@ class ASDFCutout(ImageCutout):
             return self._fits_cutouts
 
         self._fits_cutouts = self.get_fits_cutouts()
-
         return self._fits_cutouts
 
-    def get_asdf_cutouts(
+    def get_cutouts(
         self,
         *,
         input_files: Optional[List[Union[str, Path, S3Path]]] = None,
         coordinates: Optional[List[Union[SkyCoord, str]]] = None,
-    ) -> Dict[Tuple[str, str], asdf.AsdfFile]:
+    ) -> Table:
         """
-        Get the cutouts as `asdf.AsdfFile` objects.
+        Get the cutouts as an `astropy.table.Table` with columns for input file, coordinate, and the corresponding
+        `astropy.nddata.Cutout2D` object.
 
         Parameters
         ----------
@@ -162,7 +173,61 @@ class ASDFCutout(ImageCutout):
 
         Returns
         -------
-        asdf_cutouts : astropy.table.Table
+        cutouts : `astropy.table.Table`
+            Table with columns for input file, coordinate, and the corresponding `astropy.nddata.Cutout2D` object.
+        """
+        cutout_table = Table(
+            rows=list(self.iter_cutouts(input_files=input_files, coordinates=coordinates)),
+            names=["file", "coordinate", "cutout"],
+        )
+        return cutout_table
+
+    def iter_cutouts(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> Iterator[Tuple[str, SkyCoord, Cutout2D]]:
+        """
+        Yield base `~astropy.nddata.Cutout2D` cutouts lazily for selected file/coordinate pairs.
+
+        Parameters
+        ----------
+        input_files : list
+            Optional. List of input image files to include in the output. If not specified, all input files will be
+            included.
+        coordinates : list
+            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
+
+        Yields
+        ------
+        tuple
+            Tuples of (input file, coordinate, `astropy.nddata.Cutout2D`).
+        """
+        for file, coord in self.get_file_coord_pairs(input_files=input_files, coordinates=coordinates):
+            yield file, SkyCoord(coord, unit="deg"), self.cutouts_by_file[file][coord]
+
+    def get_asdf_cutouts(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> Table:
+        """
+        Get the cutouts as an `astropy.table.Table` with columns for input file, coordinate,
+        and the corresponding `asdf.AsdfFile` object.
+
+        Parameters
+        ----------
+        input_files : list
+            Optional. List of input image files to include in the output. If not specified, all input files will be
+            included.
+        coordinates : list
+            Optional. List of coordinates to include in the output. If not specified, all coordinates will be included.
+
+        Returns
+        -------
+        asdf_cutouts : `astropy.table.Table`
             Table with columns for input file, coordinate, and the corresponding `asdf.AsdfFile` object representing
             the cutout.
         """
@@ -216,9 +281,10 @@ class ASDFCutout(ImageCutout):
         *,
         input_files: Optional[List[Union[str, Path, S3Path]]] = None,
         coordinates: Optional[List[Union[SkyCoord, str]]] = None,
-    ) -> Dict[Tuple[str, str], fits.HDUList]:
+    ) -> Table:
         """
-        Get the cutouts as `astropy.io.fits.HDUList` objects.
+        Get the cutouts as an `astropy.table.Table` with columns for input file, coordinate, and the
+        corresponding `astropy.io.fits.HDUList` object.
 
         Parameters
         ----------
@@ -230,7 +296,7 @@ class ASDFCutout(ImageCutout):
 
         Returns
         -------
-        fits_cutouts : Table
+        fits_cutouts : `astropy.table.Table`
             Table with columns for input file, coordinate, and the corresponding `astropy.io.fits.HDUList` object
             representing the cutout.
         """
@@ -347,10 +413,10 @@ class ASDFCutout(ImageCutout):
         invert: Optional[bool] = False,
         colorize: Optional[bool] = False,
         flip_orientation: Optional[bool] = True,
-    ) -> List[Image]:
+    ) -> Table:
         """
-        Get the cutouts as `~PIL.Image` objects given certain normalization parameters. This method also sets
-        the `image_cutouts` attribute.
+        Get the cutouts as an `astropy.table.Table` with columns for input file, coordinate, and the corresponding
+        `~PIL.Image` object representing the image cutout.
 
         Parameters
         ----------
@@ -382,7 +448,7 @@ class ASDFCutout(ImageCutout):
 
         Returns
         -------
-        image_cutouts : Table
+        image_cutouts : `astropy.table.Table`
             Table with columns for input file(s), coordinate, and the corresponding `~PIL.Image` object representing
             the image cutout.
         """
@@ -608,7 +674,7 @@ class ASDFCutout(ImageCutout):
             self._cutout_file(file)
 
         # If no cutouts contain data, raise exception
-        if not self.cutouts:
+        if not self.cutouts_by_file:
             raise InvalidQueryError("Cutout contains no data! (Check image footprint.)")
 
         # Log total time elapsed
@@ -953,7 +1019,6 @@ class ASDFCutout(ImageCutout):
 
                     # Store the Cutout2D object and associated metadata
                     coord_key = coord.to_string(precision=8)
-                    self.cutouts.add_row((input_file, coord, data_cutout))
                     file_cutouts[coord_key] = data_cutout
                     self.cutouts_by_file.setdefault(input_file, {})[coord_key] = data_cutout
 

--- a/astrocut/asdf_spectral_subset.py
+++ b/astrocut/asdf_spectral_subset.py
@@ -135,7 +135,7 @@ def _subset_single_file(
     out_trees_for_file = {}
     emitted_warnings = []
 
-    with asdf.open(file) as af:
+    with asdf.open(file, memmap=True) as af:
         in_tree = af.tree
         mission_data = in_tree[mission_keyword]["data"]
 

--- a/astrocut/cube_cutout.py
+++ b/astrocut/cube_cutout.py
@@ -77,6 +77,8 @@ class CubeCutout(Cutout, ABC):
         self._wcs_axes_value = None  # Expected value for the WCS axis keyword
         self._skip_kwds = []  # Keywords to skip when adding to the TPF headers
 
+        self._coordinates = self._coordinates[0]
+
     @property
     def cutouts(self):
         """
@@ -372,7 +374,7 @@ class CubeCutout(Cutout, ABC):
             }
 
             # Get cutout limits
-            self.cutout_lims = self._parent._get_cutout_limits(cube_wcs)
+            self.cutout_lims = self._parent._get_cutout_limits(parent._coordinates, cube_wcs)
 
             # Get cutout data
             self.data, self.uncertainty, self.aperture = self._get_cutout_data(cube[1].section, self._parent._threads)

--- a/astrocut/cutout.py
+++ b/astrocut/cutout.py
@@ -59,7 +59,7 @@ class Cutout(BaseCutout, ABC):
     def __init__(
         self,
         input_files: List[Union[str, Path, S3Path]],
-        coordinates: Union[SkyCoord, str],
+        coordinates: Union[SkyCoord, str, List[Union[SkyCoord, str]]],
         cutout_size: Union[int, np.ndarray, u.Quantity, List[int], Tuple[int]] = 25,
         fill_value: Union[int, float] = np.nan,
         limit_rounding_method: str = "round",
@@ -73,9 +73,11 @@ class Cutout(BaseCutout, ABC):
         self._input_files = input_files
 
         # Get coordinates as a SkyCoord object
-        if not isinstance(coordinates, SkyCoord):
-            coordinates = SkyCoord(coordinates, unit="deg")
-        self._coordinates = coordinates
+        if not isinstance(coordinates, (list, tuple)):
+            coordinates = [coordinates]
+        self._coordinates = [
+            SkyCoord(coord, unit="deg") if not isinstance(coord, SkyCoord) else coord for coord in coordinates
+        ]
         log.debug("Coordinates: %s", self._coordinates)
 
         # Turning the cutout size into an array of two values
@@ -100,7 +102,7 @@ class Cutout(BaseCutout, ABC):
         # Initialize cutout dictionary
         self.cutouts_by_file = {}
 
-    def _get_cutout_limits(self, img_wcs: wcs.WCS) -> np.ndarray:
+    def _get_cutout_limits(self, coordinates: SkyCoord, img_wcs: wcs.WCS) -> np.ndarray:
         """
         Returns the x and y pixel limits for the cutout.
 
@@ -109,6 +111,8 @@ class Cutout(BaseCutout, ABC):
 
         Parameters
         ----------
+        coordinates : `~astropy.coordinates.SkyCoord`
+            The coordinates of the center of the cutout.
         img_wcs : `~astropy.wcs.WCS`
             The WCS for the image or cube that the cutout is being cut from.
 
@@ -121,7 +125,7 @@ class Cutout(BaseCutout, ABC):
         try:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", message="All-NaN slice encountered")
-                center_pixel = self._coordinates.to_pixel(img_wcs)
+                center_pixel = coordinates.to_pixel(img_wcs)
         except wcs.NoConvergence:  # If wcs can't converge, center coordinate is far from the footprint
             raise InvalidQueryError("Cutout location is not in image footprint!")
 
@@ -154,7 +158,7 @@ class Cutout(BaseCutout, ABC):
                 lims[axis, 1] = lims[axis, 0] + 1
         return lims
 
-    def _make_cutout_filename(self, file_stem: str, legacy_filenames: bool = False) -> str:
+    def _make_cutout_filename(self, file_stem: str, coordinates: SkyCoord, legacy_filenames: bool = False) -> str:
         """
         Create a cutout filename based on a file stem, coordinates, and cutout size.
 
@@ -162,6 +166,8 @@ class Cutout(BaseCutout, ABC):
         ----------
         file_stem : str
             The stem of the input file to use in the cutout filename.
+        coordinates : `~astropy.coordinates.SkyCoord`
+            The coordinates of the cutout center.
         legacy_filenames : bool
             If True, use the pre-1.2.0 format (``<ny>x<nx>`` size separator and 6-decimal
             RA/Dec precision) instead of the current format (``<ny>-x-<nx>`` size separator
@@ -178,8 +184,8 @@ class Cutout(BaseCutout, ABC):
             separator = "x"
             precision = 6
 
-        ra = self._coordinates.ra.value
-        dec = self._coordinates.dec.value
+        ra = coordinates.ra.value
+        dec = coordinates.dec.value
         ny = str(self._cutout_size[0]).replace(" ", "")
         nx = str(self._cutout_size[1]).replace(" ", "")
         return f"{file_stem}_{ra:.{precision}f}_{dec:.{precision}f}_{ny}{separator}{nx}_astrocut.fits"
@@ -217,6 +223,7 @@ class Cutout(BaseCutout, ABC):
         self,
         output_dir: Union[str, Path] = ".",
         filename: Optional[Union[str, Path]] = None,
+        coordinates: Optional[SkyCoord] = None,
         build_entries: Optional[Callable[[], Iterable[Tuple[str, Any]]]] = None,
     ) -> str:
         """
@@ -227,9 +234,11 @@ class Cutout(BaseCutout, ABC):
         output_dir : str | Path, optional
             Directory where the zip will be created. Default '.'
         filename : str | Path | None, optional
-            Name (or path) of the output zip file. If not provided, defaults to
+            'astrocut_{ra}_{dec}_{size}.zip'. If not provided, defaults to
             'astrocut_{ra}_{dec}_{size}.zip'. If provided without a '.zip' suffix,
             the suffix is added automatically.
+        coordinates : `~astropy.coordinates.SkyCoord`
+            The coordinates of the cutout center.
         build_entries : callable -> iterable of (arcname, payload), optional
             Function that yields entries lazily. Useful to build streams on demand.
 
@@ -240,12 +249,15 @@ class Cutout(BaseCutout, ABC):
         """
         # Resolve zip path and ensure directory exists
         if filename is None:
-            filename = "astrocut_{:.7f}_{:.7f}_{}-x-{}.zip".format(
-                self._coordinates.ra.value,
-                self._coordinates.dec.value,
-                str(self._cutout_size[0]).replace(" ", ""),
-                str(self._cutout_size[1]).replace(" ", ""),
-            )
+            if coordinates is None:
+                filename = "astrocut.zip"
+            else:
+                filename = "astrocut_{:.7f}_{:.7f}_{}-x-{}.zip".format(
+                    coordinates.ra.value,
+                    coordinates.dec.value,
+                    str(self._cutout_size[0]).replace(" ", ""),
+                    str(self._cutout_size[1]).replace(" ", ""),
+                )
         filename = Path(filename)
         if filename.suffix.lower() != ".zip":
             filename = filename.with_suffix(".zip")

--- a/astrocut/cutout.py
+++ b/astrocut/cutout.py
@@ -75,6 +75,8 @@ class Cutout(BaseCutout, ABC):
         # Get coordinates as a SkyCoord object
         if not isinstance(coordinates, (list, tuple)):
             coordinates = [coordinates]
+        if len(coordinates) == 0:
+            raise InvalidInputError("At least one coordinate must be provided.")
         self._coordinates = [
             SkyCoord(coord, unit="deg") if not isinstance(coord, SkyCoord) else coord for coord in coordinates
         ]

--- a/astrocut/cutout.py
+++ b/astrocut/cutout.py
@@ -73,8 +73,7 @@ class Cutout(BaseCutout, ABC):
         self._input_files = input_files
 
         # Get coordinates as a SkyCoord object
-        if not isinstance(coordinates, (list, tuple)):
-            coordinates = [coordinates]
+        coordinates = self._normalize_coordinates_input(coordinates)
         if len(coordinates) == 0:
             raise InvalidInputError("At least one coordinate must be provided.")
         self._coordinates = [
@@ -103,6 +102,31 @@ class Cutout(BaseCutout, ABC):
 
         # Initialize cutout dictionary
         self.cutouts_by_file = {}
+
+    @staticmethod
+    def _normalize_coordinates_input(
+        coordinates: Union[SkyCoord, str, List[Union[SkyCoord, str]], Tuple[Union[SkyCoord, str], ...]],
+    ) -> List[Union[SkyCoord, str]]:
+        """
+        Normalize coordinate inputs into a flat list.
+
+        Array-valued ``SkyCoord`` inputs are expanded into scalar coordinates so
+        workflows that provide one ``SkyCoord`` with many rows are handled the
+        same as a list of scalar coordinates.
+        """
+        if isinstance(coordinates, (list, tuple)):
+            raw_coords = list(coordinates)
+        else:
+            raw_coords = [coordinates]
+
+        normalized_coords: List[Union[SkyCoord, str]] = []
+        for coord in raw_coords:
+            if isinstance(coord, SkyCoord) and not coord.isscalar:
+                normalized_coords.extend(list(coord))
+            else:
+                normalized_coords.append(coord)
+
+        return normalized_coords
 
     def _get_cutout_limits(self, coordinates: SkyCoord, img_wcs: wcs.WCS) -> np.ndarray:
         """

--- a/astrocut/cutout_processing.py
+++ b/astrocut/cutout_processing.py
@@ -472,7 +472,7 @@ def build_default_combine_function(template_hdu_arr, no_data_val=np.nan):
         templates = (img_arrs != no_data_val).astype(float)
 
     multiplier_arr = np.sum(templates, axis=0)
-    multiplier_arr = np.divide(1, multiplier_arr, where=(multiplier_arr != 0))
+    np.divide(1, multiplier_arr, out=multiplier_arr, where=multiplier_arr != 0)
     for t_arr in templates:
         t_arr *= multiplier_arr
 

--- a/astrocut/fits_cutout.py
+++ b/astrocut/fits_cutout.py
@@ -88,6 +88,7 @@ class FITSCutout(ImageCutout):
         self._fits_cutouts = None
         self.hdu_cutouts_by_file = {}
         self._fsspec_kwargs = fsspec_kwargs
+        self._coordinates = self._coordinates[0]
 
         # Make the cutouts upon initialization
         self.cutout()
@@ -446,7 +447,7 @@ class FITSCutout(ImageCutout):
             log.debug("Returning cutout as a single FITS file.")
 
             cutout_fits = self.fits_cutouts[0]
-            filename = self._make_cutout_filename(cutout_prefix)
+            filename = self._make_cutout_filename(cutout_prefix, self._coordinates)
             cutout_path = Path(output_dir, filename)
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
@@ -460,7 +461,7 @@ class FITSCutout(ImageCutout):
             cutout_paths = []
             for i, file in enumerate(self.hdu_cutouts_by_file):
                 cutout_fits = self.fits_cutouts[i]
-                filename = self._make_cutout_filename(Path(file).stem)
+                filename = self._make_cutout_filename(Path(file).stem, self._coordinates)
                 cutout_path = Path(output_dir, filename)
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
@@ -493,17 +494,19 @@ class FITSCutout(ImageCutout):
         def build_entries():
             if self._single_outfile:
                 # Mirror the single-file naming used by write_as_fits
-                arcname = self._make_cutout_filename("cutout")
+                arcname = self._make_cutout_filename("cutout", self._coordinates)
                 hdu = self.fits_cutouts[0]
                 yield arcname, hdu
             else:
                 # One file per input; mirror write_as_fits naming
                 for i, file in enumerate(self.hdu_cutouts_by_file):
-                    arcname = self._make_cutout_filename(Path(file).stem)
+                    arcname = self._make_cutout_filename(Path(file).stem, self._coordinates)
                     hdu = self.fits_cutouts[i]
                     yield arcname, hdu
 
-        return self._write_cutouts_to_zip(output_dir=output_dir, filename=filename, build_entries=build_entries)
+        return self._write_cutouts_to_zip(
+            output_dir=output_dir, filename=filename, coordinates=self._coordinates, build_entries=build_entries
+        )
 
     class CutoutInstance:
         """
@@ -543,7 +546,7 @@ class FITSCutout(ImageCutout):
 
         def __init__(self, img_data: fits.Section, img_wcs: WCS, parent: "FITSCutout"):
             # Calculate cutout limits
-            cutout_lims = parent._get_cutout_limits(img_wcs)
+            cutout_lims = parent._get_cutout_limits(parent._coordinates, img_wcs)
 
             # Extract data from Section
             self.data = self._get_cutout_data(img_data, cutout_lims, parent)

--- a/astrocut/image_cutout.py
+++ b/astrocut/image_cutout.py
@@ -2,10 +2,11 @@ import json
 import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 from astropy.coordinates import SkyCoord
+from astropy.table import Column, Table
 from astropy.units import Quantity
 from astropy.visualization import (
     AsinhStretch,
@@ -198,47 +199,140 @@ class ImageCutout(Cutout, ABC):
 
         return self._image_cutouts
 
-    @abstractmethod
-    def _cutout_file(self, file: Union[str, Path, S3Path]):
+    @staticmethod
+    def normalize_img(
+        img_arr: np.ndarray,
+        stretch: str = "asinh",
+        minmax_percent: Optional[List[int]] = None,
+        minmax_value: Optional[List[int]] = None,
+        invert: bool = False,
+    ) -> np.ndarray:
         """
-        Cutout an image file.
-
-        This method is abstract and should be defined in subclasses.
-        """
-        raise NotImplementedError("Subclasses must implement this method.")
-
-    @abstractmethod
-    def cutout(self):
-        """
-        Generate the cutout(s).
-
-        This method is abstract and should be defined in subclasses.
-        """
-        raise NotImplementedError("Subclasses must implement this method.")
-
-    def _parse_output_format(self, output_format: str) -> str:
-        """
-        Parse the output format string and return it in a standardized format.
+        Apply given stretch and scaling to an image array.
 
         Parameters
         ----------
-        output_format : str
-            The output format string.
+        img_arr : array
+            The input image array.
+        stretch : str
+            Optional, default 'asinh'. The stretch to apply to the image array.
+            Valid values are: asinh, sinh, sqrt, log, linear
+        minmax_percent : array
+            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric)
+            when scaling the image. The format is [lower percentile, upper percentile], where pixel
+            values below the lower percentile and above the upper percentile are clipped.
+            Only one of minmax_percent and minmax_value shoul be specified.
+        minmax_value : array
+            Optional. Interval based on user-specified pixel values when scaling the image.
+            The format is [min value, max value], where pixel values below the min value and above
+            the max value are clipped.
+            Only one of minmax_percent and minmax_value should be specified.
+        invert : bool
+            Optional, default False.  If True the image is inverted (light pixels become dark and vice versa).
 
         Returns
         -------
-        out_format : str
-            The output format string in a standardized format.
+        response : array
+            The normalized image array, in the form in an integer arrays with values in the range 0-255.
+
+        Raises
+        ------
+        InvalidInputError
+            If the stretch is not supported.
         """
-        # Put format in standard format
-        out_lower = output_format.lower()
-        output_format = f".{out_lower}" if not output_format.startswith(".") else out_lower
 
-        # Error if the output format is not supported
-        if output_format not in registered_extensions().keys():
-            raise InvalidInputError(f"Output format {output_format} is not supported.")
+        # Check if the input image array is empty
+        if img_arr.size == 0:
+            raise InvalidInputError("Input image array is empty.")
 
-        return output_format
+        # Setting up the transform with the stretch
+        if stretch == "asinh":
+            transform = AsinhStretch()
+        elif stretch == "sinh":
+            transform = SinhStretch()
+        elif stretch == "sqrt":
+            transform = SqrtStretch()
+        elif stretch == "log":
+            transform = LogStretch()
+        elif stretch == "linear":
+            transform = LinearStretch()
+        else:
+            raise InvalidInputError(
+                f"Stretch {stretch} is not supported!Valid options are: asinh, sinh, sqrt, log, linear."
+            )
+
+        # Adding the scaling to the transform
+        if minmax_percent is not None:
+            transform += AsymmetricPercentileInterval(*minmax_percent)
+
+            if minmax_value is not None:
+                warnings.warn(
+                    "Both minmax_percent and minmax_value are set, minmax_value will be ignored.", InputWarning
+                )
+        elif minmax_value is not None:
+            transform += ManualInterval(*minmax_value)
+        else:  # Default, scale the entire image range to [0,1]
+            transform += MinMaxInterval()
+
+        # Performing the transform and then putting it into the integer range 0-255
+        norm_img = transform(img_arr)
+        np.multiply(255, norm_img, out=norm_img)
+        # Does the image have any NaN values? If so, set them to 0
+        norm_img = np.nan_to_num(norm_img, nan=0)
+        norm_img = norm_img.astype(np.uint8)
+
+        # Applying invert if requested
+        np.subtract(255, norm_img, out=norm_img, where=invert)
+
+        return norm_img
+
+    def _prepare_image_render_options(
+        self,
+        stretch: Optional[str],
+        minmax_percent: Optional[List[int]],
+        minmax_value: Optional[List[int]],
+    ) -> Tuple[str, Optional[List[int]], Optional[List[int]]]:
+        """
+        Validate image-render parameters and apply defaults.
+
+        Returns
+        -------
+        tuple
+            Normalized (stretch, minmax_percent, minmax_value) values.
+        """
+        valid_stretches = ["asinh", "sinh", "sqrt", "log", "linear"]
+        if not isinstance(stretch, str) or stretch.lower() not in valid_stretches:
+            raise InvalidInputError(f"Stretch {stretch} is not recognized. Valid options are {valid_stretches}.")
+        stretch = stretch.lower()
+
+        if (minmax_percent is None) and (minmax_value is None):
+            minmax_percent = [0.5, 99.5]
+
+        return stretch, minmax_percent, minmax_value
+
+    @staticmethod
+    def _coerce_coordinate_list(coordinates) -> List[Union[SkyCoord, str]]:
+        """
+        Coerce coordinates input to a list for iteration.
+        """
+        if coordinates is None:
+            return []
+        if isinstance(coordinates, (list, tuple)):
+            return list(coordinates)
+        return [coordinates]
+
+    @staticmethod
+    def _build_image_cutout_table(image_rows: List[Tuple[str, SkyCoord, Image]]) -> Table:
+        """
+        Build a standard image cutout output table from iterator rows.
+        """
+        image_table = Table()
+        image_table["file"] = [row[0] for row in image_rows]
+        image_table["coordinate"] = [row[1] for row in image_rows]
+        image_table.add_column(Column(length=len(image_rows), dtype=object, name="cutout"))
+        for i, row in enumerate(image_rows):
+            image_table["cutout"][i] = row[2]
+        return image_table
 
     def _build_cutout_metadata(self, input_files: List[Union[str, Path, S3Path]], cutout, coord: str) -> dict:
         """
@@ -286,82 +380,211 @@ class ImageCutout(Cutout, ABC):
 
         return meta
 
-    def _get_img_save_kwargs(self, im: Image, file_path: str) -> dict:
+    def _build_single_cutout_image(
+        self,
+        *,
+        file: Union[str, Path, S3Path],
+        coord: Union[SkyCoord, str],
+        cutout,
+        stretch: str,
+        minmax_percent: Optional[List[int]],
+        minmax_value: Optional[List[int]],
+        invert: bool,
+        flip_orientation: bool,
+    ) -> Image:
         """
-        Return format-specific keyword arguments for saving an image.
+        Render one cutout as a PIL image and attach metadata.
+        """
+        img_arr = self.normalize_img(cutout.data, stretch, minmax_percent, minmax_value, invert)
+        img = fromarray(img_arr)
+        if flip_orientation:
+            img = img.transpose(Transpose.FLIP_TOP_BOTTOM)
+        img.info.update(self._build_cutout_metadata([file], cutout, coord))
+        return img
 
-        Parameters
-        ----------
-        im : `~PIL.Image`
-            The image to save.
-        file_path : str
-            The output file path.
+    def _build_colorized_cutout_image(
+        self,
+        *,
+        coord_cutouts: List,
+        coord_cutout_files: List[Union[str, Path, S3Path]],
+        coordinate: Union[SkyCoord, str],
+        stretch: str,
+        minmax_percent: Optional[List[int]],
+        minmax_value: Optional[List[int]],
+        invert: bool,
+        flip_orientation: bool,
+    ) -> Image:
+        """
+        Render three cutouts as one RGB image and attach metadata.
+        """
+        img_arrs = [
+            self.normalize_img(cutout.data, stretch, minmax_percent, minmax_value, invert) for cutout in coord_cutouts
+        ]
+
+        color_img = fromarray(np.dstack([img_arrs[0], img_arrs[1], img_arrs[2]]).astype(np.uint8))
+        if flip_orientation:
+            color_img = color_img.transpose(Transpose.FLIP_TOP_BOTTOM)
+        color_img.info.update(self._build_cutout_metadata(coord_cutout_files, coord_cutouts[0], coordinate))
+        return color_img
+
+    def _iter_selected_cutouts(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+    ) -> Iterator[Tuple[str, SkyCoord, any]]:
+        """
+        Yield selected base cutouts as (file, coordinate, cutout).
+
+        Subclasses can override this to support richer file/coordinate selection.
+        """
+        if coordinates is not None:
+            raise InvalidInputError("Selecting image cutouts by coordinates is not supported for this cutout type.")
+
+        if input_files is None:
+            files_to_include = list(self.cutouts_by_file.keys())
+        else:
+            files_to_include = input_files if isinstance(input_files, (list, tuple)) else [input_files]
+            files_to_include = [str(file) for file in files_to_include]
+            for file in files_to_include:
+                if file not in self.cutouts_by_file:
+                    raise InvalidInputError(f"Input file {file} is not in the cutout results.")
+
+        for file in files_to_include:
+            cutout_list = self.cutouts_by_file.get(file, [])
+            for cutout in cutout_list:
+                yield file, self._coordinates, cutout
+
+    @staticmethod
+    def _coerce_coord_object(coord: Union[SkyCoord, str]) -> SkyCoord:
+        """
+        Convert a coordinate value to a SkyCoord object.
+        """
+        if isinstance(coord, SkyCoord):
+            return coord
+        return SkyCoord(coord, unit="deg")
+
+    def _warn_too_many_color_cutouts(self, coord: SkyCoord):
+        """
+        Emit a warning when more than three cutouts are available for color output.
+        """
+        warnings.warn("Too many inputs for a color cutout, only the first three will be used.", InputWarning)
+
+    def _handle_insufficient_color_cutouts(self, coord: SkyCoord) -> bool:
+        """
+        Handle the case where fewer than three cutouts are available for color output.
 
         Returns
         -------
-        save_kwargs : dict
-            Keyword arguments to pass to `PIL.Image.Image.save`.
+        bool
+            True to continue processing and emit an output, False to skip this coordinate.
         """
-        # Get the cutout metadata from top-level Image.info
-        metadata = im.info
-        if not metadata:
-            return {}
-        metadata_json = json.dumps(metadata)
-        output_suffix = Path(file_path).suffix.lower()
-
-        # Format for saving to file depends on output format
-        if output_suffix == ".png":
-            pnginfo = PngInfo()
-            for key, value in metadata.items():
-                pnginfo.add_text(key, str(value))
-            return {"pnginfo": pnginfo}
-
-        if output_suffix in {".jpg", ".jpeg", ".tif", ".tiff"}:
-            exif = im.getexif()
-            # Use tag for image description to store cutout metadata as json string
-            exif[270] = metadata_json
-            return {"exif": exif.tobytes()}
-
-        return {}
-
-    def _save_img_to_file(self, im: Image, file_path: str) -> bool:
-        """
-        Save a `~PIL.Image` object to a file.
-
-        Parameters
-        ----------
-        im : `~PIL.Image`
-            The image to save.
-        file_path : str
-            The path to save the image to.
-
-        Returns
-        -------
-        success : bool
-            True if the image was saved successfully, False otherwise.
-        """
-        try:
-            save_kwargs = self._get_img_save_kwargs(im, file_path)
-            im.save(file_path, **save_kwargs)
-            return True
-        except ValueError as e:
-            output_format = Path(file_path).suffix
-            warnings.warn(
-                f"Cutout could not be saved in {output_format} format: {e}. Please try a different output format.",
-                DataWarning,
+        raise InvalidInputError(
+            (
+                "Color cutouts require 3 input images (RGB)."
+                "If you supplied 3 images one of the cutouts may have been empty."
             )
-            return False
-        except KeyError as e:
-            output_format = Path(file_path).suffix
-            warnings.warn(
-                f"Cutout could not be saved in {output_format} format due to a KeyError: {e}. "
-                "Please try a different output format.",
-                DataWarning,
-            )
-            return False
-        except OSError as e:
-            warnings.warn(f"Cutout could not be saved: {e}", DataWarning)
-            return False
+        )
+
+    def _iter_image_cutout_rows(
+        self,
+        *,
+        input_files: Optional[List[Union[str, Path, S3Path]]] = None,
+        coordinates: Optional[List[Union[SkyCoord, str]]] = None,
+        stretch: Optional[str] = "asinh",
+        minmax_percent: Optional[List[int]] = None,
+        minmax_value: Optional[List[int]] = None,
+        invert: Optional[bool] = False,
+        colorize: Optional[bool] = False,
+        flip_orientation: Optional[bool] = True,
+    ) -> Iterator[Tuple[str, SkyCoord, Image]]:
+        """
+        Generic iterator that renders selected cutouts to image rows.
+        """
+        stretch, minmax_percent, minmax_value = self._prepare_image_render_options(
+            stretch, minmax_percent, minmax_value
+        )
+
+        selected_cutouts = list(self._iter_selected_cutouts(input_files=input_files, coordinates=coordinates))
+
+        if colorize:
+            grouped_cutouts = {}
+            coord_order = []
+
+            for file, coord, cutout in selected_cutouts:
+                coord_obj = self._coerce_coord_object(coord)
+                coord_key = coord_obj.to_string(precision=8)
+                if coord_key not in grouped_cutouts:
+                    grouped_cutouts[coord_key] = {
+                        "coord": coord_obj,
+                        "files": [],
+                        "cutouts": [],
+                    }
+                    coord_order.append(coord_key)
+
+                grouped_cutouts[coord_key]["files"].append(file)
+                grouped_cutouts[coord_key]["cutouts"].append(cutout)
+
+            for coord_key in coord_order:
+                grouped = grouped_cutouts[coord_key]
+                coord_obj = grouped["coord"]
+                coord_cutouts = grouped["cutouts"]
+                coord_cutout_files = grouped["files"]
+
+                print(len(coord_cutouts))
+                if len(coord_cutouts) > 3:
+                    print("here")
+                    self._warn_too_many_color_cutouts(coord_obj)
+                    coord_cutouts = coord_cutouts[:3]
+                    coord_cutout_files = coord_cutout_files[:3]
+
+                if len(coord_cutouts) < 3:
+                    if not self._handle_insufficient_color_cutouts(coord_obj):
+                        continue
+
+                color_img = self._build_colorized_cutout_image(
+                    coord_cutouts=coord_cutouts,
+                    coord_cutout_files=coord_cutout_files,
+                    coordinate=coord_obj,
+                    stretch=stretch,
+                    minmax_percent=minmax_percent,
+                    minmax_value=minmax_value,
+                    invert=invert,
+                    flip_orientation=flip_orientation,
+                )
+                yield ", ".join(coord_cutout_files), coord_obj, color_img
+        else:
+            for file, coord, cutout in selected_cutouts:
+                coord_obj = self._coerce_coord_object(coord)
+                img = self._build_single_cutout_image(
+                    file=file,
+                    coord=coord_obj,
+                    cutout=cutout,
+                    stretch=stretch,
+                    minmax_percent=minmax_percent,
+                    minmax_value=minmax_value,
+                    invert=invert,
+                    flip_orientation=flip_orientation,
+                )
+                yield file, coord_obj, img
+
+    @abstractmethod
+    def _cutout_file(self, file: Union[str, Path, S3Path]):
+        """
+        Cutout an image file.
+
+        This method is abstract and should be defined in subclasses.
+        """
+        raise NotImplementedError("Subclasses must implement this method.")
+
+    @abstractmethod
+    def cutout(self):
+        """
+        Generate the cutout(s).
+
+        This method is abstract and should be defined in subclasses.
+        """
+        raise NotImplementedError("Subclasses must implement this method.")
 
     def write_as_img(
         self,
@@ -474,92 +697,106 @@ class ImageCutout(Cutout, ABC):
         log.debug("Cutout filepaths: {}".format(cutout_paths))
         return cutout_paths
 
-    @staticmethod
-    def normalize_img(
-        img_arr: np.ndarray,
-        stretch: str = "asinh",
-        minmax_percent: Optional[List[int]] = None,
-        minmax_value: Optional[List[int]] = None,
-        invert: bool = False,
-    ) -> np.ndarray:
+    def _parse_output_format(self, output_format: str) -> str:
         """
-        Apply given stretch and scaling to an image array.
+        Parse the output format string and return it in a standardized format.
 
         Parameters
         ----------
-        img_arr : array
-            The input image array.
-        stretch : str
-            Optional, default 'asinh'. The stretch to apply to the image array.
-            Valid values are: asinh, sinh, sqrt, log, linear
-        minmax_percent : array
-            Optional. Interval based on a keeping a specified fraction of pixels (can be asymmetric)
-            when scaling the image. The format is [lower percentile, upper percentile], where pixel
-            values below the lower percentile and above the upper percentile are clipped.
-            Only one of minmax_percent and minmax_value shoul be specified.
-        minmax_value : array
-            Optional. Interval based on user-specified pixel values when scaling the image.
-            The format is [min value, max value], where pixel values below the min value and above
-            the max value are clipped.
-            Only one of minmax_percent and minmax_value should be specified.
-        invert : bool
-            Optional, default False.  If True the image is inverted (light pixels become dark and vice versa).
+        output_format : str
+            The output format string.
 
         Returns
         -------
-        response : array
-            The normalized image array, in the form in an integer arrays with values in the range 0-255.
-
-        Raises
-        ------
-        InvalidInputError
-            If the stretch is not supported.
+        out_format : str
+            The output format string in a standardized format.
         """
+        # Put format in standard format
+        out_lower = output_format.lower()
+        output_format = f".{out_lower}" if not output_format.startswith(".") else out_lower
 
-        # Check if the input image array is empty
-        if img_arr.size == 0:
-            raise InvalidInputError("Input image array is empty.")
+        # Error if the output format is not supported
+        if output_format not in registered_extensions().keys():
+            raise InvalidInputError(f"Output format {output_format} is not supported.")
 
-        # Setting up the transform with the stretch
-        if stretch == "asinh":
-            transform = AsinhStretch()
-        elif stretch == "sinh":
-            transform = SinhStretch()
-        elif stretch == "sqrt":
-            transform = SqrtStretch()
-        elif stretch == "log":
-            transform = LogStretch()
-        elif stretch == "linear":
-            transform = LinearStretch()
-        else:
-            raise InvalidInputError(
-                f"Stretch {stretch} is not supported!Valid options are: asinh, sinh, sqrt, log, linear."
+        return output_format
+
+    def _get_img_save_kwargs(self, im: Image, file_path: str) -> dict:
+        """
+        Return format-specific keyword arguments for saving an image.
+
+        Parameters
+        ----------
+        im : `~PIL.Image`
+            The image to save.
+        file_path : str
+            The output file path.
+
+        Returns
+        -------
+        save_kwargs : dict
+            Keyword arguments to pass to `PIL.Image.Image.save`.
+        """
+        # Get the cutout metadata from top-level Image.info
+        metadata = im.info
+        if not metadata:
+            return {}
+        metadata_json = json.dumps(metadata)
+        output_suffix = Path(file_path).suffix.lower()
+
+        # Format for saving to file depends on output format
+        if output_suffix == ".png":
+            pnginfo = PngInfo()
+            for key, value in metadata.items():
+                pnginfo.add_text(key, str(value))
+            return {"pnginfo": pnginfo}
+
+        if output_suffix in {".jpg", ".jpeg", ".tif", ".tiff"}:
+            exif = im.getexif()
+            # Use tag for image description to store cutout metadata as json string
+            exif[270] = metadata_json
+            return {"exif": exif.tobytes()}
+
+        return {}
+
+    def _save_img_to_file(self, im: Image, file_path: str) -> bool:
+        """
+        Save a `~PIL.Image` object to a file.
+
+        Parameters
+        ----------
+        im : `~PIL.Image`
+            The image to save.
+        file_path : str
+            The path to save the image to.
+
+        Returns
+        -------
+        success : bool
+            True if the image was saved successfully, False otherwise.
+        """
+        try:
+            save_kwargs = self._get_img_save_kwargs(im, file_path)
+            im.save(file_path, **save_kwargs)
+            return True
+        except ValueError as e:
+            output_format = Path(file_path).suffix
+            warnings.warn(
+                f"Cutout could not be saved in {output_format} format: {e}. Please try a different output format.",
+                DataWarning,
             )
-
-        # Adding the scaling to the transform
-        if minmax_percent is not None:
-            transform += AsymmetricPercentileInterval(*minmax_percent)
-
-            if minmax_value is not None:
-                warnings.warn(
-                    "Both minmax_percent and minmax_value are set, minmax_value will be ignored.", InputWarning
-                )
-        elif minmax_value is not None:
-            transform += ManualInterval(*minmax_value)
-        else:  # Default, scale the entire image range to [0,1]
-            transform += MinMaxInterval()
-
-        # Performing the transform and then putting it into the integer range 0-255
-        norm_img = transform(img_arr)
-        np.multiply(255, norm_img, out=norm_img)
-        # Does the image have any NaN values? If so, set them to 0
-        norm_img = np.nan_to_num(norm_img, nan=0)
-        norm_img = norm_img.astype(np.uint8)
-
-        # Applying invert if requested
-        np.subtract(255, norm_img, out=norm_img, where=invert)
-
-        return norm_img
+            return False
+        except KeyError as e:
+            output_format = Path(file_path).suffix
+            warnings.warn(
+                f"Cutout could not be saved in {output_format} format due to a KeyError: {e}. "
+                "Please try a different output format.",
+                DataWarning,
+            )
+            return False
+        except OSError as e:
+            warnings.warn(f"Cutout could not be saved: {e}", DataWarning)
+            return False
 
 
 def normalize_img(

--- a/astrocut/image_cutout.py
+++ b/astrocut/image_cutout.py
@@ -531,9 +531,7 @@ class ImageCutout(Cutout, ABC):
                 coord_cutouts = grouped["cutouts"]
                 coord_cutout_files = grouped["files"]
 
-                print(len(coord_cutouts))
                 if len(coord_cutouts) > 3:
-                    print("here")
                     self._warn_too_many_color_cutouts(coord_obj)
                     coord_cutouts = coord_cutouts[:3]
                     coord_cutout_files = coord_cutout_files[:3]

--- a/astrocut/image_cutout.py
+++ b/astrocut/image_cutout.py
@@ -6,7 +6,7 @@ from typing import Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 from astropy.coordinates import SkyCoord
-from astropy.table import Column, Table
+from astropy.table import Table
 from astropy.units import Quantity
 from astropy.visualization import (
     AsinhStretch,
@@ -326,13 +326,21 @@ class ImageCutout(Cutout, ABC):
         """
         Build a standard image cutout output table from iterator rows.
         """
-        image_table = Table()
-        image_table["file"] = [row[0] for row in image_rows]
-        image_table["coordinate"] = [row[1] for row in image_rows]
-        image_table.add_column(Column(length=len(image_rows), dtype=object, name="cutout"))
-        for i, row in enumerate(image_rows):
-            image_table["cutout"][i] = row[2]
-        return image_table
+        # Have to construct columns separately to avoid astropy.table trying to convert the
+        # Image objects to a numpy array
+        files = [row[0] for row in image_rows]
+        coordinates = [row[1] for row in image_rows]
+
+        cutouts = np.empty(len(image_rows), dtype=object)
+        cutouts[:] = [row[2] for row in image_rows]
+
+        return Table(
+            {
+                "file": files,
+                "coordinate": coordinates,
+                "cutout": cutouts,
+            }
+        )
 
     def _build_cutout_metadata(self, input_files: List[Union[str, Path, S3Path]], cutout, coord: str) -> dict:
         """

--- a/astrocut/image_cutout.py
+++ b/astrocut/image_cutout.py
@@ -532,7 +532,11 @@ class ImageCutout(Cutout, ABC):
             stretch, minmax_percent, minmax_value
         )
 
-        selected_cutouts = list(self._iter_selected_cutouts(input_files=input_files, coordinates=coordinates))
+        selected_cutouts = (
+            self._iter_selected_cutouts(input_files=input_files, coordinates=coordinates)
+            if not colorize
+            else list(self._iter_selected_cutouts(input_files=input_files, coordinates=coordinates))
+        )
 
         if colorize:
             grouped_cutouts = {}

--- a/astrocut/image_cutout.py
+++ b/astrocut/image_cutout.py
@@ -69,7 +69,7 @@ class ImageCutout(Cutout, ABC):
     def __init__(
         self,
         input_files: List[Union[str, Path, S3Path]],
-        coordinates: Union[SkyCoord, str],
+        coordinates: Union[SkyCoord, str, List[Union[SkyCoord, str]]],
         cutout_size: Union[int, np.ndarray, Quantity, List[int], Tuple[int]] = 25,
         fill_value: Union[int, float] = np.nan,
         limit_rounding_method: str = "round",
@@ -178,7 +178,7 @@ class ImageCutout(Cutout, ABC):
             if flip_orientation:
                 # Flip the image vertically to match the orientation of the input cutouts
                 color_img = color_img.transpose(Transpose.FLIP_TOP_BOTTOM)
-            color_img.info.update(self._build_cutout_metadata(all_cutout_files))
+            color_img.info.update(self._build_cutout_metadata(all_cutout_files, all_cutouts[0], self._coordinates))
             self._image_cutouts = [color_img]
         else:  # one image per cutout
             image_cutouts = []
@@ -191,7 +191,7 @@ class ImageCutout(Cutout, ABC):
                     if flip_orientation:
                         # Flip the image vertically to match the orientation of the input cutouts
                         img = img.transpose(Transpose.FLIP_TOP_BOTTOM)
-                    img.info.update(self._build_cutout_metadata([file]))
+                    img.info.update(self._build_cutout_metadata([file], cutout, self._coordinates))
                     image_cutouts.append(img)
 
             self._image_cutouts = image_cutouts
@@ -240,7 +240,7 @@ class ImageCutout(Cutout, ABC):
 
         return output_format
 
-    def _build_cutout_metadata(self, input_files: List[Union[str, Path, S3Path]]) -> dict:
+    def _build_cutout_metadata(self, input_files: List[Union[str, Path, S3Path]], cutout, coord: str) -> dict:
         """
         Build metadata describing a cutout image.
 
@@ -248,6 +248,10 @@ class ImageCutout(Cutout, ABC):
         ----------
         input_files : list
             The input file or files used to create the cutout.
+        cutout : `~astropy.nddata.Cutout2D`
+            The cutout object.
+        coord : str
+            The center coordinate of the cutout.
 
         Returns
         -------
@@ -263,18 +267,18 @@ class ImageCutout(Cutout, ABC):
         else:
             meta["input_files"] = ", ".join([Path(file).name for file in input_files])
 
-        # For color cutouts, we can get the pixel scale and cutout size from the first cutout
-        # since we assume they have the same WCS
-        cutout = self.cutouts_by_file.get(input_files[0], [None])[0]
-        if cutout is not None:
-            meta["cutout_size_x_pix"] = cutout.shape[1]
-            meta["cutout_size_y_pix"] = cutout.shape[0]
-            meta["pixel_scale_arcsec_per_pix"] = proj_plane_pixel_scales(cutout.wcs)[0] * 3600
+        meta["cutout_size_x_pix"] = cutout.shape[1]
+        meta["cutout_size_y_pix"] = cutout.shape[0]
+        meta["pixel_scale_arcsec_per_pix"] = proj_plane_pixel_scales(cutout.wcs)[0] * 3600
 
+        if isinstance(coord, SkyCoord):
+            ra, dec = coord.ra.deg, coord.dec.deg
+        else:
+            ra, dec = coord.split()
         meta.update(
             {
-                "center_ra_deg": self._coordinates.ra.deg.item(),
-                "center_dec_deg": self._coordinates.dec.deg.item(),
+                "center_ra_deg": float(ra),
+                "center_dec_deg": float(dec),
                 "origin": "STScI/MAST",
                 "version": __version__,
             }
@@ -548,6 +552,8 @@ class ImageCutout(Cutout, ABC):
         # Performing the transform and then putting it into the integer range 0-255
         norm_img = transform(img_arr)
         np.multiply(255, norm_img, out=norm_img)
+        # Does the image have any NaN values? If so, set them to 0
+        norm_img = np.nan_to_num(norm_img, nan=0)
         norm_img = norm_img.astype(np.uint8)
 
         # Applying invert if requested

--- a/astrocut/image_cutout.py
+++ b/astrocut/image_cutout.py
@@ -2,7 +2,7 @@ import json
 import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Iterator, List, Optional, Tuple, Union
+from typing import Any, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 from astropy.coordinates import SkyCoord
@@ -322,23 +322,42 @@ class ImageCutout(Cutout, ABC):
         return [coordinates]
 
     @staticmethod
-    def _build_image_cutout_table(image_rows: List[Tuple[str, SkyCoord, Image]]) -> Table:
+    def _build_cutout_table(
+        rows: Iterator[Tuple[str, SkyCoord, Any]],
+        *,
+        object_cutout: bool = False,
+    ) -> Table:
         """
-        Build a standard image cutout output table from iterator rows.
-        """
-        # Have to construct columns separately to avoid astropy.table trying to convert the
-        # Image objects to a numpy array
-        files = [row[0] for row in image_rows]
-        coordinates = [row[1] for row in image_rows]
+        Build a standard cutout table with columns for file, coordinate, and cutout.
 
-        cutouts = np.empty(len(image_rows), dtype=object)
-        cutouts[:] = [row[2] for row in image_rows]
+        Parameters
+        ----------
+        rows : iterator
+            Iterator of (file, coordinate, cutout) tuples.
+        object_cutout : bool
+            If True, force the cutout column to object dtype.
+
+        Returns
+        -------
+        table : `astropy.table.Table`
+            The constructed cutout table.
+        """
+        if not object_cutout:
+            return Table(rows=rows, names=["file", "coordinate", "cutout"])
+
+        rows = list(rows)
+        if not rows:
+            return Table(names=["file", "coordinate", "cutout"])
+
+        files, coordinates, cutouts = zip(*rows)
+        cutouts_col = np.empty(len(rows), dtype=object)
+        cutouts_col[:] = cutouts
 
         return Table(
             {
                 "file": files,
                 "coordinate": coordinates,
-                "cutout": cutouts,
+                "cutout": cutouts_col,
             }
         )
 

--- a/astrocut/tess_cube_cutout.py
+++ b/astrocut/tess_cube_cutout.py
@@ -586,7 +586,9 @@ class TessCubeCutout(CubeCutout):
 
         def build_entries():
             for file, tpf in self.tpf_cutouts_by_file.items():
-                arcname = self._make_cutout_filename(Path(file).stem.rstrip("-cube"), self._coordinates, legacy_filenames=legacy_filenames)
+                arcname = self._make_cutout_filename(
+                    Path(file).stem.rstrip("-cube"), self._coordinates, legacy_filenames=legacy_filenames
+                )
                 yield arcname, tpf
 
         return self._write_cutouts_to_zip(

--- a/astrocut/tess_cube_cutout.py
+++ b/astrocut/tess_cube_cutout.py
@@ -531,7 +531,7 @@ class TessCubeCutout(CubeCutout):
             # Determine file name
             if not output_file or len(self._input_files) > 1:
                 filename = self._make_cutout_filename(
-                    Path(file).stem.rstrip("-cube"), legacy_filenames=legacy_filenames
+                    Path(file).stem.rstrip("-cube"), self._coordinates, legacy_filenames=legacy_filenames
                 )
             else:
                 filename = output_file
@@ -586,10 +586,12 @@ class TessCubeCutout(CubeCutout):
 
         def build_entries():
             for file, tpf in self.tpf_cutouts_by_file.items():
-                arcname = self._make_cutout_filename(Path(file).stem.rstrip("-cube"), legacy_filenames=legacy_filenames)
+                arcname = self._make_cutout_filename(Path(file).stem.rstrip("-cube"), self._coordinates, legacy_filenames=legacy_filenames)
                 yield arcname, tpf
 
-        return self._write_cutouts_to_zip(output_dir=output_dir, filename=filename, build_entries=build_entries)
+        return self._write_cutouts_to_zip(
+            output_dir=output_dir, filename=filename, coordinates=self._coordinates, build_entries=build_entries
+        )
 
     class CubeCutoutInstance(CubeCutout.CubeCutoutInstance):
         """

--- a/astrocut/tess_footprint_cutout.py
+++ b/astrocut/tess_footprint_cutout.py
@@ -75,6 +75,9 @@ class TessFootprintCutout(FootprintCutout):
         verbose: bool = False,
     ):
         super().__init__(coordinates, cutout_size, fill_value, limit_rounding_method, sequence, verbose)
+
+        self._coordinates = self._coordinates[0]
+
         # Make the cutouts upon initialization
         self.cutout()
 

--- a/astrocut/tests/test_asdf_cutout.py
+++ b/astrocut/tests/test_asdf_cutout.py
@@ -181,6 +181,56 @@ def test_asdf_cutout(images, center_coord, cutout_size):
 
 
 @pytest.mark.parametrize("lite", [False, True])
+def test_asdf_cutout_get_cutouts(images, multi_coord, cutout_size, lite):
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout = ASDFCutout(images, multi_coord, cutout_size, lite=lite)
+
+    # No filters returns all generated cutouts.
+    all_rows = cutout.get_cutouts()
+    assert isinstance(all_rows, Table)
+    assert len(all_rows) == len(cutout.cutouts)
+    for row in all_rows:
+        assert isinstance(row["coordinate"], SkyCoord)
+        assert isinstance(row["cutout"], Cutout2D)
+
+    # With input files and coordinates specified.
+    cutout_rows = cutout.get_cutouts(input_files=images[1:], coordinates=multi_coord[1:])
+    assert isinstance(cutout_rows, Table)
+    assert len(cutout_rows) == 3  # one coordinate will not have a cutout for one of the images
+    for row in cutout_rows:
+        assert row["file"] in {image.as_posix() for image in images[1:]}
+        assert isinstance(row["cutout"], Cutout2D)
+
+    # Error if a file is not found.
+    with pytest.raises(InvalidInputError, match="is not in the cutout results."):
+        cutout.get_cutouts(input_files=["nonexistent_file.asdf"], coordinates=multi_coord[1:])
+
+    # Error if a coordinate is not found.
+    with pytest.raises(InvalidInputError, match="is not in the cutout results."):
+        cutout.get_cutouts(input_files=images[1:], coordinates=[SkyCoord("0 0", unit="deg")])
+
+    # Error if invalid coordinate string is provided.
+    with pytest.raises(InvalidInputError, match="Invalid coordinate string"):
+        cutout.get_cutouts(input_files=images[1:], coordinates=["invalid_coord"])
+
+    # Error if invalid coordinate type is provided.
+    with pytest.raises(InvalidInputError, match="is not a valid SkyCoord or string"):
+        cutout.get_cutouts(input_files=images[1:], coordinates=[12345])
+
+
+def test_asdf_cutout_iter_cutouts(images, multi_coord, cutout_size):
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout = ASDFCutout(images, multi_coord, cutout_size)
+
+    cutout_rows = list(cutout.iter_cutouts(input_files=images[1:], coordinates=multi_coord[1:]))
+    assert len(cutout_rows) == 3
+    for file, coordinate, cutout_obj in cutout_rows:
+        assert file in {image.as_posix() for image in images[1:]}
+        assert isinstance(coordinate, SkyCoord)
+        assert isinstance(cutout_obj, Cutout2D)
+
+
+@pytest.mark.parametrize("lite", [False, True])
 def test_asdf_cutout_get_asdf_cutouts(images, multi_coord, cutout_size, lite):
     with pytest.warns(DataWarning, match="does not overlap the image"):
         cutout = ASDFCutout(images, multi_coord, cutout_size, lite=lite)
@@ -195,22 +245,6 @@ def test_asdf_cutout_get_asdf_cutouts(images, multi_coord, cutout_size, lite):
         assert "roman" in af
         assert "data" in af["roman"]
         assert af["roman"]["data"].shape == (cutout_size, cutout_size)
-
-    # Error if a file is not found
-    with pytest.raises(InvalidInputError, match="is not in the cutout results."):
-        cutout.get_asdf_cutouts(input_files=["nonexistent_file.asdf"], coordinates=multi_coord[1:])
-
-    # Error if a coordinate is not found
-    with pytest.raises(InvalidInputError, match="is not in the cutout results."):
-        cutout.get_asdf_cutouts(input_files=images[1:], coordinates=[SkyCoord("0 0", unit="deg")])
-
-    # Error if invalid coordinate string is provided
-    with pytest.raises(InvalidInputError, match="Invalid coordinate string"):
-        cutout.get_asdf_cutouts(input_files=images[1:], coordinates=["invalid_coord"])
-
-    # Error if invalid coordinate type is provided
-    with pytest.raises(InvalidInputError, match="is not a valid SkyCoord or string"):
-        cutout.get_asdf_cutouts(input_files=images[1:], coordinates=[12345])
 
 
 def test_asdf_cutout_iter_asdf_cutouts(images, multi_coord, cutout_size):

--- a/astrocut/tests/test_asdf_cutout.py
+++ b/astrocut/tests/test_asdf_cutout.py
@@ -12,7 +12,9 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.modeling import models
 from astropy.nddata import Cutout2D
+from astropy.table import Table
 from astropy.time import Time
+from astropy.wcs import WCS
 from gwcs import coordinate_frames, wcs
 from PIL import Image
 
@@ -50,36 +52,30 @@ def make_wcs(xsize, ysize, ra=30.0, dec=45.0):
     return wcs.WCS([(detector_frame, det2sky), (sky_frame, None)])
 
 
-@pytest.fixture()
-def makefake():
+def make_fake(nx, ny, ra, dec, zero=False, asint=False):
     """Fixture factory to make a fake gwcs and dataset"""
+    wcsobj = make_wcs(nx / 2, ny / 2, ra=ra, dec=dec)
+    wcsobj.bounding_box = ((0, nx), (0, ny))
 
-    def _make_fake(nx, ny, ra, dec, zero=False, asint=False):
-        # create the wcs
-        wcsobj = make_wcs(nx / 2, ny / 2, ra=ra, dec=dec)
-        wcsobj.bounding_box = ((0, nx), (0, ny))
+    # create the data
+    if zero:
+        data = np.zeros([nx, ny])
+    else:
+        size = nx * ny
+        data = np.arange(size).reshape(nx, ny)
 
-        # create the data
-        if zero:
-            data = np.zeros([nx, ny])
-        else:
-            size = nx * ny
-            data = np.arange(size).reshape(nx, ny)
+    # make a quantity
+    data *= u.electron / u.second
 
-        # make a quantity
-        data *= u.electron / u.second
+    # make integer array
+    if asint:
+        data = data.astype(int)
 
-        # make integer array
-        if asint:
-            data = data.astype(int)
-
-        return data, wcsobj
-
-    yield _make_fake
+    return data, wcsobj
 
 
 @pytest.fixture()
-def fakedata(makefake):
+def fake_data():
     """Fixture to create fake data and wcs"""
     # set up initial parameters
     nx = 1000
@@ -87,41 +83,41 @@ def fakedata(makefake):
     ra = 30.0
     dec = 45.0
 
-    yield makefake(nx, ny, ra, dec)
+    yield make_fake(nx, ny, ra, dec)
 
 
 @pytest.fixture()
-def images(tmp_path, fakedata):
+def images(tmp_path):
     """Fixture to create a fake dataset of 3 images"""
-    # get the fake data
-    data, wcsobj = fakedata
-
-    # create meta
-    meta = {
-        "wcs": wcsobj,
-        "product_type": "l2",
-        "origin": "STSCI/SOC",
-        "file_date": Time("2023-10-01T00:00:00", format="isot"),
-    }
-
-    # create and write the asdf file
-    tree = {
-        "roman": {
-            "meta": meta,
-            "data": data,
-            "dq": data.astype(int),  # DQ is typically an integer array
-            "err": data,
-            "context": np.expand_dims(data, axis=0),
-            "invalid_dims": np.ndarray(shape=(10)),
-        }
-    }
-    af = asdf.AsdfFile(tree)
-
     path = tmp_path / "roman"
     path.mkdir(exist_ok=True)
 
     files = []
     for i in range(3):
+        # get the fake data
+        data, wcsobj = make_fake(1000, 1000, 30.0 + i * 0.001, 45.0 + i * 0.001)
+
+        # create meta
+        meta = {
+            "wcs": wcsobj,
+            "product_type": "l2",
+            "origin": "STSCI/SOC",
+            "file_date": Time("2023-10-01T00:00:00", format="isot"),
+        }
+
+        # create and write the asdf file
+        tree = {
+            "roman": {
+                "meta": meta,
+                "data": data,
+                "dq": data.astype(int),  # DQ is typically an integer array
+                "err": data,
+                "context": np.expand_dims(data, axis=0),
+                "invalid_dims": np.ndarray(shape=(10)),
+            }
+        }
+        af = asdf.AsdfFile(tree)
+
         filename = path / f"test_roman_{i}.asdf"
         af.write_to(filename)
         files.append(filename)
@@ -133,6 +129,16 @@ def images(tmp_path, fakedata):
 def center_coord():
     """Fixture to return a center coordinate"""
     return SkyCoord("29.99901792 44.99930555", unit="deg")
+
+
+@pytest.fixture
+def multi_coord():
+    """Fixture to return a list of coordinates"""
+    return [
+        SkyCoord("29.99901792 44.99930555", unit="deg"),
+        SkyCoord("30.00098208 44.99930555", unit="deg"),
+        SkyCoord("29.98201792 45.00069445", unit="deg"),
+    ]
 
 
 @pytest.fixture
@@ -148,27 +154,63 @@ def test_asdf_cutout(images, center_coord, cutout_size):
     assert isinstance(cutouts, list)
     assert isinstance(cutouts[0], Cutout2D)
     assert len(cutouts) == 3
-    assert isinstance(cutout.asdf_cutouts, list)
-    assert isinstance(cutout.asdf_cutouts[0], asdf.AsdfFile)
-    assert isinstance(cutout.fits_cutouts, list)
-    assert isinstance(cutout.fits_cutouts[0], fits.HDUList)
+    assert isinstance(cutout.asdf_cutouts, Table)
+    assert isinstance(cutout.asdf_cutouts["cutout"][0], asdf.AsdfFile)
+    assert isinstance(cutout.fits_cutouts, Table)
+    assert isinstance(cutout.fits_cutouts["cutout"][0], fits.HDUList)
 
     # Open output files
     for i, cutout in enumerate(cutouts):
         # Check shape of data
         cutout_data = cutout.data
         cutout_wcs = cutout.wcs
+        bbox = cutouts[i].bbox_original
         assert cutout_data.shape == (10, 10)
 
         # Check that data is equal between cutout and original image
         with asdf.open(images[i]) as input_af:
-            assert np.all(cutout_data == input_af["roman"]["data"].value[470:480, 471:481])
+            assert np.all(
+                cutout_data == input_af["roman"]["data"].value[bbox[0][0] : bbox[0][1] + 1, bbox[1][0] : bbox[1][1] + 1]
+            )
 
         # Check WCS and that center coordinate matches input
         s_coord = cutout_wcs.pixel_to_world(cutout_size / 2, cutout_size / 2)
         assert cutout_wcs.pixel_shape == (10, 10)
         assert np.isclose(s_coord.ra.deg, center_coord.ra.deg)
         assert np.isclose(s_coord.dec.deg, center_coord.dec.deg)
+
+
+def test_asdf_cutout_get_asdf_cutouts(images, multi_coord, cutout_size):
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout = ASDFCutout(images, multi_coord, cutout_size)
+
+    # With input files and coordinates specified
+    # Choose 2 files and 2 coordinates
+    asdf_cutouts = cutout.get_asdf_cutouts(input_files=images[1:], coordinates=multi_coord[1:])
+    assert isinstance(asdf_cutouts, Table)
+    assert len(asdf_cutouts) == 3  # one coordinate will not have a cutout for one of the images
+    for af in asdf_cutouts["cutout"]:
+        assert isinstance(af, asdf.AsdfFile)
+        assert "roman" in af
+        assert "data" in af["roman"]
+        assert af["roman"]["data"].shape == (cutout_size, cutout_size)
+
+
+def test_asdf_cutout_get_fits_cutouts(images, multi_coord, cutout_size):
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout = ASDFCutout(images, multi_coord, cutout_size)
+
+    # With input files and coordinates specified
+    # Choose 2 files and 2 coordinates
+    fits_cutouts = cutout.get_fits_cutouts(input_files=images[1:], coordinates=multi_coord[1:])
+    assert isinstance(fits_cutouts, Table)
+    assert len(fits_cutouts) == 3  # one coordinate will not have a cutout for one of the images
+    for hdul in fits_cutouts["cutout"]:
+        assert isinstance(hdul, fits.HDUList)
+        assert len(hdul) == 2 if not HAS_ASDF_IN_FITS else 3  # primary + cutout HDU + optional ASDF extension
+        assert hdul[0].name == "PRIMARY"
+        assert hdul[1].name == "CUTOUT"
+        assert hdul[1].data.shape == (cutout_size, cutout_size)
 
 
 def test_asdf_cutout_write_to_file(images, center_coord, cutout_size, tmpdir):
@@ -266,12 +308,12 @@ def test_asdf_cutout_lite(images, center_coord, cutout_size):
 
     # Write cutouts to ASDF objects in lite mode
     cutout = ASDFCutout(images, center_coord, cutout_size, lite=True)
-    for af in cutout.asdf_cutouts:
+    for af in cutout.asdf_cutouts["cutout"]:
         check_lite_metadata(af)
 
     # Write cutouts to HDUList objects in lite mode
     cutout = ASDFCutout(images, center_coord, cutout_size, lite=True)
-    for hdul in cutout.fits_cutouts:
+    for hdul in cutout.fits_cutouts["cutout"]:
         assert len(hdul) == 3 if HAS_ASDF_IN_FITS else 2  # primary HDU + cutout HDU + embedded ASDF extension
         assert hdul[0].name == "PRIMARY"
         assert hdul[1].name == "CUTOUT"
@@ -288,7 +330,7 @@ def test_asdf_cutout_partial(images, center_coord, cutout_size):
     center_coord = SkyCoord("29.99901792 44.9861", unit="deg")
     asdf_cutout = ASDFCutout(images[0], center_coord, cutout_size, lite=False)
     cutout = asdf_cutout.cutouts[0]
-    cutout_asdf = asdf_cutout.asdf_cutouts[0]
+    cutout_asdf = list(asdf_cutout.asdf_cutouts["cutout"])[0]
     assert cutout.data.shape == (10, 10)
     assert np.isnan(cutout.data[: cutout_size // 2, :]).all()
     assert np.isnan(cutout_asdf["roman"]["err"][: cutout_size // 2, :]).all()
@@ -310,20 +352,21 @@ def test_asdf_cutout_partial(images, center_coord, cutout_size):
     center_coord = SkyCoord("30.01961 44.99930555", unit="deg")
     asdf_cutout = ASDFCutout(images[0], center_coord, cutout_size, fill_value=1.5, lite=False)
     cutout = asdf_cutout.cutouts[0]
+    cutout_asdf = list(asdf_cutout.asdf_cutouts["cutout"])[0]
     assert np.all(cutout.data[:, cutout_size // 2 :] == 1.5)
     # Convert to integer fill value for DQ array
-    assert np.all(asdf_cutout.asdf_cutouts[0]["roman"]["dq"][:, cutout_size // 2 :] == 1)
+    assert np.all(cutout_asdf["roman"]["dq"][:, cutout_size // 2 :] == 1)
 
     # Error if unexpected fill value
     with pytest.raises(InvalidInputError, match="Fill value must be an integer or a float."):
         ASDFCutout(images[0], center_coord, cutout_size, fill_value="invalid")
 
 
-def test_asdf_cutout_poles(cutout_size, makefake, tmp_path):
+def test_asdf_cutout_poles(cutout_size, tmp_path):
     """Test we can make cutouts around poles"""
     # Make fake zero data around the pole
     ra, dec = 315.0, 89.995
-    data, gwcs = makefake(1000, 1000, ra, dec, zero=True)
+    data, gwcs = make_fake(1000, 1000, ra, dec, zero=True)
 
     # Add some values (5x5 array)
     data.value[245:250, 245:250] = 1
@@ -353,7 +396,7 @@ def test_asdf_cutout_poles(cutout_size, makefake, tmp_path):
 
 def test_asdf_cutout_not_in_footprint(images, center_coord, cutout_size):
     # Throw error if cutout location is not in image footprint
-    with pytest.warns(DataWarning, match="Cutout footprint does not overlap"):
+    with pytest.warns(DataWarning, match="does not overlap"):
         with pytest.raises(InvalidQueryError, match="Cutout contains no data!"):
             ASDFCutout(images[0], SkyCoord("0 0", unit="deg"), cutout_size)
 
@@ -403,12 +446,12 @@ def test_asdf_cutout_img_output(images, center_coord, cutout_size, tmpdir):
     # Save to memory only
     img_cutouts = ASDFCutout(images[0], center_coord, cutout_size).get_image_cutouts()
     assert len(img_cutouts) == 1
-    assert isinstance(img_cutouts[0], Image.Image)
-    assert np.array(img_cutouts[0]).shape == (10, 10)
+    assert isinstance(img_cutouts["cutout"][0], Image.Image)
+    assert np.array(img_cutouts["cutout"][0]).shape == (10, 10)
 
     # Color image
     color_jpg = ASDFCutout(images, center_coord, cutout_size).write_as_img(output_dir=tmpdir, colorize=True)
-    img = Image.open(color_jpg)
+    img = Image.open(color_jpg[0])
     assert img.mode == "RGB"
 
 
@@ -417,13 +460,13 @@ def test_asdf_cutout_cube_angular_size(images, center_coord):
     cutout = ASDFCutout(images[0], center_coord, 2 * u.arcsec, lite=False)
 
     assert cutout.cutouts[0].data.shape == (20, 20)
-    assert cutout.asdf_cutouts[0]["roman"]["context"].shape == (1, 20, 20)
+    assert list(cutout.asdf_cutouts["cutout"])[0]["roman"]["context"].shape == (1, 20, 20)
 
 
 def test_asdf_cutout_gwcs(images, center_coord):
     """Test creating a rectangular cutout to make sure cutout gwcs is correct"""
     cutout = ASDFCutout(images[0], center_coord, cutout_size=[20, 40])
-    asdf_cutouts = cutout.asdf_cutouts
+    asdf_cutouts = cutout.asdf_cutouts["cutout"]
     gwcs = asdf_cutouts[0]["roman"]["meta"]["wcs"]
     assert isinstance(gwcs, wcs.WCS)
     assert gwcs.pixel_shape == (20, 40)
@@ -451,7 +494,7 @@ def test_asdf_cutout_stdatamodels(images, center_coord, cutout_size, is_installe
         with patch("sys.version_info", (3, 11, 0)):
             with pytest.warns(ModuleWarning, match=warn_msg):
                 cutout = ASDFCutout(images, center_coord, cutout_size)
-                fits_cutouts = cutout.fits_cutouts
+                fits_cutouts = cutout.fits_cutouts["cutout"]
             assert len(fits_cutouts[0]) == 2  # primary + cutout HDU only
 
 
@@ -460,26 +503,39 @@ def test_asdf_cutout_python_version(images, center_coord, cutout_size):
     with patch("sys.version_info", (3, 10, 0)):
         with pytest.warns(ModuleWarning, match="requires Python 3.11 or higher"):
             cutout = ASDFCutout(images, center_coord, cutout_size)
-            fits_cutouts = cutout.fits_cutouts
+            fits_cutouts = cutout.fits_cutouts["cutout"]
         assert cutout._py311_or_higher is False
         assert cutout._asdf_in_fits is None
         assert len(fits_cutouts[0]) == 2  # primary + cutout HDU only
 
 
-def test_get_center_pixel(fakedata):
+def test_asdf_cutout_convert_gwcs_to_fits_wcs(fake_data):
+    """Test that we can convert a gwcs to a FITS WCS for cutout output"""
+    # Get the fake data
+    __, gwcs = fake_data
+
+    cutout = ASDFCutout.__new__(ASDFCutout)  # create instance without calling __init__
+    fits_wcs = cutout._convert_gwcs_to_fits_wcs(gwcs)
+    print(fits_wcs)
+    assert isinstance(fits_wcs, WCS)
+    assert fits_wcs.pixel_shape == (1001, 1001)
+    assert fits_wcs.wcs.crval[0] == 30.0
+    assert fits_wcs.wcs.crval[1] == 45.0
+
+
+def test_get_center_pixel(fake_data):
     """Test get_center_pixel function"""
     # Get the fake data
-    __, gwcs = fakedata
+    __, gwcs = fake_data
 
     # Using center coordinates
-    pixel_coordinates, wcs = get_center_pixel(gwcs, 30, 45)
+    pixel_coordinates = get_center_pixel(gwcs, 30, 45)
     assert np.allclose(pixel_coordinates, (np.array(500), np.array(500)))
-    assert np.allclose(wcs.celestial.wcs.crval, np.array([30, 45]))
 
     # Using upper left corner
     # Running this without parametrization to make sure that gwcs is not corrupted
-    ra, dec = wcs.all_pix2world(0, 0, 0)
-    pixel_coordinates, wcs = get_center_pixel(gwcs, ra, dec)
+    coord = gwcs.pixel_to_world(0, 0)
+    pixel_coordinates = get_center_pixel(gwcs, coord.ra.deg, coord.dec.deg)
     assert np.allclose(pixel_coordinates, (np.array(0), np.array(0)))
 
 

--- a/astrocut/tests/test_asdf_cutout.py
+++ b/astrocut/tests/test_asdf_cutout.py
@@ -151,8 +151,8 @@ def test_asdf_cutout(images, center_coord, cutout_size):
     cutout = ASDFCutout(images, center_coord, cutout_size)
     cutouts = cutout.cutouts
     # Should output a list of strings for multiple input files
-    assert isinstance(cutouts, list)
-    assert isinstance(cutouts[0], Cutout2D)
+    assert isinstance(cutouts, Table)
+    assert isinstance(cutouts["cutout"][0], Cutout2D)
     assert len(cutouts) == 3
     assert isinstance(cutout.asdf_cutouts, Table)
     assert isinstance(cutout.asdf_cutouts["cutout"][0], asdf.AsdfFile)
@@ -160,11 +160,11 @@ def test_asdf_cutout(images, center_coord, cutout_size):
     assert isinstance(cutout.fits_cutouts["cutout"][0], fits.HDUList)
 
     # Open output files
-    for i, cutout in enumerate(cutouts):
+    for i, cutout_row in enumerate(cutouts):
         # Check shape of data
-        cutout_data = cutout.data
-        cutout_wcs = cutout.wcs
-        bbox = cutouts[i].bbox_original
+        cutout_data = cutout_row["cutout"].data
+        cutout_wcs = cutout_row["cutout"].wcs
+        bbox = cutout_row["cutout"].bbox_original
         assert cutout_data.shape == (10, 10)
 
         # Check that data is equal between cutout and original image
@@ -196,6 +196,20 @@ def test_asdf_cutout_get_asdf_cutouts(images, multi_coord, cutout_size):
         assert af["roman"]["data"].shape == (cutout_size, cutout_size)
 
 
+def test_asdf_cutout_iter_asdf_cutouts(images, multi_coord, cutout_size):
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout = ASDFCutout(images, multi_coord, cutout_size)
+
+    asdf_cutouts = list(cutout.iter_asdf_cutouts(input_files=images[1:], coordinates=multi_coord[1:]))
+    assert len(asdf_cutouts) == 3
+    for file, coordinate, af in asdf_cutouts:
+        assert file in {image.as_posix() for image in images[1:]}
+        assert isinstance(coordinate, SkyCoord)
+        assert isinstance(af, asdf.AsdfFile)
+        assert "roman" in af
+        assert af["roman"]["data"].shape == (cutout_size, cutout_size)
+
+
 def test_asdf_cutout_get_fits_cutouts(images, multi_coord, cutout_size):
     with pytest.warns(DataWarning, match="does not overlap the image"):
         cutout = ASDFCutout(images, multi_coord, cutout_size)
@@ -213,6 +227,59 @@ def test_asdf_cutout_get_fits_cutouts(images, multi_coord, cutout_size):
         assert hdul[1].data.shape == (cutout_size, cutout_size)
 
 
+def test_asdf_cutout_iter_fits_cutouts(images, multi_coord, cutout_size):
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout = ASDFCutout(images, multi_coord, cutout_size)
+
+    fits_cutouts = list(cutout.iter_fits_cutouts(input_files=images[1:], coordinates=multi_coord[1:]))
+    assert len(fits_cutouts) == 3
+    for file, coordinate, hdul in fits_cutouts:
+        assert file in {image.as_posix() for image in images[1:]}
+        assert isinstance(coordinate, SkyCoord)
+        assert isinstance(hdul, fits.HDUList)
+        assert len(hdul) == 2 if not HAS_ASDF_IN_FITS else 3
+        assert hdul[0].name == "PRIMARY"
+        assert hdul[1].name == "CUTOUT"
+        assert hdul[1].data.shape == (cutout_size, cutout_size)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kwargs", "blocked_getter"),
+    [
+        ("write_as_asdf", {"output_dir": "."}, "get_asdf_cutouts"),
+        ("write_as_fits", {"output_dir": "."}, "get_fits_cutouts"),
+        ("write_as_zip", {"output_dir": ".", "output_format": ".asdf"}, "get_asdf_cutouts"),
+        ("write_as_zip", {"output_dir": ".", "output_format": ".fits"}, "get_fits_cutouts"),
+    ],
+)
+def test_asdf_cutout_write_streams_from_iterators(
+    images,
+    center_coord,
+    cutout_size,
+    tmpdir,
+    method_name,
+    kwargs,
+    blocked_getter,
+):
+    cutout = ASDFCutout(images, center_coord, cutout_size)
+    call_kwargs = dict(kwargs)
+    call_kwargs["output_dir"] = tmpdir
+
+    with patch.object(
+        ASDFCutout,
+        blocked_getter,
+        side_effect=AssertionError(f"{blocked_getter} should not be used"),
+    ):
+        output = getattr(cutout, method_name)(**call_kwargs)
+
+    if isinstance(output, list):
+        assert len(output) == len(images)
+        for file_path in output:
+            assert Path(file_path).exists()
+    else:
+        assert Path(output).exists()
+
+
 def test_asdf_cutout_write_to_file(images, center_coord, cutout_size, tmpdir):
     def check_asdf_metadata(af, original_file, cutout_data, meta_only=False):
         """Check that ASDF file contains correct metadata"""
@@ -224,6 +291,7 @@ def test_asdf_cutout_write_to_file(images, center_coord, cutout_size, tmpdir):
         assert meta["file_date"] == Time("2023-10-01T00:00:00", format="isot")
         assert meta["origin"] == "STSCI/SOC"
         assert meta["orig_file"] == original_file.as_posix()
+        assert meta["coordinate"] == center_coord.to_string(precision=8)
 
         if not meta_only:
             # Check cutout data and metadata
@@ -237,7 +305,7 @@ def test_asdf_cutout_write_to_file(images, center_coord, cutout_size, tmpdir):
     assert len(asdf_files) == 3
     for i, asdf_file in enumerate(asdf_files):
         with asdf.open(asdf_file) as af:
-            check_asdf_metadata(af, images[i], cutout.cutouts[i].data)
+            check_asdf_metadata(af, images[i], cutout.cutouts["cutout"][i].data)
             # Check file size is smaller than original
             assert Path(asdf_file).stat().st_size < Path(images[i]).stat().st_size
 
@@ -249,7 +317,7 @@ def test_asdf_cutout_write_to_file(images, center_coord, cutout_size, tmpdir):
         with fits.open(fits_file) as hdul:
             assert hdul[0].name == "PRIMARY"
             assert hdul[1].name == "CUTOUT"
-            assert np.all(hdul[1].data == cutout.cutouts[i].data)
+            assert np.all(hdul[1].data == cutout.cutouts["cutout"][i].data)
             assert hdul[1].header["NAXIS1"] == 10
             assert hdul[1].header["NAXIS2"] == 10
             assert hdul[1].header["ORIG_FLE"] == images[i].as_posix()
@@ -257,7 +325,7 @@ def test_asdf_cutout_write_to_file(images, center_coord, cutout_size, tmpdir):
 
         if HAS_ASDF_IN_FITS:
             with asdf_in_fits.open(fits_file) as af:
-                check_asdf_metadata(af, images[i], cutout.cutouts[i].data, meta_only=True)
+                check_asdf_metadata(af, images[i], cutout.cutouts["cutout"][i].data, meta_only=True)
 
 
 @pytest.mark.parametrize("output_format", [".asdf", ".fits"])
@@ -301,8 +369,9 @@ def test_asdf_cutout_lite(images, center_coord, cutout_size):
         assert "meta" in af["roman"]
         assert "wcs" in af["roman"]["meta"]
         assert "orig_file" in af["roman"]["meta"]
+        assert "coordinate" in af["roman"]["meta"]
         assert len(af["roman"]) == (1 if meta_only else 2)
-        assert len(af["roman"]["meta"]) == 2  # only wcs and original filename
+        assert len(af["roman"]["meta"]) == 3  # only wcs, original filename, and coordinate
         if not meta_only:
             assert "data" in af["roman"]
 
@@ -329,7 +398,7 @@ def test_asdf_cutout_partial(images, center_coord, cutout_size):
     # Off the top
     center_coord = SkyCoord("29.99901792 44.9861", unit="deg")
     asdf_cutout = ASDFCutout(images[0], center_coord, cutout_size, lite=False)
-    cutout = asdf_cutout.cutouts[0]
+    cutout = asdf_cutout.cutouts["cutout"][0]
     cutout_asdf = list(asdf_cutout.asdf_cutouts["cutout"])[0]
     assert cutout.data.shape == (10, 10)
     assert np.isnan(cutout.data[: cutout_size // 2, :]).all()
@@ -340,18 +409,18 @@ def test_asdf_cutout_partial(images, center_coord, cutout_size):
 
     # Off the bottom
     center_coord = SkyCoord("29.99901792 45.01387", unit="deg")
-    cutout = ASDFCutout(images[0], center_coord, cutout_size).cutouts[0]
+    cutout = ASDFCutout(images[0], center_coord, cutout_size).cutouts["cutout"][0]
     assert np.isnan(cutout.data[cutout_size // 2 :, :]).all()
 
     # Off the left, with integer fill value
     center_coord = SkyCoord("29.98035835 44.99930555", unit="deg")
-    cutout = ASDFCutout(images[0], center_coord, cutout_size, fill_value=1).cutouts[0]
+    cutout = ASDFCutout(images[0], center_coord, cutout_size, fill_value=1).cutouts["cutout"][0]
     assert np.all(cutout.data[:, : cutout_size // 2] == 1)
 
     # Off the right, with float fill value
     center_coord = SkyCoord("30.01961 44.99930555", unit="deg")
     asdf_cutout = ASDFCutout(images[0], center_coord, cutout_size, fill_value=1.5, lite=False)
-    cutout = asdf_cutout.cutouts[0]
+    cutout = asdf_cutout.cutouts["cutout"][0]
     cutout_asdf = list(asdf_cutout.asdf_cutouts["cutout"])[0]
     assert np.all(cutout.data[:, cutout_size // 2 :] == 1.5)
     # Convert to integer fill value for DQ array
@@ -388,7 +457,7 @@ def test_asdf_cutout_poles(cutout_size, tmp_path):
     af.write_to(filename)
 
     # Get cutout
-    cutout = ASDFCutout(filename, center_coord, cutout_size).cutouts[0]
+    cutout = ASDFCutout(filename, center_coord, cutout_size).cutouts["cutout"][0]
 
     # Check cutout contains all data
     assert len(np.where(cutout.data == 1)[0]) == 25
@@ -455,11 +524,52 @@ def test_asdf_cutout_img_output(images, center_coord, cutout_size, tmpdir):
     assert img.mode == "RGB"
 
 
+def test_asdf_cutout_iter_image_cutouts(images, center_coord, cutout_size):
+    cutout = ASDFCutout(images, center_coord, cutout_size)
+
+    image_cutouts = list(cutout.iter_image_cutouts(input_files=images[1:]))
+    assert len(image_cutouts) == 2
+    for file, coordinate, image in image_cutouts:
+        assert file in {image_path.as_posix() for image_path in images[1:]}
+        assert isinstance(coordinate, SkyCoord)
+        assert isinstance(image, Image.Image)
+        assert np.array(image).shape == (cutout_size, cutout_size)
+
+
+def test_asdf_cutout_iter_image_cutouts_colorize(images, center_coord, cutout_size):
+    cutout = ASDFCutout(images, center_coord, cutout_size)
+
+    image_cutouts = list(cutout.iter_image_cutouts(colorize=True))
+    assert len(image_cutouts) == 1
+    files, coordinate, image = image_cutouts[0]
+    assert all(image_path.as_posix() in files for image_path in images)
+    assert isinstance(coordinate, SkyCoord)
+    assert isinstance(image, Image.Image)
+    assert image.mode == "RGB"
+
+
+@pytest.mark.parametrize("colorize", [False, True])
+def test_asdf_cutout_write_img_streams_from_iterator(images, center_coord, cutout_size, tmpdir, colorize):
+    cutout = ASDFCutout(images, center_coord, cutout_size)
+
+    with patch.object(
+        ASDFCutout,
+        "get_image_cutouts",
+        side_effect=AssertionError("get_image_cutouts should not be used"),
+    ):
+        output = cutout.write_as_img(output_dir=tmpdir, colorize=colorize)
+
+    expected_count = 1 if colorize else len(images)
+    assert len(output) == expected_count
+    for file_path in output:
+        assert Path(file_path).exists()
+
+
 def test_asdf_cutout_cube_angular_size(images, center_coord):
     """Test that cube-like arrays use the computed cutout shape for angular sizes."""
     cutout = ASDFCutout(images[0], center_coord, 2 * u.arcsec, lite=False)
 
-    assert cutout.cutouts[0].data.shape == (20, 20)
+    assert cutout.cutouts["cutout"][0].data.shape == (20, 20)
     assert cutout.asdf_cutouts["cutout"][0]["roman"]["context"].shape == (1, 20, 20)
 
 
@@ -515,6 +625,7 @@ def test_asdf_cutout_convert_gwcs_to_fits_wcs(fake_data):
     __, gwcs = fake_data
 
     cutout = ASDFCutout.__new__(ASDFCutout)  # create instance without calling __init__
+    cutout._gwcs_to_fits_cache = {}  # initialize cache
     fits_wcs = cutout._convert_gwcs_to_fits_wcs(gwcs)
     assert isinstance(fits_wcs, WCS)
     assert fits_wcs.pixel_shape == (1001, 1001)
@@ -563,12 +674,12 @@ def test_asdf_cut(images, center_coord, cutout_size, tmpdir):
     fits_paths = asdf_cut(
         images, center_coord.ra.deg, center_coord.dec.deg, cutout_size, output_dir=tmpdir, output_format="fits"
     )
-    check_paths = (fits_paths, ".fits")
+    check_paths(fits_paths, ".fits")
 
     # Write cutouts to memory as Cutout2D objects
     cutouts = asdf_cut(images, center_coord.ra.deg, center_coord.dec.deg, cutout_size, write_file=False)
-    assert isinstance(cutouts, list)
-    assert isinstance(cutouts[0], Cutout2D)
+    assert isinstance(cutouts, Table)
+    assert isinstance(cutouts["cutout"][0], Cutout2D)
     assert len(cutouts) == 3
 
     # Error if output format is not supported

--- a/astrocut/tests/test_asdf_cutout.py
+++ b/astrocut/tests/test_asdf_cutout.py
@@ -460,7 +460,7 @@ def test_asdf_cutout_cube_angular_size(images, center_coord):
     cutout = ASDFCutout(images[0], center_coord, 2 * u.arcsec, lite=False)
 
     assert cutout.cutouts[0].data.shape == (20, 20)
-    assert list(cutout.asdf_cutouts["cutout"])[0]["roman"]["context"].shape == (1, 20, 20)
+    assert cutout.asdf_cutouts["cutout"][0]["roman"]["context"].shape == (1, 20, 20)
 
 
 def test_asdf_cutout_gwcs(images, center_coord):
@@ -516,7 +516,6 @@ def test_asdf_cutout_convert_gwcs_to_fits_wcs(fake_data):
 
     cutout = ASDFCutout.__new__(ASDFCutout)  # create instance without calling __init__
     fits_wcs = cutout._convert_gwcs_to_fits_wcs(gwcs)
-    print(fits_wcs)
     assert isinstance(fits_wcs, WCS)
     assert fits_wcs.pixel_shape == (1001, 1001)
     assert fits_wcs.wcs.crval[0] == 30.0

--- a/astrocut/tests/test_asdf_cutout.py
+++ b/astrocut/tests/test_asdf_cutout.py
@@ -19,7 +19,7 @@ from gwcs import coordinate_frames, wcs
 from PIL import Image
 
 from astrocut.asdf_cutout import ASDFCutout, asdf_cut, get_center_pixel
-from astrocut.exceptions import DataWarning, InvalidInputError, InvalidQueryError, ModuleWarning
+from astrocut.exceptions import DataWarning, InputWarning, InvalidInputError, InvalidQueryError, ModuleWarning
 
 try:
     from stdatamodels import asdf_in_fits
@@ -137,7 +137,7 @@ def multi_coord():
     return [
         SkyCoord("29.99901792 44.99930555", unit="deg"),
         SkyCoord("30.00098208 44.99930555", unit="deg"),
-        SkyCoord("29.98201792 45.00069445", unit="deg"),
+        "29.98201792 45.00069445",
     ]
 
 
@@ -180,9 +180,10 @@ def test_asdf_cutout(images, center_coord, cutout_size):
         assert np.isclose(s_coord.dec.deg, center_coord.dec.deg)
 
 
-def test_asdf_cutout_get_asdf_cutouts(images, multi_coord, cutout_size):
+@pytest.mark.parametrize("lite", [False, True])
+def test_asdf_cutout_get_asdf_cutouts(images, multi_coord, cutout_size, lite):
     with pytest.warns(DataWarning, match="does not overlap the image"):
-        cutout = ASDFCutout(images, multi_coord, cutout_size)
+        cutout = ASDFCutout(images, multi_coord, cutout_size, lite=lite)
 
     # With input files and coordinates specified
     # Choose 2 files and 2 coordinates
@@ -194,6 +195,22 @@ def test_asdf_cutout_get_asdf_cutouts(images, multi_coord, cutout_size):
         assert "roman" in af
         assert "data" in af["roman"]
         assert af["roman"]["data"].shape == (cutout_size, cutout_size)
+
+    # Error if a file is not found
+    with pytest.raises(InvalidInputError, match="is not in the cutout results."):
+        cutout.get_asdf_cutouts(input_files=["nonexistent_file.asdf"], coordinates=multi_coord[1:])
+
+    # Error if a coordinate is not found
+    with pytest.raises(InvalidInputError, match="is not in the cutout results."):
+        cutout.get_asdf_cutouts(input_files=images[1:], coordinates=[SkyCoord("0 0", unit="deg")])
+
+    # Error if invalid coordinate string is provided
+    with pytest.raises(InvalidInputError, match="Invalid coordinate string"):
+        cutout.get_asdf_cutouts(input_files=images[1:], coordinates=["invalid_coord"])
+
+    # Error if invalid coordinate type is provided
+    with pytest.raises(InvalidInputError, match="is not a valid SkyCoord or string"):
+        cutout.get_asdf_cutouts(input_files=images[1:], coordinates=[12345])
 
 
 def test_asdf_cutout_iter_asdf_cutouts(images, multi_coord, cutout_size):
@@ -210,9 +227,10 @@ def test_asdf_cutout_iter_asdf_cutouts(images, multi_coord, cutout_size):
         assert af["roman"]["data"].shape == (cutout_size, cutout_size)
 
 
-def test_asdf_cutout_get_fits_cutouts(images, multi_coord, cutout_size):
+@pytest.mark.parametrize("lite", [False, True])
+def test_asdf_cutout_get_fits_cutouts(images, multi_coord, cutout_size, lite):
     with pytest.warns(DataWarning, match="does not overlap the image"):
-        cutout = ASDFCutout(images, multi_coord, cutout_size)
+        cutout = ASDFCutout(images, multi_coord, cutout_size, lite=lite)
 
     # With input files and coordinates specified
     # Choose 2 files and 2 coordinates
@@ -329,15 +347,16 @@ def test_asdf_cutout_write_to_file(images, center_coord, cutout_size, tmpdir):
 
 
 @pytest.mark.parametrize("output_format", [".asdf", ".fits"])
-def test_asdf_cutout_write_to_zip(tmpdir, images, center_coord, cutout_size, output_format):
+def test_asdf_cutout_write_to_zip(tmpdir, images, multi_coord, cutout_size, output_format):
     # Zip ASDF representations
-    cutout = ASDFCutout(images, center_coord, cutout_size)
+    cutout = ASDFCutout(images, multi_coord[:2], cutout_size)
     zip_path = cutout.write_as_zip(output_dir=tmpdir, output_format=output_format)
+    assert Path(zip_path).stem == f"astrocut_{output_format[1:]}_cutouts"
     assert Path(zip_path).exists()
 
     with zipfile.ZipFile(zip_path, "r") as zf:
         names = zf.namelist()
-        assert len(names) == len(images)
+        assert len(names) == 6  # 3 images * 2 coordinates = 6 cutouts
         for name in names:
             assert name.endswith(f"_astrocut{output_format}")
 
@@ -498,6 +517,10 @@ def test_asdf_cutout_invalid_params(images, center_coord, cutout_size, tmpdir):
     with pytest.raises(InvalidInputError, match="Cutout size unit meter is not supported."):
         ASDFCutout(images, center_coord, cutout_size)
 
+    # No coordinates provided
+    with pytest.raises(InvalidInputError, match="At least one coordinate must be provided."):
+        ASDFCutout(images, [], cutout_size)
+
 
 def test_asdf_cutout_img_output(images, center_coord, cutout_size, tmpdir):
     # Basic JPG image
@@ -518,10 +541,31 @@ def test_asdf_cutout_img_output(images, center_coord, cutout_size, tmpdir):
     assert isinstance(img_cutouts["cutout"][0], Image.Image)
     assert np.array(img_cutouts["cutout"][0]).shape == (10, 10)
 
+
+def test_asdf_cutout_img_output_colorize(images, multi_coord, cutout_size, tmpdir):
+    # Make a copy of one of the input images
+    with asdf.open(images[0], mode="rw") as af:
+        af["roman"]["data"] = af["roman"]["data"][::-1, ::-1]  # flip data to make it different
+        af.update()
+        af.write_to(images[0].with_name("test_roman_extra.asdf"))
+    images_extra = images + [images[0].with_name("test_roman_extra.asdf")]
+
     # Color image
-    color_jpg = ASDFCutout(images, center_coord, cutout_size).write_as_img(output_dir=tmpdir, colorize=True)
-    img = Image.open(color_jpg[0])
+    cutout = ASDFCutout(images_extra, multi_coord[:2], cutout_size)
+    color_jpgs = cutout.write_as_img(output_dir=tmpdir, colorize=True, input_files=images_extra[:3])
+    assert len(color_jpgs) == 2
+    img = Image.open(color_jpgs[0])
     assert img.mode == "RGB"
+
+    # Warn if not enough input files for colorization
+    with pytest.warns(InputWarning, match="Color cutouts require 3 input images"):
+        color_imgs = cutout.get_image_cutouts(colorize=True, input_files=images_extra[:2])
+    assert len(color_imgs) == 0
+
+    # Warn if too many input files for colorization
+    with pytest.warns(InputWarning, match="More than 3 cutouts found for coordinate"):
+        color_imgs = cutout.get_image_cutouts(colorize=True)
+    assert len(color_imgs) == 2
 
 
 def test_asdf_cutout_iter_image_cutouts(images, center_coord, cutout_size):

--- a/astrocut/tests/test_asdf_cutout.py
+++ b/astrocut/tests/test_asdf_cutout.py
@@ -142,6 +142,15 @@ def multi_coord():
 
 
 @pytest.fixture
+def multi_coord_skycoord_array():
+    """Fixture to return coordinates as one array-valued SkyCoord."""
+    return SkyCoord(
+        ["29.99901792 44.99930555", "30.00098208 44.99930555", "29.98201792 45.00069445"],
+        unit="deg",
+    )
+
+
+@pytest.fixture
 def cutout_size():
     """Fixture to return a cutout size"""
     return 10
@@ -218,6 +227,98 @@ def test_asdf_cutout_get_cutouts(images, multi_coord, cutout_size, lite):
         cutout.get_cutouts(input_files=images[1:], coordinates=[12345])
 
 
+def test_asdf_cutout_with_skycoord_array_input(images, multi_coord_skycoord_array, cutout_size):
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout = ASDFCutout(images, multi_coord_skycoord_array, cutout_size)
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout_list_input = ASDFCutout(images, list(multi_coord_skycoord_array), cutout_size)
+
+    all_rows = cutout.get_cutouts()
+    list_rows = cutout_list_input.get_cutouts()
+    assert isinstance(all_rows, Table)
+    assert len(all_rows) == len(list_rows)
+
+    input_coord_keys = {coord.to_string(precision=8) for coord in multi_coord_skycoord_array}
+    output_coord_keys = {row["coordinate"].to_string(precision=8) for row in all_rows}
+    assert output_coord_keys.issubset(input_coord_keys)
+
+
+def test_asdf_cutout_get_cutouts_filter_with_skycoord_array(images, multi_coord, cutout_size):
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout = ASDFCutout(images, multi_coord, cutout_size)
+
+    filter_coords = SkyCoord(["29.99901792 44.99930555", "30.00098208 44.99930555"], unit="deg")
+    filtered_rows = cutout.get_cutouts(input_files=images, coordinates=filter_coords)
+
+    assert isinstance(filtered_rows, Table)
+    assert len(filtered_rows) == 6
+    assert {row["coordinate"].to_string(precision=8) for row in filtered_rows} == {
+        coord.to_string(precision=8) for coord in filter_coords
+    }
+
+
+def test_asdf_cutout_get_cutouts_uses_cached_table_for_filtering(images, multi_coord, cutout_size):
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout = ASDFCutout(images, multi_coord, cutout_size)
+
+    cached_rows = cutout.cutouts
+    selected_file = cached_rows[0]["file"]
+    selected_coord = cached_rows[0]["coordinate"]
+    selected_cutout = cached_rows[0]["cutout"]
+
+    with patch.object(ASDFCutout, "iter_cutouts", side_effect=AssertionError("iter_cutouts should not be used")):
+        filtered_rows = cutout.get_cutouts(input_files=[selected_file], coordinates=[selected_coord])
+
+    assert len(filtered_rows) == 1
+    assert filtered_rows[0]["file"] == selected_file
+    assert filtered_rows[0]["coordinate"].to_string(precision=8) == selected_coord.to_string(precision=8)
+    assert filtered_rows[0]["cutout"] is selected_cutout
+
+
+def test_asdf_cutout_get_asdf_cutouts_uses_cached_table_for_filtering(images, multi_coord, cutout_size):
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout = ASDFCutout(images, multi_coord, cutout_size)
+
+    cached_rows = cutout.asdf_cutouts
+    selected_file = cached_rows[0]["file"]
+    selected_coord = cached_rows[0]["coordinate"]
+    selected_cutout = cached_rows[0]["cutout"]
+
+    with patch.object(
+        ASDFCutout,
+        "iter_asdf_cutouts",
+        side_effect=AssertionError("iter_asdf_cutouts should not be used"),
+    ):
+        filtered_rows = cutout.get_asdf_cutouts(input_files=[selected_file], coordinates=[selected_coord])
+
+    assert len(filtered_rows) == 1
+    assert filtered_rows[0]["file"] == selected_file
+    assert filtered_rows[0]["coordinate"].to_string(precision=8) == selected_coord.to_string(precision=8)
+    assert filtered_rows[0]["cutout"] is selected_cutout
+
+
+def test_asdf_cutout_get_fits_cutouts_uses_cached_table_for_filtering(images, multi_coord, cutout_size):
+    with pytest.warns(DataWarning, match="does not overlap the image"):
+        cutout = ASDFCutout(images, multi_coord, cutout_size)
+
+    cached_rows = cutout.fits_cutouts
+    selected_file = cached_rows[0]["file"]
+    selected_coord = cached_rows[0]["coordinate"]
+    selected_cutout = cached_rows[0]["cutout"]
+
+    with patch.object(
+        ASDFCutout,
+        "iter_fits_cutouts",
+        side_effect=AssertionError("iter_fits_cutouts should not be used"),
+    ):
+        filtered_rows = cutout.get_fits_cutouts(input_files=[selected_file], coordinates=[selected_coord])
+
+    assert len(filtered_rows) == 1
+    assert filtered_rows[0]["file"] == selected_file
+    assert filtered_rows[0]["coordinate"].to_string(precision=8) == selected_coord.to_string(precision=8)
+    assert filtered_rows[0]["cutout"] is selected_cutout
+
+
 def test_asdf_cutout_iter_cutouts(images, multi_coord, cutout_size):
     with pytest.warns(DataWarning, match="does not overlap the image"):
         cutout = ASDFCutout(images, multi_coord, cutout_size)
@@ -270,6 +371,7 @@ def test_asdf_cutout_get_fits_cutouts(images, multi_coord, cutout_size, lite):
     # Choose 2 files and 2 coordinates
     fits_cutouts = cutout.get_fits_cutouts(input_files=images[1:], coordinates=multi_coord[1:])
     assert isinstance(fits_cutouts, Table)
+    assert fits_cutouts["cutout"].dtype == object
     assert len(fits_cutouts) == 3  # one coordinate will not have a cutout for one of the images
     for hdul in fits_cutouts["cutout"]:
         assert isinstance(hdul, fits.HDUList)
@@ -695,6 +797,22 @@ def test_asdf_cutout_python_version(images, center_coord, cutout_size):
         assert cutout._py311_or_higher is False
         assert cutout._asdf_in_fits is None
         assert len(fits_cutouts[0]) == 2  # primary + cutout HDU only
+
+
+def test_asdf_cutout_passes_default_memmap_to_asdf_open(images, center_coord, cutout_size):
+    with patch("astrocut.asdf_cutout.asdf.open", wraps=asdf.open) as mock_asdf_open:
+        ASDFCutout(images[0], center_coord, cutout_size)
+
+    assert mock_asdf_open.call_count >= 1
+    assert all(call.kwargs.get("memmap") is True for call in mock_asdf_open.call_args_list)
+
+
+def test_asdf_cutout_passes_user_asdf_kwargs_to_asdf_open(images, center_coord, cutout_size):
+    with patch("astrocut.asdf_cutout.asdf.open", wraps=asdf.open) as mock_asdf_open:
+        ASDFCutout(images[0], center_coord, cutout_size, asdf_kwargs={"memmap": False})
+
+    assert mock_asdf_open.call_count >= 1
+    assert all(call.kwargs.get("memmap") is False for call in mock_asdf_open.call_args_list)
 
 
 def test_asdf_cutout_convert_gwcs_to_fits_wcs(fake_data):

--- a/astrocut/tests/test_image_cutout.py
+++ b/astrocut/tests/test_image_cutout.py
@@ -133,15 +133,6 @@ def test_coerce_coordinate_list_variants():
     assert ImageCutout._coerce_coordinate_list("1 2") == ["1 2"]
 
 
-def test_build_image_cutout_table_populates_cutout_column():
-    coord = SkyCoord("1 2", unit="deg")
-    img = Image.fromarray(np.zeros((3, 3), dtype=np.uint8))
-    table = ImageCutout._build_image_cutout_table([("file_1", coord, img), ("file_2", coord, img)])
-    assert len(table) == 2
-    assert table["file"][0] == "file_1"
-    assert table["cutout"][1] is img
-
-
 def test_build_cutout_metadata_with_string_coordinate():
     cutout = _DummyImageCutout()
     fake_cutout = _make_fake_cutout()

--- a/astrocut/tests/test_image_cutout.py
+++ b/astrocut/tests/test_image_cutout.py
@@ -1,9 +1,44 @@
 import numpy as np
 import pytest
+from astropy.coordinates import SkyCoord
+from astropy.wcs import WCS
+from PIL import Image
 
-from astrocut.image_cutout import ImageCutout
+from astrocut.image_cutout import ImageCutout, normalize_img
 
 from ..exceptions import InputWarning, InvalidInputError
+
+
+class _DummyImageCutout(ImageCutout):
+    """Minimal concrete ImageCutout for testing helper methods."""
+
+    def __init__(self):
+        # Avoid parent initialization and set only what tests need.
+        self._coordinates = SkyCoord("1 2", unit="deg")
+        self.cutouts_by_file = {}
+
+    def _cutout_file(self, file):
+        return None
+
+    def cutout(self):
+        return None
+
+
+def _make_fake_cutout(shape=(4, 6)):
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [1.0, 1.0]
+    wcs.wcs.crval = [30.0, 45.0]
+    wcs.wcs.cdelt = [-0.0002777778, 0.0002777778]
+    wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+
+    class _FakeCutout:
+        pass
+
+    cutout = _FakeCutout()
+    cutout.shape = shape
+    cutout.wcs = wcs
+    cutout.data = np.arange(shape[0] * shape[1], dtype=float).reshape(shape)
+    return cutout
 
 
 def test_normalize_img():
@@ -83,3 +118,88 @@ def test_normalize_img_errors():
     img_arr = np.array([])
     with pytest.raises(InvalidInputError):
         ImageCutout.normalize_img(img_arr)
+
+
+def test_prepare_render_options_invalid_stretch():
+    cutout = _DummyImageCutout()
+    with pytest.raises(InvalidInputError, match="is not recognized"):
+        cutout._prepare_image_render_options("bad-stretch", None, None)
+
+
+def test_coerce_coordinate_list_variants():
+    assert ImageCutout._coerce_coordinate_list(None) == []
+    assert ImageCutout._coerce_coordinate_list(["1 2"]) == ["1 2"]
+    assert ImageCutout._coerce_coordinate_list(("1 2", "3 4")) == ["1 2", "3 4"]
+    assert ImageCutout._coerce_coordinate_list("1 2") == ["1 2"]
+
+
+def test_build_image_cutout_table_populates_cutout_column():
+    coord = SkyCoord("1 2", unit="deg")
+    img = Image.fromarray(np.zeros((3, 3), dtype=np.uint8))
+    table = ImageCutout._build_image_cutout_table([("file_1", coord, img), ("file_2", coord, img)])
+    assert len(table) == 2
+    assert table["file"][0] == "file_1"
+    assert table["cutout"][1] is img
+
+
+def test_build_cutout_metadata_with_string_coordinate():
+    cutout = _DummyImageCutout()
+    fake_cutout = _make_fake_cutout()
+    meta = cutout._build_cutout_metadata(["input_a.fits", "input_b.fits"], fake_cutout, "30.0 45.0")
+    assert "input_files" in meta
+    assert meta["center_ra_deg"] == 30.0
+    assert meta["center_dec_deg"] == 45.0
+
+
+def test_iter_selected_cutouts_branches_and_errors():
+    cutout = _DummyImageCutout()
+    fake_cutout = _make_fake_cutout()
+    cutout.cutouts_by_file = {"file_a": [fake_cutout], "file_b": [fake_cutout]}
+
+    with pytest.raises(InvalidInputError, match="Selecting image cutouts by coordinates is not supported"):
+        list(cutout._iter_selected_cutouts(coordinates=[SkyCoord("1 2", unit="deg")]))
+
+    with pytest.raises(InvalidInputError, match="is not in the cutout results"):
+        list(cutout._iter_selected_cutouts(input_files=["missing_file"]))
+
+    rows = list(cutout._iter_selected_cutouts(input_files="file_a"))
+    assert len(rows) == 1
+    assert rows[0][0] == "file_a"
+    assert rows[0][2] is fake_cutout
+
+    # Default path selects all files from cutouts_by_file.
+    all_rows = list(cutout._iter_selected_cutouts())
+    assert len(all_rows) == 2
+
+
+def test_coord_object_and_colorize_helper_warnings():
+    cutout = _DummyImageCutout()
+
+    coord = cutout._coerce_coord_object("30.0 45.0")
+    assert isinstance(coord, SkyCoord)
+
+    with pytest.warns(InputWarning, match="Too many inputs for a color cutout"):
+        cutout._warn_too_many_color_cutouts(coord)
+
+    with pytest.raises(InvalidInputError, match="Color cutouts require 3 input images"):
+        cutout._handle_insufficient_color_cutouts(coord)
+
+
+def test_get_img_save_kwargs_without_metadata_and_save_oserror(tmp_path):
+    cutout = _DummyImageCutout()
+    img = Image.fromarray(np.zeros((4, 4), dtype=np.uint8))
+
+    assert cutout._get_img_save_kwargs(img, "no_meta.png") == {}
+
+    def _raise_oserror(*args, **kwargs):
+        raise OSError("disk full")
+
+    img.save = _raise_oserror
+    with pytest.warns(Warning, match="Cutout could not be saved"):
+        success = cutout._save_img_to_file(img, (tmp_path / "x.png").as_posix())
+    assert success is False
+
+
+def test_module_normalize_img_wrapper():
+    img_arr = np.array([[1.0, 0.0], [0.25, 0.75]])
+    assert (normalize_img(img_arr, stretch="linear") == ImageCutout.normalize_img(img_arr, stretch="linear")).all()

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -123,6 +123,7 @@ single coordinate or a list of coordinates, and Astrocut will generate one cutou
 The resulting `~astrocut.ASDFCutout` object can be used to access the cutout science data and metadata.
 The ``cutouts_by_file`` attribute is a nested dictionary keyed by input filename and coordinate string,
 where each value is a `~astropy.nddata.Cutout2D` object.
+
 The ``cutouts`` attribute is an `~astropy.table.Table` with columns ``file``, ``coordinate``, and ``cutout``.
 The ``cutout`` column stores `~astropy.nddata.Cutout2D` objects, with one row per valid
 ``(input file, coordinate)`` pair.
@@ -136,13 +137,23 @@ The ``cutout`` column stores `~astropy.nddata.Cutout2D` objects, with one row pe
   /path/to/input_0.asdf          <SkyCoord (ICRS): ...>          <astropy.nddata.utils.Cutout2D object at 0x11f216720>
   /path/to/input_1.asdf          <SkyCoord (ICRS): ...>          <astropy.nddata.utils.Cutout2D object at 0x11eb951c0>
 
+Use `~astrocut.ASDFCutout.get_cutouts` to retrieve a filtered subset of the base
+`~astropy.nddata.Cutout2D` table by input file and/or coordinate:
+
+.. code-block:: python
+
+  >>> subset = asdf_cutout.get_cutouts( #doctest: +SKIP
+  ...     input_files=input_files[:1],
+  ...     coordinates=coords[:1],
+  ... )
+  >>> len(subset) #doctest: +SKIP
+  1
+  >>> subset["cutout"][0].data.shape #doctest: +SKIP
+  (25, 25)
+
 The ``asdf_cutouts`` and ``fits_cutouts`` attributes also both return `~astropy.table.Table` objects
 with columns ``file``, ``coordinate``, and ``cutout``. The ``cutout`` column stores `~asdf.AsdfFile`
 or `~astropy.io.fits.HDUList` objects, respectively.
-
-.. note::
-  Although Astrocut supports writing ASDF cutouts as FITS objects, we recommend using the ASDF output format whenever possible. FITS files may not
-  accurately represent the ASDF world coordinate system, so saving cutouts in their original format will generally give the most reliable results.
 
 .. code-block:: python
 
@@ -195,11 +206,16 @@ cutout FITS files.
 By default, the cutouts are written to the current working directory. You can specify a different output directory using the ``output_dir`` parameter
 in either of the write functions.
 
+.. note::
+  Although Astrocut supports writing ASDF cutouts as FITS objects, we recommend using the ASDF output format whenever possible. FITS files may not
+  accurately represent the ASDF world coordinate system, so saving cutouts in their original format will generally give the most reliable results.
+
 Streaming Cutouts
 ^^^^^^^^^^^^^^^^^^
 
 For large batches, you can stream cutouts lazily using iterator methods rather than materializing full tables in memory:
 
+- ``iter_cutouts(...)`` yields tuples of ``(file, coordinate, cutout2D)``.
 - ``iter_asdf_cutouts(...)`` yields tuples of ``(file, coordinate, asdf_cutout)``.
 - ``iter_fits_cutouts(...)`` yields tuples of ``(file, coordinate, fits_cutout)``.
 - ``iter_image_cutouts(...)`` yields tuples of ``(file, coordinate, image_cutout)``.

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -124,8 +124,17 @@ The resulting `~astrocut.ASDFCutout` object can be used to access the cutout sci
 The ``cutouts_by_file`` attribute is a nested dictionary keyed by input filename and coordinate string,
 where each value is a `~astropy.nddata.Cutout2D` object.
 
+.. code-block:: python
+
+  >>> pprint(cutout.cutouts_by_file)  #doctest: +SKIP
+  {'/path/to/input_0.asdf': {"80.15189743 29.74561219": <astropy.nddata.utils.Cutout2D object at 0x11fb3bc80>,
+                             "80.15500000 29.75000000": <astropy.nddata.utils.Cutout2D object at 0x11fafff20>},
+   '/path/to/input_1.asdf': {"80.15189743 29.74561219": <astropy.nddata.utils.Cutout2D object at 0x11f99d610>,
+                             "80.15500000 29.75000000": <astropy.nddata.utils.Cutout2D object at 0x11f7da5d0>}}
+
+
 The ``cutouts`` attribute is an `~astropy.table.Table` with columns ``file``, ``coordinate``, and ``cutout``.
-The ``cutout`` column stores `~astropy.nddata.Cutout2D` objects, with one row per valid
+The ``cutout`` column stores `~astropy.nddata.Cutout2D` objects, with one row per unique cutout, defined by a valid
 ``(input file, coordinate)`` pair.
 
 .. code-block:: python
@@ -153,7 +162,8 @@ Use `~astrocut.ASDFCutout.get_cutouts` to retrieve a filtered subset of the base
 
 The ``asdf_cutouts`` and ``fits_cutouts`` attributes also both return `~astropy.table.Table` objects
 with columns ``file``, ``coordinate``, and ``cutout``. The ``cutout`` column stores `~asdf.AsdfFile`
-or `~astropy.io.fits.HDUList` objects, respectively.
+or `~astropy.io.fits.HDUList` objects, respectively. To retrieve a filtered subset of the ASDF or FITS cutouts,
+use `~astrocut.ASDFCutout.get_asdf_cutouts` or `~astrocut.ASDFCutout.get_fits_cutouts`, respectively.
 
 .. code-block:: python
 

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -98,7 +98,8 @@ The Advanced Scientific Data Format (ASDF) is a flexible format for storing scie
 and return the results in memory or as a written file, depending on the user's preference. The cutout ASDF file format is
 described in the :ref:`Astrocut File Formats <asdf-cutout-files>` page.
 
-To make a cutout from an ASDF file or files, use the `~astrocut.ASDFCutout` class.
+To make cutouts from an ASDF file or files, use the `~astrocut.ASDFCutout` class. The ``coordinates`` argument can be a
+single coordinate or a list of coordinates, and Astrocut will generate one cutout for each coordinate in each input file.
 
 .. code-block:: python
 
@@ -107,10 +108,11 @@ To make a cutout from an ASDF file or files, use the `~astrocut.ASDFCutout` clas
 
   >>> input_files = [""]  # Path(s) to local ASDF file, URL, or S3 URI
 
-  >>> center_coord = SkyCoord("80.15189743 29.74561219", unit="deg")
+  >>> coords = [SkyCoord("80.15189743 29.74561219", unit="deg"),
+  ...           SkyCoord("80.15500000 29.75000000", unit="deg")]
   >>> cutout_size = 25
   >>> asdf_cutout = ASDFCutout(input_files=input_files,
-  ...                          coordinates=center_coord,
+  ...                          coordinates=coords,
   ...                          cutout_size=cutout_size) #doctest: +SKIP
 
 .. warning::
@@ -118,13 +120,25 @@ To make a cutout from an ASDF file or files, use the `~astrocut.ASDFCutout` clas
   cutouts that are more accurately centered on the target coordinates than even values
   for ``cutout_size``.
 
-The resulting `~astrocut.ASDFCutout` object can be used to access the cutout science data and metadata. The ``cutouts_by_file`` attribute is a dictionary that
-stores the individual science data cutouts as a list of `~astropy.nddata.Cutout2D` objects by input filename. The `~astropy.nddata.Cutout2D`
-object contains the science cutout data, shape, world coordinate system (WCS) and other helpful properties. The ``cutouts`` attribute is a list of
-science data cutouts as `~astropy.nddata.Cutout2D` objects, one for each input file.
+The resulting `~astrocut.ASDFCutout` object can be used to access the cutout science data and metadata.
+The ``cutouts_by_file`` attribute is a nested dictionary keyed by input filename and coordinate string,
+where each value is a `~astropy.nddata.Cutout2D` object.
+The ``cutouts`` attribute is an `~astropy.table.Table` with columns ``file``, ``coordinate``, and ``cutout``.
+The ``cutout`` column stores `~astropy.nddata.Cutout2D` objects, with one row per valid
+``(input file, coordinate)`` pair.
 
-The ``asdf_cutouts`` attribute is a list of cutouts as `~asdf.AsdfFile` objects, and the ``fits_cutout`` attribute is a list of cutouts as
-`~astropy.io.fits.HDUList` objects. The cutout objects in these lists can be used to access cutout data and metadata, as shown below.
+.. code-block:: python
+
+  >>> cutout_table = cutout.cutouts #doctest: +SKIP
+  >>> cutout_table.pprint_all() #doctest: +SKIP
+           file                         coordinate                                      cutout
+  ------------------------------ ------------------------------- -----------------------------------------------------
+  /path/to/input_0.asdf          <SkyCoord (ICRS): ...>          <astropy.nddata.utils.Cutout2D object at 0x11f216720>
+  /path/to/input_1.asdf          <SkyCoord (ICRS): ...>          <astropy.nddata.utils.Cutout2D object at 0x11eb951c0>
+
+The ``asdf_cutouts`` and ``fits_cutouts`` attributes also both return `~astropy.table.Table` objects
+with columns ``file``, ``coordinate``, and ``cutout``. The ``cutout`` column stores `~asdf.AsdfFile`
+or `~astropy.io.fits.HDUList` objects, respectively.
 
 .. note::
   Although Astrocut supports writing ASDF cutouts as FITS objects, we recommend using the ASDF output format whenever possible. FITS files may not
@@ -132,7 +146,7 @@ The ``asdf_cutouts`` attribute is a list of cutouts as `~asdf.AsdfFile` objects,
 
 .. code-block:: python
 
-  >>> cutout_asdf = asdf_cutout.asdf_cutouts[0] #doctest: +SKIP
+  >>> cutout_asdf = asdf_cutout.asdf_cutouts["cutout"][0] #doctest: +SKIP
   >>> cutout_asdf.info() #doctest: +SKIP
   root (AsdfObject)
   └─roman (dict)
@@ -140,7 +154,7 @@ The ``asdf_cutouts`` attribute is a list of cutouts as `~asdf.AsdfFile` objects,
     │ └─wcs (WCS)
     └─data (ndarray): shape=(25, 25), dtype=float32
 
-  >>> cutout_fits = asdf_cutout.fits_cutouts[0] #doctest: +SKIP
+  >>> cutout_fits = asdf_cutout.fits_cutouts["cutout"][0] #doctest: +SKIP
   >>> cutout_fits.info() #doctest: +SKIP
   Filename: (No file associated with this HDUList)
   No.    Name      Ver    Type      Cards   Dimensions   Format
@@ -181,10 +195,27 @@ cutout FITS files.
 By default, the cutouts are written to the current working directory. You can specify a different output directory using the ``output_dir`` parameter
 in either of the write functions.
 
+Streaming Cutouts
+^^^^^^^^^^^^^^^^^^
+
+For large batches, you can stream cutouts lazily using iterator methods rather than materializing full tables in memory:
+
+- ``iter_asdf_cutouts(...)`` yields tuples of ``(file, coordinate, asdf_cutout)``.
+- ``iter_fits_cutouts(...)`` yields tuples of ``(file, coordinate, fits_cutout)``.
+- ``iter_image_cutouts(...)`` yields tuples of ``(file, coordinate, image_cutout)``.
+
+.. code-block:: python
+
+  >>> for file, coordinate, af in asdf_cutout.iter_asdf_cutouts(): #doctest: +SKIP
+  ...     print(file, coordinate.ra.deg, af["roman"]["data"].shape) #doctest: +SKIP
+
+All ``get_*_cutouts(...)`` and ``iter_*_cutouts(...)`` methods support optional ``input_files`` and
+``coordinates`` filters to limit the cutouts returned to a subset of the original input files and coordinates.
+
 Lite Mode
 ^^^^^^^^^
 By default, `~astrocut.ASDFCutout` creates lite cutouts that include only the science data array and the updated world coordinate system. These cutouts
-can be accessed through the `asdf_cutouts` attribute.
+can be accessed through the ``asdf_cutouts`` table (in its ``cutout`` column).
 
 If you need the full ASDF tree, including other arrays in the input file (e.g., data, error, uncertainty, variance, etc.) and the original metadata,
 set the ``lite`` parameter to False. This produces larger cutouts, but preserves the full set of arrays and metadata for downstream analysis.
@@ -192,10 +223,10 @@ set the ``lite`` parameter to False. This produces larger cutouts, but preserves
 .. code-block:: python
 
   >>> asdf_cutout_full = ASDFCutout(input_files=input_files,
-  ...                               coordinates=center_coord,
+  ...                               coordinates=coords,
   ...                               cutout_size=cutout_size,
   ...                               lite=False) #doctest: +SKIP
-  >>> cutout_asdf_full = asdf_cutout_full.asdf_cutouts[0] #doctest: +SKIP
+  >>> cutout_asdf_full = asdf_cutout_full.asdf_cutouts["cutout"][0] #doctest: +SKIP
   >>> cutout_asdf_full.info() #doctest: +SKIP
   root (AsdfObject)
   ├─asdf_library (Software)
@@ -226,10 +257,11 @@ Image Outputs
 -------------
 
 Both the `~astrocut.FITSCutout` and `~astrocut.ASDFCutout` classes provide methods to normalize the cutout data and write it as an image,
-either as a a `~PIL.Image.Image` object or a file.
+either as a `~PIL.Image.Image` object or a file.
 
-To create cutouts as `~PIL.Image.Image` objects, use the `~astrocut.FITSCutout.get_image_cutouts` method. You can provide the following
-normalization parameters:
+To create image cutouts in memory, use ``get_image_cutouts``. For `~astrocut.FITSCutout`, this returns a list of `~PIL.Image.Image` objects,
+one for each input file. For `~astrocut.ASDFCutout`, this returns an `~astropy.table.Table` with columns ``file``, ``coordinate``, and ``cutout``
+(where ``cutout`` is a `~PIL.Image.Image` object). You can provide the following normalization parameters:
 
 - ``stretch``: The stretch function to apply to the image array. Options include "asinh", "sinh", "sqrt", "log", and "linear".
 - ``minmax_percent``: Defines an interval for scaling the image based on percentiles. The format is [lower percentile, upper percentile],
@@ -246,6 +278,23 @@ normalization parameters:
   >>> fits_img.show() #doctest: +SKIP
 
 .. image:: imgs/img_cutout.png
+
+For `~astrocut.ASDFCutout`, ``get_image_cutouts`` returns a table. Access the image object from the
+``cutout`` column:
+
+.. code-block:: python
+
+  >>> img_table = asdf_cutout.get_image_cutouts(stretch='linear', minmax_percent=[10, 99]) #doctest: +SKIP
+  >>> asdf_img = img_table["cutout"][0] #doctest: +SKIP
+  >>> print(asdf_img.size) #doctest: +SKIP
+  (50, 50)
+
+For large batches, use ``iter_image_cutouts`` to stream one cutout at a time:
+
+.. code-block:: python
+
+  >>> for file, coordinate, img in asdf_cutout.iter_image_cutouts(): #doctest: +SKIP
+  ...     print(file, coordinate.ra.deg, img.size) #doctest: +SKIP
 
 To produce a colorized RGB image, set the ``colorize`` parameter to True. Color images require three cutouts,
 which will be treated as the R, G, and B channels, respectively.

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -126,7 +126,7 @@ where each value is a `~astropy.nddata.Cutout2D` object.
 
 .. code-block:: python
 
-  >>> pprint(cutout.cutouts_by_file)  #doctest: +SKIP
+  >>> pprint(asdf_cutout.cutouts_by_file)  #doctest: +SKIP
   {'/path/to/input_0.asdf': {"80.15189743 29.74561219": <astropy.nddata.utils.Cutout2D object at 0x11fb3bc80>,
                              "80.15500000 29.75000000": <astropy.nddata.utils.Cutout2D object at 0x11fafff20>},
    '/path/to/input_1.asdf': {"80.15189743 29.74561219": <astropy.nddata.utils.Cutout2D object at 0x11f99d610>,
@@ -139,7 +139,7 @@ The ``cutout`` column stores `~astropy.nddata.Cutout2D` objects, with one row pe
 
 .. code-block:: python
 
-  >>> cutout_table = cutout.cutouts #doctest: +SKIP
+  >>> cutout_table = asdf_cutout.cutouts #doctest: +SKIP
   >>> cutout_table.pprint_all() #doctest: +SKIP
            file                         coordinate                                      cutout
   ------------------------------ ------------------------------- -----------------------------------------------------


### PR DESCRIPTION
This PR expands the ASDF cutout workflow to support multiple target coordinates per input file, instead of only a single coordinate. It also updates the cutout APIs to return structured tables of results, making it easier to inspect and work with cutouts across file/coordinate combinations.

- `ASDFCutout` can now accept a single coordinate or a list of coordinates. Cutouts are generated for each valid (input file, coordinate) pair.
- `cutouts`, `asdf_cutouts`, `fits_cutouts`, and `get_image_cutouts()` now expose results as `astropy.table.Table` objects for ASDF-based cutouts.
- Added iterator-based methods to lazily stream cutouts without materializing everything in memory.
- Added selection filters for input files and coordinates.
- `Cutout`, `FITSCutout`, `CubeCutout`, and TESS cutout classes were adjusted to align with the new coordinate handling. TESS footprint and cube cutout logic were updated accordingly.

This is a broader refactor of the ASDF cutout pipeline, so downstream code that previously expected lists of cutouts may need to be updated to work with the new table-based return values.