### PR TITLE
Update `RomanSpectralSubset` outputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Unreleased
 
 - Extend the ASDF cutout workflow to accept multiple target coordinates and to expose downstream cutout products in
   an ``astropy.table.Table`` object with columns for input file, coordinate, and cutout object. [#196]
+- ``RomanSpectralSubset`` class now returns spectral subsets in memory as an `~astropy.table.Table` with columns for
+  source ID(s), input file(s), and the corresponding subset. [#198]
 
 1.3.0 (2026-09-02)
 -------------------

--- a/astrocut/asdf_spectral_subset.py
+++ b/astrocut/asdf_spectral_subset.py
@@ -888,7 +888,7 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
             for row in subset_table:
                 file, sid = row["file"], row["source_id"]
                 filename = f"{Path(file).stem}_subset_{sid}{'_lite' if self._lite else ''}.asdf"
-                write_jobs.append((row["asdf"], str(output_dir / filename)))
+                write_jobs.append((row["subset"], str(output_dir / filename)))
 
         elif group_by == "file":
             # Write one ASDF file per input file, containing all specified source IDs from that file
@@ -899,7 +899,7 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
             )
             for row in subset_table:
                 filename = f"{Path(row['file']).stem}_subset{'_lite' if self._lite else ''}.asdf"
-                write_jobs.append((row["asdf"], str(output_dir / filename)))
+                write_jobs.append((row["subset"], str(output_dir / filename)))
 
         elif group_by == "combined":
             # Write a single ASDF file containing all specified source IDs from all input files
@@ -909,7 +909,7 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
                 spectral_files=spectral_files,
             )
             filename = f"combined_spectral_subset{'_lite' if self._lite else ''}.asdf"
-            write_jobs.append((subset_table[0]["asdf"], str(output_dir / filename)))
+            write_jobs.append((subset_table[0]["subset"], str(output_dir / filename)))
 
         else:
             raise InvalidInputError(self._invalid_group_by_msg.format(group_by))

--- a/astrocut/asdf_spectral_subset.py
+++ b/astrocut/asdf_spectral_subset.py
@@ -6,13 +6,13 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from contextlib import contextmanager, nullcontext
 from copy import deepcopy
 from datetime import datetime, timezone
-from hashlib import blake2s
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Tuple, Union
+from typing import Dict, Iterator, List, Literal, Optional, Tuple, Union
 
 import asdf
 import asdf.schema as asdf_schema
 import numpy as np
+from astropy.table import Table
 from s3path import S3Path
 
 from . import __version__, log
@@ -161,7 +161,6 @@ def _subset_single_file(
                             f"Source ID {sid} not found in file {file}. Skipping this source for this file."
                         )
                     continue
-
             source = mission_data[mission_key]
             wl = source["wl"]
 
@@ -339,6 +338,9 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
     get_asdf_subsets(group_by=group_by, source_ids=source_ids, spectral_files=spectral_files)
         Get ASDF subset(s) for specified source IDs and input files, grouped by source and file,
         file, or combined.
+    iter_asdf_subsets(group_by=group_by, source_ids=source_ids, spectral_files=spectral_files)
+        Lazily yield ASDF subset rows for specified source IDs and input files, grouped by source
+        and file, file, or combined.
     write_as_asdf(output_dir=output_dir, group_by=group_by, source_ids=source_ids, spectral_files=spectral_files)
         Write the ASDF subset(s) to files in the specified output directory, grouped by source
         and file, file, or combined.
@@ -451,60 +453,24 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
                 "the spectral files and that the wavelength range overlaps with the data."
             )
 
-    def get_source_file_keys(
-        self,
-        *,
-        spectral_files: Union[str, Path, S3Path, List[Union[str, Path, S3Path]]] = None,
-        source_ids: Union[str, int, List[Union[str, int]]] = None,
-    ) -> Dict[str, Tuple[str, str]]:
-        """
-        Get valid string keys for source/file subset selection.
-
-        Parameters
-        ----------
-        spectral_files : str or Path or S3Path or list, optional
-            Specific spectral files to include. If None, all available files are included.
-        source_ids : str or int or list, optional
-            Specific source IDs to include. If None, all available source IDs are included.
-
-        Returns
-        -------
-        dict
-            Mapping from a user-friendly key string to ``(file, source_id)`` tuples.
-        """
-        files_to_include, sources_to_include = self._resolve_selection(
-            spectral_files=spectral_files, source_ids=source_ids
-        )
-
-        source_file_pairs = []
-        for file in files_to_include:
-            for sid in sources_to_include:
-                if sid not in self._out_trees[file]:
-                    log.debug(f"Source ID {sid} not found in file {file}. Skipping this source for this file.")
-                    continue
-                source_file_pairs.append((file, sid))
-
-        keys = self._build_source_file_keys(source_file_pairs)
-
-        return keys
-
-    def get_asdf_subsets(
+    def iter_asdf_subsets(
         self,
         *,
         group_by: Literal["source_file", "file", "combined"] = "combined",
         spectral_files: Union[str, Path, S3Path, List[Union[str, Path, S3Path]]] = None,
         source_ids: Union[str, int, List[Union[str, int]]] = None,
-    ) -> dict:
+    ) -> Iterator[Tuple]:
         """
-        Get ASDF subset objects for specified source IDs and input files, grouped by source and file, file, or combined.
+        Yield ASDF subset rows lazily for specified source IDs and input files, grouped by source and
+        file, file, or combined.
 
         Parameters
         ----------
         group_by : {'source_file', 'file', 'combined'}, optional
-            Determines how the subsets are grouped in the output ASDF objects. Default is 'combined'.
-            - 'source_file': Separate ASDF object for each source ID and input file combination.
-            - 'file': One ASDF object per input file, containing all specified source IDs from that file.
-            - 'combined': A single ASDF object containing all specified source IDs from all input files.
+            Determines how the subsets are grouped. Default is 'combined'.
+            - 'source_file': One row per source ID and input file combination.
+            - 'file': One row per input file, containing all specified source IDs from that file.
+            - 'combined': A single row containing all specified source IDs from all input files.
         spectral_files : str or Path or S3Path or list, optional
             Specific spectral files to include in the output. If None, all input spectral files will be included.
             Can be a single file or a list of files.
@@ -512,35 +478,33 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
             Specific source IDs to include in the output. If None, all source IDs from the subset
             results will be included. Can be a single ID or a list of IDs.
 
-        Returns
-        -------
-        dict or asdf.AsdfFile
-            Depending on the value of `group_by`, this method returns either a dictionary of ASDF subset objects keyed
-            by source ID and input file combination ('source_file'), a dictionary of ASDF subset objects
-            keyed by input file ('file'), or a single ASDF subset object containing all subsets ('combined').
+        Yields
+        ------
+        tuple
+            For 'source_file': ``(file, source_id, asdf.AsdfFile)``. For 'file': ``(file, source_ids, asdf.AsdfFile)``.
+            For 'combined': a single ``(files, source_ids, asdf.AsdfFile)`` tuple.
         """
