### PR TITLE
Update `wcsinfo` in ASDF cutout metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Unreleased
 
 - Extend the ASDF cutout workflow to accept multiple target coordinates and to expose downstream cutout products in
   an ``astropy.table.Table`` object with columns for input file, coordinate, and cutout object. [#196]
+- Update the ``wcsinfo`` section of the ASDF metadata dictionary to reflect the cutout's spatial extent and local WCS properties
+  when creating full cutouts from ASDF images. [#199]
 
 1.3.0 (2026-09-02)
 -------------------

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -981,10 +981,9 @@ class ASDFCutout(ImageCutout):
         return tmp
 
     @staticmethod
-    def _update_s_region(meta: dict, cutout_wcs: gwcs.wcs.WCS) -> None:
+    def _update_wcsinfo(meta: dict, cutout_wcs: gwcs.wcs.WCS) -> None:
         """
-        This method updates the 's_region' entry in the 'wcsinfo' metadata
-        dictionary to reflect the spatial footprint of the cutout WCS.
+        Update spatial metadata that depends on the cutout array extent.
 
         Parameters
         ----------
@@ -996,10 +995,45 @@ class ASDFCutout(ImageCutout):
         if "wcsinfo" not in meta:
             return
 
+        wcsinfo = deepcopy(meta["wcsinfo"])
         footprint = np.asarray(cutout_wcs.footprint(axis_type="spatial"))
         coordinates = " ".join(f"{value:.9f}" for value in footprint.ravel())
-        meta["wcsinfo"] = deepcopy(meta["wcsinfo"])
-        meta["wcsinfo"]["s_region"] = f"POLYGON ICRS {coordinates}"
+        wcsinfo["s_region"] = f"POLYGON ICRS {coordinates}"
+
+        # Check if the required L3 fields are present in the wcsinfo before updating them
+        l3_fields = {"x_ref", "y_ref", "image_shape", "pixel_scale", "orientation"}
+        if l3_fields.issubset(wcsinfo):
+
+            def as_float(value):
+                # Convert the value to a float, handling Quantity objects
+                return float(value.value) if isinstance(value, Quantity) else float(value)
+
+            pixel_shape = tuple(cutout_wcs.pixel_shape)
+            center_pixel = tuple((size - 1) / 2 for size in pixel_shape)
+            center_world = cutout_wcs(*center_pixel)
+
+            reference_pixel = cutout_wcs.invert(wcsinfo["ra_ref"], wcsinfo["dec_ref"], with_bounding_box=False)
+            wcsinfo["x_ref"] = as_float(reference_pixel[0])
+            wcsinfo["y_ref"] = as_float(reference_pixel[1])
+
+            center_coord = SkyCoord(*center_world, unit="deg")
+            x_world = cutout_wcs(center_pixel[0] + 1, center_pixel[1], with_bounding_box=False)
+            y_world = cutout_wcs(center_pixel[0], center_pixel[1] + 1, with_bounding_box=False)
+            x_scale = center_coord.separation(SkyCoord(*x_world, unit="deg")).degree
+            y_scale = center_coord.separation(SkyCoord(*y_world, unit="deg")).degree
+            local_scale = float(np.sqrt(x_scale * y_scale))
+
+            orientation_pixel = (center_pixel[0], center_pixel[1] + 100)
+            orientation_world = cutout_wcs(*orientation_pixel, with_bounding_box=False)
+            local_orientation = center_coord.position_angle(SkyCoord(*orientation_world, unit="deg")).degree
+
+            wcsinfo["image_shape"] = list(cutout_wcs.array_shape)
+            wcsinfo["ra"] = as_float(center_world[0])
+            wcsinfo["dec"] = as_float(center_world[1])
+            wcsinfo["pixel_scale"] = local_scale
+            wcsinfo["orientation"] = local_orientation
+
+        meta["wcsinfo"] = wcsinfo
 
     def _cutout_file(self, file: Union[str, Path, S3Path]):
         """
@@ -1102,7 +1136,7 @@ class ASDFCutout(ImageCutout):
                         self._asdf_trees.setdefault(input_file, {})[coord_key] = lite_tree
                     else:
                         coord_mission_tree["meta"]["wcs"] = sliced_gwcs
-                        self._update_s_region(coord_mission_tree["meta"], sliced_gwcs)
+                        self._update_wcsinfo(coord_mission_tree["meta"], sliced_gwcs)
                         coord_mission_tree["meta"]["orig_file"] = input_file
                         coord_mission_tree["meta"]["coordinate"] = coord_key
                         self._asdf_trees.setdefault(input_file, {})[coord_key] = {self._mission_kwd: coord_mission_tree}

--- a/astrocut/asdf_cutout.py
+++ b/astrocut/asdf_cutout.py
@@ -980,6 +980,27 @@ class ASDFCutout(ImageCutout):
         tmp.array_shape = shape[::-1]
         return tmp
 
+    @staticmethod
+    def _update_s_region(meta: dict, cutout_wcs: gwcs.wcs.WCS) -> None:
+        """
+        This method updates the 's_region' entry in the 'wcsinfo' metadata
+        dictionary to reflect the spatial footprint of the cutout WCS.
+
+        Parameters
+        ----------
+        meta : dict
+            The metadata dictionary containing the 'wcsinfo' section.
+        cutout_wcs : gwcs.wcs.WCS
+            The WCS object of the cutout.
+        """
+        if "wcsinfo" not in meta:
+            return
+
+        footprint = np.asarray(cutout_wcs.footprint(axis_type="spatial"))
+        coordinates = " ".join(f"{value:.9f}" for value in footprint.ravel())
+        meta["wcsinfo"] = deepcopy(meta["wcsinfo"])
+        meta["wcsinfo"]["s_region"] = f"POLYGON ICRS {coordinates}"
+
     def _cutout_file(self, file: Union[str, Path, S3Path]):
         """
         Create a cutout from a single input file.
@@ -1081,6 +1102,7 @@ class ASDFCutout(ImageCutout):
                         self._asdf_trees.setdefault(input_file, {})[coord_key] = lite_tree
                     else:
                         coord_mission_tree["meta"]["wcs"] = sliced_gwcs
+                        self._update_s_region(coord_mission_tree["meta"], sliced_gwcs)
                         coord_mission_tree["meta"]["orig_file"] = input_file
                         coord_mission_tree["meta"]["coordinate"] = coord_key
                         self._asdf_trees.setdefault(input_file, {})[coord_key] = {self._mission_kwd: coord_mission_tree}

--- a/astrocut/tests/test_asdf_cutout.py
+++ b/astrocut/tests/test_asdf_cutout.py
@@ -100,6 +100,18 @@ def images(tmp_path):
         # create meta
         meta = {
             "wcs": wcsobj,
+            "wcsinfo": {
+                "aperture_name": "WFI01_FULL",
+                "v2_ref": 1312.9491452484797,
+                "v3_ref": -1040.7853726755036,
+                "vparity": -1,
+                "v3yangle": -60.0,
+                "ra_ref": 30.0 + i * 0.001,
+                "dec_ref": 45.0 + i * 0.001,
+                "roll_ref": 59.84660742516984,
+                "s_region": "POLYGON ICRS 0 0 0 1 1 1 1 0",
+                "pa_aperture": 0,
+            },
             "product_type": "l2",
             "origin": "STSCI/SOC",
             "file_date": Time("2023-10-01T00:00:00", format="isot"),
@@ -480,6 +492,35 @@ def test_asdf_cutout_write_to_file(images, center_coord, cutout_size, tmpdir):
         if HAS_ASDF_IN_FITS:
             with asdf_in_fits.open(fits_file) as af:
                 check_asdf_metadata(af, images[i], cutout.cutouts["cutout"][i].data, meta_only=True)
+
+
+def test_asdf_cutout_updates_only_wcsinfo_s_region(images, center_coord, cutout_size):
+    cutout = ASDFCutout(images[0], center_coord, cutout_size, lite=False)
+    output_meta = cutout.asdf_cutouts["cutout"][0]["roman"]["meta"]
+
+    with asdf.open(images[0]) as original:
+        original_wcsinfo = original["roman"]["meta"]["wcsinfo"]
+        for key, value in original_wcsinfo.items():
+            if key != "s_region":
+                assert output_meta["wcsinfo"][key] == value
+        assert output_meta["wcsinfo"]["s_region"] != original_wcsinfo["s_region"]
+
+    footprint = np.asarray(output_meta["wcs"].footprint(axis_type="spatial"))
+    expected_coordinates = " ".join(f"{value:.9f}" for value in footprint.ravel())
+    assert output_meta["wcsinfo"]["s_region"] == f"POLYGON ICRS {expected_coordinates}"
+
+
+def test_asdf_cutout_s_region_is_independent_for_each_coordinate(images, multi_coord, cutout_size):
+    cutout = ASDFCutout(images[0], multi_coord[:2], cutout_size, lite=False)
+    output_metadata = [asdf_file["roman"]["meta"] for asdf_file in cutout.asdf_cutouts["cutout"]]
+
+    assert output_metadata[0]["wcsinfo"] is not output_metadata[1]["wcsinfo"]
+    assert output_metadata[0]["wcsinfo"]["s_region"] != output_metadata[1]["wcsinfo"]["s_region"]
+
+    for meta in output_metadata:
+        footprint = np.asarray(meta["wcs"].footprint(axis_type="spatial"))
+        expected_coordinates = " ".join(f"{value:.9f}" for value in footprint.ravel())
+        assert meta["wcsinfo"]["s_region"] == f"POLYGON ICRS {expected_coordinates}"
 
 
 @pytest.mark.parametrize("output_format", [".asdf", ".fits"])

--- a/astrocut/tests/test_asdf_cutout.py
+++ b/astrocut/tests/test_asdf_cutout.py
@@ -137,6 +137,32 @@ def images(tmp_path):
     return files
 
 
+@pytest.fixture()
+def l3_image(tmp_path):
+    data, wcsobj = make_fake(1000, 1000, 30.0, 45.0)
+    wcsinfo = {
+        "ra_ref": 30.0,
+        "dec_ref": 45.0,
+        "x_ref": 500.0,
+        "y_ref": 500.0,
+        "rotation_matrix": [[1.0, 0.0], [0.0, 1.0]],
+        "pixel_scale": -1.0,
+        "pixel_scale_ref": 0.1 / 3600.0,
+        "projection": "TAN",
+        "s_region": "POLYGON ICRS 0 0 0 1 1 1 1 0",
+        "image_shape": [1000, 1000],
+        "ra": -1.0,
+        "dec": -1.0,
+        "orientation": -1.0,
+        "orientation_ref": 0.0,
+        "skycell_name": "030p45x00y00",
+    }
+
+    filename = tmp_path / "test_roman_l3.asdf"
+    asdf.AsdfFile({"roman": {"meta": {"wcs": wcsobj, "wcsinfo": wcsinfo}, "data": data}}).write_to(filename)
+    return filename
+
+
 @pytest.fixture
 def center_coord():
     """Fixture to return a center coordinate"""
@@ -521,6 +547,36 @@ def test_asdf_cutout_s_region_is_independent_for_each_coordinate(images, multi_c
         footprint = np.asarray(meta["wcs"].footprint(axis_type="spatial"))
         expected_coordinates = " ".join(f"{value:.9f}" for value in footprint.ravel())
         assert meta["wcsinfo"]["s_region"] == f"POLYGON ICRS {expected_coordinates}"
+
+
+def test_asdf_cutout_updates_l3_wcsinfo(l3_image):
+    cutout_size = (12, 8)
+    cutout = ASDFCutout(l3_image, SkyCoord(30.0, 45.0, unit="deg"), cutout_size, lite=False)
+    meta = cutout.asdf_cutouts["cutout"][0]["roman"]["meta"]
+    wcsinfo = meta["wcsinfo"]
+    cutout_wcs = meta["wcs"]
+
+    assert wcsinfo["ra_ref"] == 30.0
+    assert wcsinfo["dec_ref"] == 45.0
+    assert wcsinfo["pixel_scale_ref"] == 0.1 / 3600.0
+    assert wcsinfo["rotation_matrix"] == [[1.0, 0.0], [0.0, 1.0]]
+    assert wcsinfo["projection"] == "TAN"
+    assert wcsinfo["orientation_ref"] == 0.0
+    assert wcsinfo["skycell_name"] == "030p45x00y00"
+
+    reference_pixel = cutout_wcs.invert(30.0, 45.0, with_bounding_box=False)
+    assert np.allclose([wcsinfo["x_ref"], wcsinfo["y_ref"]], reference_pixel)
+    assert wcsinfo["image_shape"] == list(cutout_wcs.array_shape)
+    assert wcsinfo["image_shape"] == [8, 12]
+
+    center_pixel = tuple((size - 1) / 2 for size in cutout_wcs.pixel_shape)
+    assert np.allclose([wcsinfo["ra"], wcsinfo["dec"]], cutout_wcs(*center_pixel))
+    assert wcsinfo["pixel_scale"] > 0
+    assert wcsinfo["orientation"] >= 0
+
+    footprint = np.asarray(cutout_wcs.footprint(axis_type="spatial"))
+    expected_coordinates = " ".join(f"{value:.9f}" for value in footprint.ravel())
+    assert wcsinfo["s_region"] == f"POLYGON ICRS {expected_coordinates}"
 
 
 @pytest.mark.parametrize("output_format", [".asdf", ".fits"])


### PR DESCRIPTION
Update the `wcsinfo` value in ASDF cutouts to reflect the new spatial metadata of the cutout. 

For L2 files:
- Updates the `s_region`

For L3 files:
- Updates the `s_region`
- Calculates and updates `image_shape`, `ra`, `dec`, `pixel_scale`, and `orientation`.