-        asdf_subsets = {}
-        if group_by == "source_file":
-            # Build deterministic keys for the source/file combinations and disambiguate if needed
-            source_file_keys = self.get_source_file_keys(spectral_files=spectral_files, source_ids=source_ids)
-
-            # Create separate ASDF objects for each source/file combination
-            for string_key, (file, sid) in source_file_keys.items():
-                tree = deepcopy(self._out_trees[file][sid])
-                af = asdf.AsdfFile(tree)
-                af.tree["history"] = _append_history_entry(
-                    tree.get("history", {}),
-                    f"Spectral subset created for source ID {sid} from file {file}"
-                    f"{f' with wavelength range {self._wl_range is not None}' if self._wl_range else ''}.",
-                )
-                asdf_subsets[string_key] = af
-
-            return asdf_subsets
-
         files_to_include, sources_to_include = self._resolve_selection(
             spectral_files=spectral_files, source_ids=source_ids
         )
-        if group_by == "file":
+        if group_by == "source_file":
+            # Yield a separate ASDF object for each source/file combination
+            for file in files_to_include:
+                for sid in sources_to_include:
+                    if sid not in self._out_trees[file]:
+                        log.debug(f"Source ID {sid} not found in file {file}. Skipping this source for this file.")
+                        continue
+
+                    tree = deepcopy(self._out_trees[file][sid])
+                    af = asdf.AsdfFile(tree)
+                    af.tree["history"] = _append_history_entry(
+                        tree.get("history", {}),
+                        f"Spectral subset created for source ID {sid} from file {file}"
+                        f"{f' with wavelength range {self._wl_range is not None}' if self._wl_range else ''}.",
+                    )
+                    yield file, sid, af
+
+        elif group_by == "file":
             # Group by file, combining all sources in each file
             for file in files_to_include:
                 source_ids = [sid for sid in sources_to_include if sid in self._out_trees[file]]
@@ -575,7 +539,8 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
                     f"Spectral subset created for source IDs {source_ids} from file {file}"
                     f"{f' with wavelength range {self._wl_range}' if self._wl_range is not None else ''}.",
                 )
-                asdf_subsets[file] = af
+                yield file, source_ids, af
+
         elif group_by == "combined":
             # Group all sources and spectral files into a single ASDF file
             # ASDF data should be keyed by file and then source_id to avoid key collisions
@@ -640,85 +605,132 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
                 f"Spectral subset created for source IDs {sources_to_include} from files {', '.join(files_to_include)}"
                 f"{f' with wavelength range {self._wl_range}' if self._wl_range is not None else ''}.",
             )
-            asdf_subsets = af
+            yield files_to_include, sources_to_include, af
+
         else:
             raise InvalidInputError(self._invalid_group_by_msg.format(group_by))
 
-        return asdf_subsets
-
-    def _build_write_jobs(
+    def _resolve_selection(
         self,
-        output_dir: Union[str, Path],
-        group_by: Literal["source_file", "file", "combined"],
-        spectral_files: List[Union[str, Path]],
-        source_ids: Union[str, int, List[Union[str, int]]],
-    ) -> List[Tuple[asdf.AsdfFile, str]]:
+        spectral_files: Union[str, Path, S3Path, List[Union[str, Path, S3Path]]] = None,
+        source_ids: Union[str, int, List[Union[str, int]]] = None,
+    ) -> Tuple[List[str], List[str]]:
         """
-        Build a list of ASDF subset objects and corresponding output file paths to write, based
-        on the specified grouping.
+        Resolve and validate file/source selections against available subset results.
 
         Parameters
         ----------
-        output_dir : str or Path
-            The directory where the output ASDF files will be written.
-        group_by : {'source_file', 'file', 'combined'}
-            Determines how the subsets are grouped in the output ASDF objects. Must be
-            one of 'source_file', 'file', or 'combined'.
-        spectral_files : list of str or Path
-            The list of input spectral files to include in the output subsets.
-        source_ids : str or int or list
-            Specific source IDs to include in the output. Can be a single ID or a list of IDs.
+        spectral_files : str or Path or S3Path or list, optional
+            Specific spectral files to include. If None, all available files are included.
+        source_ids : str or int or list, optional
+            Specific source IDs to include. If None, all available source IDs are included.
 
         Returns
         -------
-        list of tuples
-            A list of tuples, where each tuple contains an ASDF subset object and the corresponding
-            output file path to which it should be written.
+        tuple
+            A tuple containing two lists: (files_to_include, sources_to_include), where each list contains the
+            validated string keys for the selected files and source IDs, respectively.
         """
-        write_jobs = []  # List of tuples: (asdf.AsdfFile, output_file_path)
-        if group_by == "source_file":
-            # Write separate ASDF files for each source/file combination, using the deterministic keys
-            # for the source/file combinations
-            af_by_source_file = self.get_asdf_subsets(
-                group_by="source_file",
-                source_ids=source_ids,
-                spectral_files=spectral_files,
-            )
-            source_file_keys = self.get_source_file_keys(
-                spectral_files=spectral_files,
-                source_ids=source_ids,
-            )
-
-            for key, af in af_by_source_file.items():
-                file, sid = source_file_keys[key]
-                filename = f"{Path(file).stem}_subset_{sid}{'_lite' if self._lite else ''}.asdf"
-                write_jobs.append((af, str(output_dir / filename)))
-
-        elif group_by == "file":
-            # Write one ASDF file per input file, containing all specified source IDs from that file
-            af_by_file = self.get_asdf_subsets(
-                group_by="file",
-                source_ids=source_ids,
-                spectral_files=spectral_files,
-            )
-            for file, af in af_by_file.items():
-                filename = f"{Path(file).stem}_subset{'_lite' if self._lite else ''}.asdf"
-                write_jobs.append((af, str(output_dir / filename)))
-
-        elif group_by == "combined":
-            # Write a single ASDF file containing all specified source IDs from all input files
-            af = self.get_asdf_subsets(
-                group_by="combined",
-                source_ids=source_ids,
-                spectral_files=spectral_files,
-            )
-            filename = f"combined_spectral_subset{'_lite' if self._lite else ''}.asdf"
-            write_jobs.append((af, str(output_dir / filename)))
-
+        if spectral_files is None:
+            files_to_include = list(self._out_trees.keys())
         else:
+            files_to_include = spectral_files if isinstance(spectral_files, list) else [spectral_files]
+            files_to_include = [str(file) for file in files_to_include]
+
+            for file in files_to_include:
+                if file not in self._out_trees:
+                    raise InvalidQueryError(f"Spectral file {file} not found in subset results.")
+
+        all_source_ids = set()
+        for file in files_to_include:
+            all_source_ids.update(str(sid) for sid in self._out_trees[file].keys())
+        all_source_ids = sorted(all_source_ids)
+
+        if source_ids is None:
+            sources_to_include = all_source_ids
+        else:
+            sources_to_include = source_ids if isinstance(source_ids, list) else [source_ids]
+            sources_to_include = [str(sid) for sid in sources_to_include]
+
+            for sid in sources_to_include:
+                if sid not in all_source_ids:
+                    raise InvalidQueryError(f"Source ID {sid} not found in subset results.")
+
+        return files_to_include, sources_to_include
+
+    _SUBSET_TABLE_COLUMNS = {
+        "source_file": ["file", "source_id", "subset"],
+        "file": ["file", "source_ids", "subset"],
+        "combined": ["files", "source_ids", "subset"],
+    }
+
+    def get_asdf_subsets(
+        self,
+        *,
+        group_by: Literal["source_file", "file", "combined"] = "combined",
+        spectral_files: Union[str, Path, S3Path, List[Union[str, Path, S3Path]]] = None,
+        source_ids: Union[str, int, List[Union[str, int]]] = None,
+    ) -> Table:
+        """
+        Get ASDF subset objects for specified source IDs and input files, grouped by source and file, file, or combined.
+
+        Parameters
+        ----------
+        group_by : {'source_file', 'file', 'combined'}, optional
+            Determines how the subsets are grouped in the output table. Default is 'combined'.
+            - 'source_file': One row per source ID and input file combination.
+            - 'file': One row per input file, containing all specified source IDs from that file.
+            - 'combined': A single row containing all specified source IDs from all input files.
+        spectral_files : str or Path or S3Path or list, optional
+            Specific spectral files to include in the output. If None, all input spectral files will be included.
+            Can be a single file or a list of files.
+        source_ids : str or int or list, optional
+            Specific source IDs to include in the output. If None, all source IDs from the subset
+            results will be included. Can be a single ID or a list of IDs.
+
+        Returns
+        -------
+        `astropy.table.Table`
+            Depending on the value of `group_by`, this method returns a table with columns
+            ``file``, ``source_id``, ``subset`` ('source_file'), ``file``, ``source_ids``,
+            ``subset`` ('file'), or ``files``, ``source_ids``, ``subset`` ('combined'), where the ``subset``
+            column holds the corresponding `asdf.AsdfFile` subset object(s).
+        """
+        columns = self._SUBSET_TABLE_COLUMNS.get(group_by)
+        if columns is None:
             raise InvalidInputError(self._invalid_group_by_msg.format(group_by))
 
-        return write_jobs
+        rows = list(self.iter_asdf_subsets(group_by=group_by, spectral_files=spectral_files, source_ids=source_ids))
+        return self._build_subset_table(rows, columns)
+
+    @staticmethod
+    def _build_subset_table(rows: List[Tuple], columns: List[str]) -> Table:
+        """
+        Build a table of ASDF subset results with an object-typed ``subset`` column, where each
+        row corresponds to a specific grouping of source IDs and input files.
+
+        Parameters
+        ----------
+        rows : list of tuples
+            Row values, with the ``asdf.AsdfFile`` subset object as the last element of each tuple.
+        columns : list of str
+            Column names for the table, with ``subset`` as the last entry.
+
+        Returns
+        -------
+        table : `astropy.table.Table`
+            The constructed subset table.
+        """
+        if not rows:
+            return Table(names=columns)
+
+        *other_columns, asdf_files = zip(*rows)
+        asdf_col = np.empty(len(rows), dtype=object)
+        asdf_col[:] = asdf_files
+
+        data = dict(zip(columns[:-1], other_columns))
+        data[columns[-1]] = asdf_col
+        return Table(data)
 
     def write_as_asdf(
         self,
@@ -835,117 +847,71 @@ class ASDFSpectralSubset(SpectralSubset, ABC):
             paths.extend(batch_paths)
         return paths
 
-    def _build_source_file_keys(self, source_file_pairs: List[Tuple[str, str]]) -> Dict[str, Tuple[str, str]]:
-        """
-        Build deterministic source/file keys and disambiguate collisions when needed.
-
-        Parameters
-        ----------
-        source_file_pairs : list of tuples
-            List of (file, source_id) pairs for which to build keys.
-
-        Returns
-        -------
-        dict
-            Mapping from string keys to (file, source_id) tuples.
-        """
-        key_candidates = []
-        base_counts = {}
-        for file, sid in source_file_pairs:
-            base_key = self._make_source_file_key(file, sid)
-            key_candidates.append((base_key, file, sid))
-            base_counts[base_key] = base_counts.get(base_key, 0) + 1
-
-        keys = {}
-        for base_key, file, sid in key_candidates:
-            if base_counts[base_key] == 1 and base_key not in keys:
-                keys[base_key] = (file, sid)
-                continue
-
-            file_hash = blake2s(str(file).encode("utf-8"), digest_size=4).hexdigest()
-            disambiguated_key = self._make_source_file_key(
-                file,
-                sid,
-                disambiguator=file_hash,
-            )
-            keys[disambiguated_key] = (file, sid)
-
-        return keys
-
-    def _resolve_selection(
+    def _build_write_jobs(
         self,
-        spectral_files: Union[str, Path, S3Path, List[Union[str, Path, S3Path]]] = None,
-        source_ids: Union[str, int, List[Union[str, int]]] = None,
-    ) -> Tuple[List[str], List[str]]:
+        output_dir: Union[str, Path],
+        group_by: Literal["source_file", "file", "combined"],
+        spectral_files: List[Union[str, Path]],
+        source_ids: Union[str, int, List[Union[str, int]]],
+    ) -> List[Tuple[asdf.AsdfFile, str]]:
         """
-        Resolve and validate file/source selections against available subset results.
+        Build a list of ASDF subset objects and corresponding output file paths to write, based
+        on the specified grouping.
 
         Parameters
         ----------
-        spectral_files : str or Path or S3Path or list, optional
-            Specific spectral files to include. If None, all available files are included.
-        source_ids : str or int or list, optional
-            Specific source IDs to include. If None, all available source IDs are included.
+        output_dir : str or Path
+            The directory where the output ASDF files will be written.
+        group_by : {'source_file', 'file', 'combined'}
+            Determines how the subsets are grouped in the output ASDF objects. Must be
+            one of 'source_file', 'file', or 'combined'.
+        spectral_files : list of str or Path
+            The list of input spectral files to include in the output subsets.
+        source_ids : str or int or list
+            Specific source IDs to include in the output. Can be a single ID or a list of IDs.
 
         Returns
         -------
-        tuple
-            A tuple containing two lists: (files_to_include, sources_to_include), where each list contains the
-            validated string keys for the selected files and source IDs, respectively.
+        list of tuples
+            A list of tuples, where each tuple contains an ASDF subset object and the corresponding
+            output file path to which it should be written.
         """
-        if spectral_files is None:
-            files_to_include = list(self._out_trees.keys())
+        write_jobs = []  # List of tuples: (asdf.AsdfFile, output_file_path)
+        if group_by == "source_file":
+            # Write separate ASDF files for each source/file combination
+            subset_table = self.get_asdf_subsets(
+                group_by="source_file",
+                source_ids=source_ids,
+                spectral_files=spectral_files,
+            )
+
+            for row in subset_table:
+                file, sid = row["file"], row["source_id"]
+                filename = f"{Path(file).stem}_subset_{sid}{'_lite' if self._lite else ''}.asdf"
+                write_jobs.append((row["asdf"], str(output_dir / filename)))
+
+        elif group_by == "file":
+            # Write one ASDF file per input file, containing all specified source IDs from that file
+            subset_table = self.get_asdf_subsets(
+                group_by="file",
+                source_ids=source_ids,
+                spectral_files=spectral_files,
+            )
+            for row in subset_table:
+                filename = f"{Path(row['file']).stem}_subset{'_lite' if self._lite else ''}.asdf"
+                write_jobs.append((row["asdf"], str(output_dir / filename)))
+
+        elif group_by == "combined":
+            # Write a single ASDF file containing all specified source IDs from all input files
+            subset_table = self.get_asdf_subsets(
+                group_by="combined",
+                source_ids=source_ids,
+                spectral_files=spectral_files,
+            )
+            filename = f"combined_spectral_subset{'_lite' if self._lite else ''}.asdf"
+            write_jobs.append((subset_table[0]["asdf"], str(output_dir / filename)))
+
         else:
-            files_to_include = spectral_files if isinstance(spectral_files, list) else [spectral_files]
-            files_to_include = [str(file) for file in files_to_include]
+            raise InvalidInputError(self._invalid_group_by_msg.format(group_by))
 
-            for file in files_to_include:
-                if file not in self._out_trees:
-                    raise InvalidQueryError(f"Spectral file {file} not found in subset results.")
-
-        all_source_ids = set()
-        for file in files_to_include:
-            all_source_ids.update(str(sid) for sid in self._out_trees[file].keys())
-        all_source_ids = sorted(all_source_ids)
-
-        if source_ids is None:
-            sources_to_include = all_source_ids
-        else:
-            sources_to_include = source_ids if isinstance(source_ids, list) else [source_ids]
-            sources_to_include = [str(sid) for sid in sources_to_include]
-
-            for sid in sources_to_include:
-                if sid not in all_source_ids:
-                    raise InvalidQueryError(f"Source ID {sid} not found in subset results.")
-
-        return files_to_include, sources_to_include
-
-    @staticmethod
-    def _make_source_file_key(
-        file: Union[str, Path, S3Path],
-        source_id: Union[str, int],
-        disambiguator: Optional[str] = None,
-    ) -> str:
-        """
-        Create a stable string key for a source ID and input spectral file combination.
-
-        Parameters
-        ----------
-        file : str or Path or S3Path
-            The input spectral file path.
-        source_id : str or int
-            The source ID.
-        disambiguator : str, optional
-            Additional suffix used only when needed to disambiguate duplicate keys.
-
-        Returns
-        -------
-        str
-            A string key combining the source ID and the input file name, suitable for use as a dictionary key
-        """
-        components = [str(source_id), Path(str(file)).stem]
-
-        if disambiguator:
-            components.append(disambiguator)
-
-        return "_".join(components)
+        return write_jobs

--- a/astrocut/tests/test_roman_spectral_subset.py
+++ b/astrocut/tests/test_roman_spectral_subset.py
@@ -268,7 +268,7 @@ def test_roman_spectral_subset_asdf_subsets_source_file(spectral_files, lite):
         subset_file, subset_source_id = row["file"], row["source_id"]
         assert subset_file in spectral_files
         assert subset_source_id in ["420007", "420008"]
-        subset_af = row["asdf"]
+        subset_af = row["subset"]
         assert isinstance(subset_af, asdf.AsdfFile)
         # Check that the subset ASDF file contains the expected data structure
         assert "roman" in subset_af.tree
@@ -320,7 +320,7 @@ def test_roman_spectral_subset_asdf_subsets_file(spectral_files, lite):
     for row in subset_table:
         subset_file = row["file"]
         assert subset_file in spectral_files
-        subset_af = row["asdf"]
+        subset_af = row["subset"]
         assert isinstance(subset_af, asdf.AsdfFile)
         # Check that the subset ASDF file contains the expected data structure
         assert "roman" in subset_af.tree
@@ -346,7 +346,7 @@ def test_roman_spectral_subset_asdf_subsets_combined(spectral_files, lite):
     subset = RomanSpectralSubset(spectral_files=spectral_files, source_ids=[420007, 420008], lite=lite, max_workers=1)
     subset_table = subset.get_asdf_subsets(group_by="combined")
     assert len(subset_table) == 1  # Should have a single combined row
-    subset_af = subset_table[0]["asdf"]
+    subset_af = subset_table[0]["subset"]
     assert isinstance(subset_af, asdf.AsdfFile)
     # Check that the subset ASDF file contains the expected data structure
     assert "roman" in subset_af.tree

--- a/astrocut/tests/test_roman_spectral_subset.py
+++ b/astrocut/tests/test_roman_spectral_subset.py
@@ -1,4 +1,3 @@
-import re
 from copy import deepcopy
 
 import asdf
@@ -212,52 +211,7 @@ def test_roman_spectral_subset_parallel(subset, spectral_files):
     assert np.array_equal(parallel_flux, non_parallel_flux)
 
 
-def test_roman_spectral_subset_source_file_keys(spectral_files):
-    # Test the get_source_file_keys method of RomanSpectralsubset
-    subset = RomanSpectralSubset(
-        spectral_files=spectral_files,
-        source_ids=[420007, 420008, 430000],
-        wl_range=(550, 850),
-        lite=True,
-        max_workers=1,
-    )
-
-    source_file_keys = subset.get_source_file_keys()
-    assert len(source_file_keys) == 5  # Should have one key for each combination of source ID and file
-
-    for subset_file, subset_source_id in source_file_keys.values():
-        assert subset_file in spectral_files
-        assert subset_source_id in ["420007", "420008", "430000"]
-
-    print(subset._out_trees[spectral_files[1]])
-
-    # Filter by source IDs
-    source_file_keys = subset.get_source_file_keys(source_ids=["420007", "430000"])
-    assert len(source_file_keys) == 3  # Should only have keys for the specified source IDs
-    for subset_file, subset_source_id in source_file_keys.values():
-        assert subset_source_id == "420007" or subset_source_id == "430000"
-
-    # Filter by source files
-    source_file_keys = subset.get_source_file_keys(spectral_files=[spectral_files[0]])
-    assert len(source_file_keys) == 2  # Should only have keys for the specified file
-    for subset_file, subset_source_id in source_file_keys.values():
-        assert subset_file == spectral_files[0]
-        assert subset_source_id in ["420007", "420008"]
-
-    # Error if a file is not found in results
-    with pytest.raises(
-        InvalidQueryError, match=r"Spectral file .*temp_spectral_nonexistent\.asdf " r"not found in subset results\."
-    ):
-        subset.get_source_file_keys(
-            spectral_files=[spectral_files[0], spectral_files[1], "temp_spectral_nonexistent.asdf"]
-        )
-
-    # Error if a source ID is not found in results
-    with pytest.raises(InvalidQueryError, match=r"Source ID 999999 not found in subset results\."):
-        subset.get_source_file_keys(source_ids=["420007", "999999"])
-
-
-def test_roman_spectral_subset_source_file_keys_duplicate_stems(tmp_path):
+def test_roman_spectral_subset_asdf_subsets_duplicate_stems(tmp_path):
     def _write_spectral_file(path):
         with asdf.AsdfFile() as af:
             af["roman"] = {
@@ -293,20 +247,12 @@ def test_roman_spectral_subset_source_file_keys_duplicate_stems(tmp_path):
         max_workers=1,
     )
 
-    source_file_keys = subset.get_source_file_keys()
-
-    assert len(source_file_keys) == 2
-    assert set(source_file_keys.values()) == {
+    subset_table = subset.get_asdf_subsets(group_by="source_file")
+    assert len(subset_table) == 2
+    assert set(zip(subset_table["file"], subset_table["source_id"])) == {
         (str(prism_file_1), "402849"),
         (str(prism_file_2), "402849"),
     }
-
-    keys = list(source_file_keys.keys())
-    assert all(re.match(r"^402849_spectrum_[0-9a-f]{8}$", key) for key in keys)
-    assert len(set(keys)) == 2
-
-    asdf_subsets = subset.get_asdf_subsets(group_by="source_file")
-    assert set(asdf_subsets.keys()) == set(source_file_keys.keys())
 
 
 @pytest.mark.parametrize("lite", [True, False])
@@ -314,17 +260,15 @@ def test_roman_spectral_subset_asdf_subsets_source_file(spectral_files, lite):
     # Test the get_asdf_subsets method of RomanSpectralsubset with group_by='source_file'
     subset = RomanSpectralSubset(spectral_files=spectral_files, source_ids=[420007, 420008], lite=lite, max_workers=1)
 
-    asdf_subsets = subset.get_asdf_subsets(group_by="source_file")
-    source_file_keys = subset.get_source_file_keys()
+    subset_table = subset.get_asdf_subsets(group_by="source_file")
     # Should make a subset for every combination of source ID and file, so 2 sources x 2 files = 4 subsets
-    assert len(asdf_subsets) == 4
-    assert len(source_file_keys) == 4
+    assert len(subset_table) == 4
 
-    for key, subset_af in asdf_subsets.items():
-        assert key in source_file_keys
-        subset_file, subset_source_id = source_file_keys[key]
+    for row in subset_table:
+        subset_file, subset_source_id = row["file"], row["source_id"]
         assert subset_file in spectral_files
         assert subset_source_id in ["420007", "420008"]
+        subset_af = row["asdf"]
         assert isinstance(subset_af, asdf.AsdfFile)
         # Check that the subset ASDF file contains the expected data structure
         assert "roman" in subset_af.tree
@@ -342,33 +286,27 @@ def test_roman_spectral_subset_asdf_subsets_source_file(spectral_files, lite):
         assert history_entry["description"] == expected_entry
 
     # Only select certain source files
-    asdf_subsets = subset.get_asdf_subsets(group_by="source_file", spectral_files=[spectral_files[0]])
-    source_file_keys = subset.get_source_file_keys(spectral_files=[spectral_files[0]])
-    assert len(asdf_subsets) == 2  # Should only have subsets for the specified file
-    for key in asdf_subsets.keys():
-        subset_file, subset_source_id = source_file_keys[key]
-        assert subset_file == spectral_files[0]
-        assert subset_source_id in ["420007", "420008"]
+    subset_table = subset.get_asdf_subsets(group_by="source_file", spectral_files=[spectral_files[0]])
+    assert len(subset_table) == 2  # Should only have subsets for the specified file
+    for row in subset_table:
+        assert row["file"] == spectral_files[0]
+        assert row["source_id"] in ["420007", "420008"]
 
     # Only select certain source IDs
-    asdf_subsets = subset.get_asdf_subsets(group_by="source_file", source_ids=["420007"])
-    source_file_keys = subset.get_source_file_keys(source_ids=["420007"])
-    assert len(asdf_subsets) == 2  # Should only have subsets for the specified source ID
-    for key in asdf_subsets.keys():
-        subset_file, subset_source_id = source_file_keys[key]
-        assert subset_source_id == "420007"
-        assert subset_file in spectral_files
+    subset_table = subset.get_asdf_subsets(group_by="source_file", source_ids=["420007"])
+    assert len(subset_table) == 2  # Should only have subsets for the specified source ID
+    for row in subset_table:
+        assert row["source_id"] == "420007"
+        assert row["file"] in spectral_files
 
     # Only select certain source files and source IDs
-    asdf_subsets = subset.get_asdf_subsets(
+    subset_table = subset.get_asdf_subsets(
         group_by="source_file", spectral_files=[spectral_files[0]], source_ids=["420007"]
     )
-    source_file_keys = subset.get_source_file_keys(spectral_files=[spectral_files[0]], source_ids=["420007"])
-    assert len(asdf_subsets) == 1  # Should only have one subset for the specified file and source ID
-    for key in asdf_subsets.keys():
-        subset_file, subset_source_id = source_file_keys[key]
-        assert subset_file == spectral_files[0]
-        assert subset_source_id == "420007"
+    assert len(subset_table) == 1  # Should only have one subset for the specified file and source ID
+    for row in subset_table:
+        assert row["file"] == spectral_files[0]
+        assert row["source_id"] == "420007"
 
 
 @pytest.mark.parametrize("lite", [True, False])
@@ -376,12 +314,13 @@ def test_roman_spectral_subset_asdf_subsets_file(spectral_files, lite):
     # Test the get_asdf_subsets method of RomanSpectralsubset with group_by='file'
     subset = RomanSpectralSubset(spectral_files=spectral_files, source_ids=[420007, 420008], lite=lite, max_workers=1)
 
-    asdf_subsets = subset.get_asdf_subsets(group_by="file")
-    assert len(asdf_subsets) == 2  # Should have one subset per file
+    subset_table = subset.get_asdf_subsets(group_by="file")
+    assert len(subset_table) == 2  # Should have one subset per file
 
-    for subset_file in asdf_subsets.keys():
+    for row in subset_table:
+        subset_file = row["file"]
         assert subset_file in spectral_files
-        subset_af = asdf_subsets[subset_file]
+        subset_af = row["asdf"]
         assert isinstance(subset_af, asdf.AsdfFile)
         # Check that the subset ASDF file contains the expected data structure
         assert "roman" in subset_af.tree
@@ -405,7 +344,9 @@ def test_roman_spectral_subset_asdf_subsets_file(spectral_files, lite):
 def test_roman_spectral_subset_asdf_subsets_combined(spectral_files, lite):
     # Test the get_asdf_subsets method of RomanSpectralsubset with group_by='combined'
     subset = RomanSpectralSubset(spectral_files=spectral_files, source_ids=[420007, 420008], lite=lite, max_workers=1)
-    subset_af = subset.get_asdf_subsets(group_by="combined")
+    subset_table = subset.get_asdf_subsets(group_by="combined")
+    assert len(subset_table) == 1  # Should have a single combined row
+    subset_af = subset_table[0]["asdf"]
     assert isinstance(subset_af, asdf.AsdfFile)
     # Check that the subset ASDF file contains the expected data structure
     assert "roman" in subset_af.tree

--- a/docs/astrocut/file_formats.rst
+++ b/docs/astrocut/file_formats.rst
@@ -1,5 +1,5 @@
 :orphan:
-   
+
 *********************
 Astrocut File Formats
 *********************
@@ -18,15 +18,15 @@ PRIMARY PrimaryHDU (Extension 0)
 ========= ===================================================
 Keyword   Value
 ========= ===================================================
-SIMPLE    T (conforms to FITS standard)                     
-BITPIX    8 (array data type)                               
-NAXIS     0 (number of array dimensions)                    
-EXTEND    Number of standard extensions                                                  
+SIMPLE    T (conforms to FITS standard)
+BITPIX    8 (array data type)
+NAXIS     0 (number of array dimensions)
+EXTEND    Number of standard extensions
 ORIGIN    STScI/MAST
-DATE      File creation date                             
-PROCVER   Software version                      
-RA_OBJ    Center coordinate right ascension (deg)                         
-DEC_OBJ   Center coordinate declination (deg)                             
+DATE      File creation date
+PROCVER   Software version
+RA_OBJ    Center coordinate right ascension (deg)
+DEC_OBJ   Center coordinate declination (deg)
 CHECKSUM  HDU checksum
 DATASUM   Data unit checksum
 ========= ===================================================
@@ -49,7 +49,7 @@ Image Cutouts
 ^^^^^^^^^^^^^
 
 ASDF and FITS image cutout files are output by the `~astrocut.ASDFCutout` class.
-The output format (ASDF vs FITS) impacts the structure of the cutout file. Additionally, the ``lite`` parameter controls 
+The output format (ASDF vs FITS) impacts the structure of the cutout file. Additionally, the ``lite`` parameter controls
 whether the cutout contains only essential data or all data and metadata from the original file.
 The ``lite`` parameter has the following effects on the cutout content:
 
@@ -106,12 +106,12 @@ sliced and adjusted to account for the cutout's position and shape.
 FITS Format Output
 -------------------
 
-When writing to FITS format, the output structure differs from ASDF. The cutout data is stored in an ``ImageHDU`` extension, 
-with WCS information encoded in standard FITS headers. With Python 3.11+ and ``stdatamodels>=4.1.0``, the ASDF metadata tree is embedded in the FITS file. 
-When ``lite=True``, the embedded ASDF tree contains only the cutout WCS and original filename; when ``lite=False``, the full 
+When writing to FITS format, the output structure differs from ASDF. The cutout data is stored in an ``ImageHDU`` extension,
+with WCS information encoded in standard FITS headers. With Python 3.11+ and ``stdatamodels>=4.1.0``, the ASDF metadata tree is embedded in the FITS file.
+When ``lite=True``, the embedded ASDF tree contains only the cutout WCS and original filename; when ``lite=False``, the full
 ASDF metadata is embedded.
 
-Note that FITS output files only contain the cutout image data in the ``ImageHDU`` extension, and do not include any additional 
+Note that FITS output files only contain the cutout image data in the ``ImageHDU`` extension, and do not include any additional
 data arrays from the original ASDF file, even when ``lite=False``. This is a key difference from ASDF output.
 
 **FITS Structure:**
@@ -139,13 +139,13 @@ Spectral Subsets
 ^^^^^^^^^^^^^^^^
 
 ASDF spectral subsets are produced by the `~astrocut.RomanSpectralSubset` class.
-The amount of information in each subset file is controlled by the ``lite`` parameter, which determines whether only essential data 
+The amount of information in each subset file is controlled by the ``lite`` parameter, which determines whether only essential data
 or all data and metadata from the original file are included in the subset. The ``lite`` parameter has the following effects on the subset content:
 
 - ``lite=True`` (default): The subset data only includes the "wl", "flux", and "flux_error" arrays. All original
   metadata is preserved, but all other data arrays and top-level keys from the original file are omitted from the subset.
 
-- ``lite=False``: The subset includes all data and metadata from the original ASDF file(s), with all arrays that match the 
+- ``lite=False``: The subset includes all data and metadata from the original ASDF file(s), with all arrays that match the
   dimensions of the ``wl`` array being sliced to the subset shape if a ``wl_range`` was specified.
   The full tree structure and metadata from the original file(s) are preserved.
 
@@ -156,12 +156,12 @@ This parameter has three options and controls how the subset data is organized a
 Group by Source ID and Input File
 ----------------------------------
 
-Setting ``group_by='source_file'`` writes one ASDF file per unique combination of input file and source ID. 
-This means that if multiple source IDs are selected from the same input file, each will be written to a separate ASDF file. 
+Setting ``group_by='source_file'`` writes one ASDF file per unique combination of input file and source ID.
+This means that if multiple source IDs are selected from the same input file, each will be written to a separate ASDF file.
 The output filename pattern for this grouping is: ``<input_stem>_subset_<source_id>[_lite].asdf``
 
-When returned in memory through `~astrocut.RomanSpectralSubset.get_asdf_subsets`, these subsets are keyed by deterministic
-string keys (for example, ``<source_id>_<input_stem>``). If key collisions occur, a short hash suffix is added automatically.
+When returned in memory through `~astrocut.RomanSpectralSubset.get_asdf_subsets`, these subsets are returned as an
+`~astropy.table.Table` with one row per ``(input_file, source_id)`` pair, and columns ``file``, ``source_id``, and ``subset``.
 
 **Lite Structure:**
 
@@ -208,6 +208,9 @@ Group by Input File
 
 Setting ``group_by='file'`` writes one ASDF file per input spectral file, combining selected source IDs from that file into a single ASDF file.
 The output filename pattern for this grouping is: ``<input_stem>_subset[_lite].asdf``
+
+When returned in memory through `~astrocut.RomanSpectralSubset.get_asdf_subsets`, these subsets are returned as an
+`~astropy.table.Table` with one row per ``input_file``, and columns ``file``, ``source_ids``, and ``subset``.
 
 **Lite Structure:**
 
@@ -268,8 +271,11 @@ The output filename pattern for this grouping is: ``<input_stem>_subset[_lite].a
 Combined File for All Sources and Input Files
 ----------------------------------------------
 
-Setting ``group_by='combined'`` writes one ASDF file containing all requested files and sources. 
+Setting ``group_by='combined'`` writes one ASDF file containing all requested files and sources.
 The output filename pattern for this grouping is: ``combined_spectral_subset[_lite].asdf``
+
+When returned in memory through `~astrocut.RomanSpectralSubset.get_asdf_subsets`, these subsets are returned as an
+`~astropy.table.Table` with one row for the combined subset, and columns ``files``, ``source_ids``, and ``subset``.
 
 **Lite Structure:**
 
@@ -397,7 +403,7 @@ The cube dimensions are ordered in the FITS format as follows:
 ========= ===================================================
 Keyword   Value
 ========= ===================================================
-NAXIS     4 (number of array dimensions)                    
+NAXIS     4 (number of array dimensions)
 NAXIS1    2 (data value, error value)
 NAXIS2    Total number of FFIs
 NAXIS3    Length of first array dimension (NAXIS1 from FFIs)
@@ -408,10 +414,10 @@ NAXIS4    Length of second array dimension (NAXIS2 from FFIs)
 BinTableHDU (Extension 2)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The BinTableHDU extension contains a table that 
-holds all of the image extension header keywords from the individual FFIs. There 
-is one column for each keyword plus one additional column called "FFI_FILE" that 
-contains FFI filename for each row. Each column name keyword also has an entry in the 
+The BinTableHDU extension contains a table that
+holds all of the image extension header keywords from the individual FFIs. There
+is one column for each keyword plus one additional column called "FFI_FILE" that
+contains FFI filename for each row. Each column name keyword also has an entry in the
 Image extension header, with the value being the keyword value from the FFI header.
 This last column allows the FFI Image extension headers to be recreated completely if desired.
 

--- a/docs/astrocut/index.rst
+++ b/docs/astrocut/index.rst
@@ -394,38 +394,69 @@ The ``lite`` parameter controls the size of the subset and how much of the origi
 The resulting `~astrocut.RomanSpectralSubset` object can be used to access the subset data and metadata.
 The ``subset_data`` attribute is a dictionary that stores the subset data keyed by input filename and source ID.
 
-The `~astrocut.RomanSpectralSubset.get_asdf_subsets` method returns the subsets as `~asdf.AsdfFile` objects in memory,
-and the `~astrocut.RomanSpectralSubset.write_as_asdf` method writes the subsets to ASDF files on disk and returns a list
-of paths to the output files. Both methods support filtering the subsets by source ID and input file, as well as grouping the
-subsets in different ways. They accept the following parameters:
+.. code-block:: python
+
+  >>> print(spectral_subset.subset_data["/path/to/roman_spectral.asdf"]) #doctest: +SKIP
+  {'420007': {'flux': array([5.37157113e-17, 5.27060112e-17, 5.25740574e-17, 5.26136996e-17,
+          5.16123888e-17, 4.95479633e-17, 4.80292887e-17]),
+                'flux_error': array([2.50778703e-20, 2.46148251e-20, 2.43618767e-20, 2.41538018e-20,
+          2.37139925e-20, 2.30359954e-20, 2.24894059e-20]),
+                'wl': array([881.42062338, 884.32981611, 887.24861084, 890.17703926,
+          893.11513318, 896.06292449, 899.0204452 ])},
+    '420022': {'flux': array([5.37157113e-17, 5.27060112e-17, 5.25740574e-17, 5.26136996e-17,
+          5.16123888e-17, 4.95479633e-17, 4.80292887e-17]),
+                'flux_error': array([2.50778703e-20, 2.46148251e-20, 2.43618767e-20, 2.41538018e-20,
+          2.37139925e-20, 2.30359954e-20, 2.24894059e-20]),
+                'wl': array([881.42062338, 884.32981611, 887.24861084, 890.17703926,
+          893.11513318, 896.06292449, 899.0204452 ])}}
+
+The `~astrocut.RomanSpectralSubset.get_asdf_subsets` method returns the subsets as an `~astropy.table.Table`, with each
+row holding an `~asdf.AsdfFile` object in a ``subset`` column, and the `~astrocut.RomanSpectralSubset.write_as_asdf` method
+writes the subsets to ASDF files on disk and returns a list of paths to the output files. For lazy iteration without
+building the full table in memory, use `~astrocut.RomanSpectralSubset.iter_asdf_subsets`, which yields the same rows
+one at a time. All three methods support filtering the subsets by source ID and input file, as well as grouping the
+parameters:
 
 - ``source_ids``: A list of source IDs to include in the output. If None, all source IDs will be included.
 - ``spectral_files``: A list of input spectral files to include in the output. If None, all input files will be included.
-- ``group_by``: Controls how subsets are grouped in an `~asdf.AsdfFile` object in memory or in an output file.
+- ``group_by``: Controls how subsets are grouped into rows of the output table (or output files on disk).
 
-  - ``group_by='source_file'``: Groups subsets by source ID and input file, resulting in one subset object per source ID per input file.
-    In memory, these subsets are returned in a dictionary keyed by deterministic string keys, and each key maps
-    to one unique ``(input_file, source_id)`` pair. Use `~astrocut.RomanSpectralSubset.get_source_file_keys` to retrieve the valid keys and
-    their ``(input_file, source_id)`` mappings.
-  - ``group_by='file'``: Groups all subsets from each input file together, resulting in one subset object per input file.
-  - ``group_by='combined'``: Combines all subsets from all input files into a single subset object. See the :ref:`Spectral Subset File Formats <spectral-subsets>` for more details on the structure of subset objects.
+  - ``group_by='source_file'``: Groups subsets by source ID and input file, resulting in one table row per source ID per
+    input file, with ``file``, ``source_id``, and ``subset`` columns.
+  - ``group_by='file'``: Groups all subsets from each input file together, resulting in one table row per input file, with
+    ``file``, ``source_ids``, and ``subset`` columns.
+  - ``group_by='combined'``: Combines all subsets from all input files into a single table row, with ``files``, ``source_ids``,
+    and ``subset`` columns. See the :ref:`Spectral Subset File Formats <spectral-subsets>` for more details on the structure of subset objects.
 
 .. code-block:: python
 
-  >>> asdf_cut = spectral_subset.get_asdf_subsets(source_ids=[420007, 420022], group_by='file')[spectral_files[0]] #doctest: +SKIP
-  >>> pprint(asdf_cut['roman']['data']) #doctest: +SKIP
-   {420007: {'flux': array([5.37157113e-17, 5.27060112e-17, 5.25740574e-17, 5.26136996e-17,
-          5.16123888e-17, 4.95479633e-17, 4.80292887e-17]),
-              'flux_error': array([2.50778703e-20, 2.46148251e-20, 2.43618767e-20, 2.41538018e-20,
-          2.37139925e-20, 2.30359954e-20, 2.24894059e-20]),
-              'wl': array([881.42062338, 884.32981611, 887.24861084, 890.17703926,
-          893.11513318, 896.06292449, 899.0204452 ])},
-    420022: {'flux': array([5.37157113e-17, 5.27060112e-17, 5.25740574e-17, 5.26136996e-17,
-          5.16123888e-17, 4.95479633e-17, 4.80292887e-17]),
-              'flux_error': array([2.50778703e-20, 2.46148251e-20, 2.43618767e-20, 2.41538018e-20,
-          2.37139925e-20, 2.30359954e-20, 2.24894059e-20]),
-              'wl': array([881.42062338, 884.32981611, 887.24861084, 890.17703926,
-          893.11513318, 896.06292449, 899.0204452 ])}}
+  >>> subset_table = spectral_subset.get_asdf_subsets(source_ids=[420007, 420022], group_by='file') #doctest: +SKIP
+  >>> asdf_cut = subset_table[0]['subset'] #doctest: +SKIP
+  >>> asdf_cut.info() #doctest: +SKIP
+  root (AsdfObject)
+  ├─roman (dict)
+  │ ├─data (dict)
+  │ │ ├─420007 (dict) ...
+  │ │ └─420022 (dict) ...
+  │ └─meta (dict)
+  │   ├─file_creation_date (str): 2025-07-07T18:44:15.421941
+  │   ├─file_name (str): r0000201001001001001_00002_01001_WFI01_cal_1d_coadd.asdf
+  │   ├─file_wfi_phot_catalog_level_3 (list) ...
+  │   ├─file_wfi_phot_catalog_level_4 (list) ...
+  │   ├─file_wfi_spec_level_2_primary (str): june2_2025_prism_0000201001001001001_roll0/r0000201001001001001_0 (truncated)
+  │   ├─id_g2dp_run (str): 1
+  │   ├─id_obs (str): 0000201001001001001
+  │   ├─id_program (str): 00002
+  │   ├─instr_obsty (str): test
+  │   ├─optical_element (str): PRISM
+  │   ├─phot_filter_cut_off (str): F158
+  │   ├─pos_wcs_field_center_dec (float): 66.0
+  │   ├─pos_wcs_field_center_ra (float): 270.0
+  │   ├─program_complete (bool): False
+  │   └─10 not shown
+  └─history (dict)
+    └─entries (list) ...
+  Some nodes not shown.
 
 Multiprocessing
 ----------------


### PR DESCRIPTION
Update spectral subsets to output an Astropy table rather than a list, similar to the work done in #196. 

- `get_asdf_subsets` returns a `Table` with input file(s), source ID(s), and the corresponding subset object. Contents of table depend on what is used for the `group_by` method.
- Add `iter_asdf_subsets` method to return an iterator.